### PR TITLE
chore: release v0.3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.3.2.1 — Sprint B: LLM Tool Layer + EventStore
+
+The pipeline validator can now talk to LLMs. Sprint B connects the contract infrastructure (shipped in v0.3.2) to the tool-dispatch layer, adds persistent event logging, ships a new agent, and delivers the first demo that runs the full architecture end-to-end.
+
+### Added
+
+- **Agent-to-Tool bridge** (`agentToTool()`) — wraps any `AgentContract` + `Agent` pair into a `ToolDefinition` that `AgentLoop` can register and dispatch. Every tool call runs through the six pipeline gates. Failures throw `AgentToolError` with structured reason + issues for LLM self-correction. `registerAgentTools()` batch-converts all contracted agents into a `ToolRegistry`.
+- **Catalog generator** — `generateMcpTools()` (Claude MCP), `generateOpenAiFunctions()` (OpenAI strict mode, draft-7), `generateCatalog()` (standalone JSON Schema). All schemas from `zodToJsonSchema()` — zero hand-written JSON anywhere in the pipeline.
+- **EventStore** — `OtaipEvent` discriminated union with 6 event types (`agent.executed`, `routing.decided`, `routing.outcome`, `booking.completed`, `booking.failed`, `adapter.health`). `InMemoryEventStore` with filter-by-type/session/agent/time-window queries and percentile aggregation (p50/p95/p99). Optional auto-logging from the tool bridge via `eventStore` option.
+- **Agent 3.8 PnrRetrieval** — new agent that retrieves an existing PNR/booking by record locator across distribution adapters. `AgentContract` from day one (`actionType: 'query'`, Zod schemas, semantic validation). Stub retrieval engine — wires to real adapters when `ConnectAdapter` gains `retrieveBooking()`.
+- **GdsNdcRouter registry adapter** — `buildCarrierCapabilities()` converts the existing `carrier-channels.json` lookup table into `ChannelCapability` entries for the `CapabilityRegistry`. 8 equivalence tests prove NDC-preferred, GDS-preferred, and DIRECT-only carriers are correctly encoded. Infrastructure for the full scoring-engine swap.
+- **Full pipeline demo** (`demo/book-flight-full.ts`) — first demo that uses the Sprint A/B architecture end-to-end: contract-driven tool definitions, `agentToTool()` bridge, 6-gate pipeline validator, EventStore logging, pipeline summary. Run with `pnpm --filter @otaip/demo book:full`.
+- **`demo/README.md`** — documents all 5 demo scripts with credential requirements.
+- **`AGENT_TOOL_NAMES`** — stable snake_case name map for all 10 contracted agents (e.g. `'1.1' → 'availability_search'`).
+
+### Fixed
+
+- **`@otaip/connect` missing from vitest alias map** — the only workspace package without an alias, causing CI to fail when tests imported `CapabilityRegistry` from `@otaip/connect` (resolved to `dist/` which doesn't exist without a build step).
+
+### Tests
+
+- 39 net new tests across 7 files (2835 total passing, 0 failing)
+
 ## 0.3.2 — Sprint A: Pipeline Contract Foundation
 
 OTAIP moves from a library to a platform: every agent that participates in an LLM-orchestrated or pipeline-composed flow can now declare a machine-verifiable `AgentContract`, enforced at runtime by six gates (schema, semantic, intent lock, cross-agent consistency, confidence, action classification). Agents without contracts continue to work as direct function calls — the change is purely additive.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.3.2",
+  "version": "0.3.2.1",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump 0.3.2 → 0.3.2.1 across all 15 workspace packages + CHANGELOG entry for Sprint B.

Once merged, the release workflow auto-creates the `v0.3.2.1` GitHub release, which triggers the publish workflow to npm.

## What's in 0.3.2.1

See [CHANGELOG.md](CHANGELOG.md) — Sprint B LLM Tool Layer + EventStore:
- `agentToTool()` bridge + `registerAgentTools()` + `AgentToolError`
- Catalog generator (MCP / OpenAI / standalone)
- EventStore (`InMemoryEventStore` with percentile aggregation)
- Agent 3.8 PnrRetrieval (new agent, contracted from day one)
- GdsNdcRouter registry adapter
- Full pipeline demo (`demo/book-flight-full.ts`)
- `@otaip/connect` vitest alias fix

## Test plan
- [x] 2835/2835 tests passing, 0 failing
- [x] All 15 workspace packages at version 0.3.2.1
- [ ] After merge: verify `v0.3.2.1` GitHub release is auto-created

🤖 Generated with [Claude Code](https://claude.com/claude-code)