### PR TITLE
fix: supply chain hardening — frozen lockfile, audit gate, script blocking (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Security audit
+        run: pnpm audit --audit-level=high
 
       - name: Lint
         run: pnpm run lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Supply chain hardening (Issue #48)
+# Block lifecycle scripts from dependencies to prevent malicious postinstall
+ignore-scripts=true
+# Disable side-effects caching for reproducible installs
+side-effects-cache=false

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "data:download": "tsx scripts/download-airport-data.ts",
     "clean": "pnpm -r run clean && rm -rf node_modules"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [],
+    "overrides": {}
+  },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",


### PR DESCRIPTION
## Summary
Closes #48

- **`.npmrc`** (new): `ignore-scripts=true` blocks all lifecycle scripts from dependencies (prevents malicious postinstall attacks); `side-effects-cache=false` for reproducible installs
- **`package.json`**: Added `pnpm.onlyBuiltDependencies` (empty — no deps currently need build scripts) and `pnpm.overrides` for future pinning
- **`ci.yml`**: `pnpm install --frozen-lockfile` ensures lockfile integrity; `pnpm audit --audit-level=high` gate fails CI on high/critical vulnerabilities

### Notes
- The root `postinstall` script (data download) is now skipped during `pnpm install` due to `ignore-scripts=true`. CI already calls `pnpm run data:download` as a separate step, so no impact. Local dev: run `pnpm run data:download` manually after install.
- Brief suggested `minimumReleaseAge`, `blockExoticSubdeps`, and `trustPolicy` in pnpm-workspace.yaml — these are not supported in pnpm 10.33 (silently ignored). Omitted to avoid dead config.
- No dependencies require build scripts (`onlyBuiltDependencies` is empty).

## Test plan
- [x] `pnpm install --frozen-lockfile` — succeeds
- [x] `pnpm audit --audit-level=high` — 0 vulnerabilities
- [x] `pnpm run lint` — passes
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 2,737 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)