### PR TITLE
Sprint E: reference OTA with search flow

### DIFF
--- a/examples/ota/.env.example
+++ b/examples/ota/.env.example
@@ -1,0 +1,5 @@
+# Duffel sandbox API token (free at duffel.com/docs/getting-started)
+DUFFEL_API_TOKEN=duffel_test_your_token_here
+
+# Server port (default: 3000)
+PORT=3000

--- a/examples/ota/README.md
+++ b/examples/ota/README.md
@@ -1,0 +1,57 @@
+# OTAIP Reference OTA
+
+A reference flight search application built on the Open Travel AI Platform. Proves OTAIP works end to end with real adapter integration, agent pipelines, and a deployable web UI.
+
+Sprint E covers **search only**. Booking is Sprint F.
+
+## Quick Start
+
+```bash
+# From the repo root
+pnpm install
+
+# Option A: Run with mock data (no API key needed)
+pnpm --filter @otaip/ota-example dev
+
+# Option B: Run with live Duffel sandbox data
+cp examples/ota/.env.example examples/ota/.env
+# Edit .env and add your Duffel API token (free at duffel.com/docs/getting-started)
+pnpm --filter @otaip/ota-example dev
+```
+
+Open http://localhost:3000 in your browser.
+
+## What Happens When You Search
+
+1. **Frontend** posts search params to `POST /api/search`
+2. **SearchService** optionally validates airport codes using `AirportCodeResolver` (Agent 0.1)
+3. **SearchService** calls the configured `DistributionAdapter.search()` (Duffel or Mock)
+4. Adapter normalizes results to OTAIP canonical `SearchOffer` schema
+5. Results are sorted by price and cached for the offer detail route
+6. Frontend renders offer cards with carrier, times, duration, stops, and price
+
+## Architecture
+
+```
+Browser (plain HTML + vanilla JS)
+  |
+  v
+Fastify server (src/server.ts)
+  |
+  +-- POST /api/search  --> SearchService --> DistributionAdapter.search()
+  +-- GET /api/offers/:id --> OfferService --> cached offer lookup
+  +-- GET /health        --> adapter health check
+```
+
+## Customization
+
+- **Swap adapter**: edit `src/config/adapters.ts` to use Amadeus, Travelport, or any `DistributionAdapter`
+- **Add agents**: wire additional agents (fare rules, tax calc) into the service layer
+- **Modify UI**: edit the plain HTML/JS files in `public/` -- no build step needed
+
+## Tests
+
+```bash
+# From repo root
+pnpm test -- --filter examples/ota
+```

--- a/examples/ota/package.json
+++ b/examples/ota/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@otaip/ota-example",
+  "version": "0.3.4",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts",
+    "build": "tsup src/server.ts --format esm --clean",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@otaip/core": "workspace:*",
+    "@otaip/agents-reference": "workspace:*",
+    "@otaip/agents-search": "workspace:*",
+    "@otaip/agents-pricing": "workspace:*",
+    "@otaip/adapter-duffel": "workspace:*",
+    "fastify": "^5.3.3",
+    "@fastify/static": "^8.2.0",
+    "dotenv": "^17.4.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0",
+    "tsup": "^8.5.1"
+  },
+  "engines": {
+    "node": ">=24.14.1"
+  }
+}

--- a/examples/ota/public/app.js
+++ b/examples/ota/public/app.js
@@ -1,0 +1,138 @@
+/**
+ * OTAIP Reference OTA — shared frontend utilities.
+ *
+ * Plain vanilla JavaScript. No frameworks, no build step.
+ */
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Search for flights.
+ * @param {{ origin: string, destination: string, date: string, returnDate?: string, passengers: number, cabinClass?: string }} params
+ * @returns {Promise<{ offers: Array, totalFound: number, sources: string[] }>}
+ */
+async function searchFlights(params) {
+  const res = await fetch('/api/search', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Search request failed' }));
+    throw new Error(err.error || err.message || `HTTP ${res.status}`);
+  }
+
+  return res.json();
+}
+
+/**
+ * Get offer details by ID.
+ * @param {string} id
+ * @returns {Promise<{ offer: object, fareRules: object }>}
+ */
+async function getOffer(id) {
+  const res = await fetch(`/api/offers/${encodeURIComponent(id)}`);
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Failed to load offer' }));
+    throw new Error(err.error || err.message || `HTTP ${res.status}`);
+  }
+
+  return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// UI helpers
+// ---------------------------------------------------------------------------
+
+/** Show or hide the loading spinner. */
+function showSpinner(show) {
+  const el = document.getElementById('spinner');
+  if (el) {
+    el.setAttribute('aria-busy', show ? 'true' : 'false');
+  }
+}
+
+/** Display an error message. */
+function showError(message) {
+  const container = document.getElementById('error-container');
+  if (container) {
+    container.innerHTML = `<div class="error-box">${escapeHtml(message)}</div>`;
+  }
+}
+
+/** Clear error messages. */
+function clearError() {
+  const container = document.getElementById('error-container');
+  if (container) {
+    container.innerHTML = '';
+  }
+}
+
+/** Escape HTML to prevent XSS. */
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+// ---------------------------------------------------------------------------
+// URL param helpers
+// ---------------------------------------------------------------------------
+
+/** Get a query parameter value from the current URL. */
+function getParam(name) {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(name);
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format an ISO datetime string to a short time (HH:MM).
+ * @param {string} isoString
+ * @returns {string}
+ */
+function formatTime(isoString) {
+  try {
+    const d = new Date(isoString);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+  } catch {
+    return isoString;
+  }
+}
+
+/**
+ * Format an ISO datetime string to a readable date + time.
+ * @param {string} isoString
+ * @returns {string}
+ */
+function formatDateTime(isoString) {
+  try {
+    const d = new Date(isoString);
+    return d.toLocaleString([], {
+      year: 'numeric', month: 'short', day: 'numeric',
+      hour: '2-digit', minute: '2-digit', hour12: false,
+    });
+  } catch {
+    return isoString;
+  }
+}
+
+/**
+ * Format duration in minutes to "Xh Ym".
+ * @param {number} minutes
+ * @returns {string}
+ */
+function formatDuration(minutes) {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}

--- a/examples/ota/public/index.html
+++ b/examples/ota/public/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OTAIP Reference OTA — Flight Search</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+  <style>
+    :root { --pico-font-size: 16px; }
+    .search-form { max-width: 600px; margin: 0 auto; }
+    .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+    .brand { text-align: center; margin-bottom: 2rem; }
+    .brand h1 { margin-bottom: 0.25rem; }
+    .brand p { color: var(--pico-muted-color); }
+    .error-box { background: var(--pico-del-color); color: #fff; padding: 1rem; border-radius: var(--pico-border-radius); margin-bottom: 1rem; }
+    .spinner { display: none; text-align: center; margin: 2rem 0; }
+    .spinner[aria-busy="true"] { display: block; }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <div class="brand">
+      <h1>OTAIP Reference OTA</h1>
+      <p>Flight search powered by the Open Travel AI Platform</p>
+    </div>
+
+    <div id="error-container"></div>
+
+    <form id="search-form" class="search-form">
+      <div class="form-row">
+        <label>
+          Origin (IATA code)
+          <input type="text" id="origin" name="origin" placeholder="JFK" maxlength="3"
+                 pattern="[A-Za-z]{3}" required autocomplete="off" />
+        </label>
+        <label>
+          Destination (IATA code)
+          <input type="text" id="destination" name="destination" placeholder="LAX" maxlength="3"
+                 pattern="[A-Za-z]{3}" required autocomplete="off" />
+        </label>
+      </div>
+
+      <div class="form-row">
+        <label>
+          Departure date
+          <input type="date" id="date" name="date" required />
+        </label>
+        <label>
+          Return date (optional)
+          <input type="date" id="returnDate" name="returnDate" />
+        </label>
+      </div>
+
+      <div class="form-row">
+        <label>
+          Passengers
+          <input type="number" id="passengers" name="passengers" min="1" max="9" value="1" required />
+        </label>
+        <label>
+          Cabin class
+          <select id="cabinClass" name="cabinClass">
+            <option value="economy">Economy</option>
+            <option value="premium_economy">Premium Economy</option>
+            <option value="business">Business</option>
+            <option value="first">First</option>
+          </select>
+        </label>
+      </div>
+
+      <button type="submit">Search Flights</button>
+    </form>
+
+    <div id="spinner" class="spinner" aria-busy="false">Searching flights...</div>
+  </main>
+
+  <script src="/app.js"></script>
+  <script>
+    document.getElementById('search-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      clearError();
+      showSpinner(true);
+
+      const params = {
+        origin: document.getElementById('origin').value.toUpperCase(),
+        destination: document.getElementById('destination').value.toUpperCase(),
+        date: document.getElementById('date').value,
+        returnDate: document.getElementById('returnDate').value || undefined,
+        passengers: Number(document.getElementById('passengers').value),
+        cabinClass: document.getElementById('cabinClass').value,
+      };
+
+      try {
+        const result = await searchFlights(params);
+
+        // Store results and navigate
+        sessionStorage.setItem('searchResults', JSON.stringify(result));
+        sessionStorage.setItem('searchParams', JSON.stringify(params));
+        window.location.href = '/results.html';
+      } catch (err) {
+        showError(err.message || 'Search failed');
+      } finally {
+        showSpinner(false);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/examples/ota/public/offer.html
+++ b/examples/ota/public/offer.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OTAIP Reference OTA — Offer Details</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+  <style>
+    :root { --pico-font-size: 16px; }
+    .segment-card { border: 1px solid var(--pico-muted-border-color); border-radius: var(--pico-border-radius); padding: 1.25rem; margin-bottom: 1rem; }
+    .segment-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem; }
+    .segment-header .flight { font-weight: bold; font-size: 1.1rem; }
+    .segment-detail { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem; }
+    .segment-detail dt { color: var(--pico-muted-color); font-size: 0.85rem; margin-bottom: 0.15rem; }
+    .segment-detail dd { margin: 0 0 0.75rem 0; font-weight: 500; }
+    .price-summary { background: var(--pico-card-background-color); border: 2px solid var(--pico-primary); border-radius: var(--pico-border-radius); padding: 1.5rem; }
+    .price-summary .total { font-size: 1.5rem; font-weight: bold; color: var(--pico-primary); }
+    .price-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem; margin-top: 1rem; }
+    .price-grid dt { color: var(--pico-muted-color); }
+    .price-grid dd { margin: 0; text-align: right; }
+    .fare-info { margin-top: 1.5rem; }
+    .fare-info dt { color: var(--pico-muted-color); font-size: 0.85rem; }
+    .fare-info dd { margin: 0 0 0.5rem 0; }
+    .error-box { background: var(--pico-del-color); color: #fff; padding: 1rem; border-radius: var(--pico-border-radius); margin-bottom: 1rem; }
+    .spinner { display: none; text-align: center; margin: 2rem 0; }
+    .spinner[aria-busy="true"] { display: block; }
+    .booking-notice { margin-top: 1.5rem; padding: 1rem; background: var(--pico-muted-border-color); border-radius: var(--pico-border-radius); text-align: center; color: var(--pico-muted-color); }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <nav>
+      <ul><li><a href="javascript:history.back()">Back to Results</a></li></ul>
+      <ul><li><strong>OTAIP Reference OTA</strong></li></ul>
+    </nav>
+
+    <div id="error-container"></div>
+    <div id="spinner" class="spinner" aria-busy="false">Loading offer details...</div>
+
+    <div id="offer-container"></div>
+  </main>
+
+  <script src="/app.js"></script>
+  <script>
+    (async () => {
+      const offerId = getParam('id');
+      if (!offerId) {
+        showError('No offer ID provided');
+        return;
+      }
+
+      showSpinner(true);
+
+      try {
+        const data = await getOffer(offerId);
+
+        const offer = data.offer;
+        const container = document.getElementById('offer-container');
+
+        // Segments
+        let segmentsHtml = '<h2>Itinerary</h2>';
+        for (const seg of offer.itinerary.segments) {
+          segmentsHtml += `
+            <div class="segment-card">
+              <div class="segment-header">
+                <span class="flight">${seg.carrier} ${seg.flight_number}</span>
+                <span>${seg.cabin_class || 'economy'}</span>
+              </div>
+              <dl class="segment-detail">
+                <div>
+                  <dt>Departure</dt>
+                  <dd>${seg.origin} &middot; ${formatDateTime(seg.departure_time)}</dd>
+                </div>
+                <div>
+                  <dt>Arrival</dt>
+                  <dd>${seg.destination} &middot; ${formatDateTime(seg.arrival_time)}</dd>
+                </div>
+                <div>
+                  <dt>Duration</dt>
+                  <dd>${formatDuration(seg.duration_minutes)}</dd>
+                </div>
+                <div>
+                  <dt>Aircraft</dt>
+                  <dd>${seg.aircraft || 'N/A'}</dd>
+                </div>
+                <div>
+                  <dt>Booking Class</dt>
+                  <dd>${seg.booking_class || 'N/A'}</dd>
+                </div>
+                <div>
+                  <dt>Stops</dt>
+                  <dd>${seg.stops === 0 ? 'Direct' : seg.stops}</dd>
+                </div>
+              </dl>
+            </div>
+          `;
+        }
+
+        // Price
+        let priceHtml = `
+          <div class="price-summary">
+            <div class="total">${offer.price.currency} ${offer.price.total.toFixed(2)}</div>
+            <dl class="price-grid">
+              <dt>Base fare</dt><dd>${offer.price.currency} ${offer.price.base_fare.toFixed(2)}</dd>
+              <dt>Taxes & fees</dt><dd>${offer.price.currency} ${offer.price.taxes.toFixed(2)}</dd>
+              <dt>Total</dt><dd>${offer.price.currency} ${offer.price.total.toFixed(2)}</dd>
+            </dl>
+        `;
+
+        if (offer.price.per_passenger && offer.price.per_passenger.length > 0) {
+          priceHtml += '<h4 style="margin-top:1rem">Per passenger</h4>';
+          for (const pp of offer.price.per_passenger) {
+            priceHtml += `<dl class="price-grid">
+              <dt>${pp.type}</dt><dd>${offer.price.currency} ${pp.total.toFixed(2)}</dd>
+            </dl>`;
+          }
+        }
+        priceHtml += '</div>';
+
+        // Fare info
+        let fareHtml = '<div class="fare-info"><h3>Fare Details</h3><dl>';
+        fareHtml += `<dt>Fare basis</dt><dd>${offer.fare_basis ? offer.fare_basis.join(', ') : 'N/A'}</dd>`;
+        fareHtml += `<dt>Booking classes</dt><dd>${offer.booking_classes ? offer.booking_classes.join(', ') : 'N/A'}</dd>`;
+        fareHtml += `<dt>Source</dt><dd>${offer.source}</dd>`;
+        fareHtml += `<dt>Offer ID</dt><dd><code>${offer.offer_id}</code></dd>`;
+        if (offer.expires_at) {
+          fareHtml += `<dt>Expires</dt><dd>${formatDateTime(offer.expires_at)}</dd>`;
+        }
+        fareHtml += '</dl></div>';
+
+        // Fare rules
+        let rulesHtml = '';
+        if (data.fareRules) {
+          rulesHtml = `<div class="fare-info"><h3>Fare Rules</h3><p>${data.fareRules.message}</p></div>`;
+        }
+
+        // Booking notice
+        const bookingHtml = '<div class="booking-notice">Booking is not available yet. Sprint F will add booking functionality.</div>';
+
+        container.innerHTML = segmentsHtml + priceHtml + fareHtml + rulesHtml + bookingHtml;
+
+      } catch (err) {
+        showError(err.message || 'Failed to load offer details');
+      } finally {
+        showSpinner(false);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/examples/ota/public/results.html
+++ b/examples/ota/public/results.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OTAIP Reference OTA — Search Results</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+  <style>
+    :root { --pico-font-size: 16px; }
+    .results-header { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
+    .results-header h2 { margin: 0; }
+    .sort-controls select { min-width: 150px; margin: 0; }
+    .offer-card { border: 1px solid var(--pico-muted-border-color); border-radius: var(--pico-border-radius); padding: 1.5rem; margin-bottom: 1rem; cursor: pointer; transition: box-shadow 0.2s; }
+    .offer-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.12); }
+    .offer-row { display: grid; grid-template-columns: 1fr 2fr 1fr; gap: 1rem; align-items: center; }
+    .carrier-info { font-weight: bold; font-size: 1.1rem; }
+    .flight-times { text-align: center; }
+    .flight-times .times { font-size: 1.2rem; font-weight: 600; }
+    .flight-times .meta { color: var(--pico-muted-color); font-size: 0.85rem; }
+    .price-info { text-align: right; }
+    .price-info .total { font-size: 1.3rem; font-weight: bold; color: var(--pico-primary); }
+    .price-info .breakdown { color: var(--pico-muted-color); font-size: 0.85rem; }
+    .stops-badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 0.25rem; font-size: 0.8rem; }
+    .stops-badge.direct { background: #d4edda; color: #155724; }
+    .stops-badge.connecting { background: #fff3cd; color: #856404; }
+    .no-results { text-align: center; padding: 3rem; }
+    .source-info { color: var(--pico-muted-color); font-size: 0.85rem; margin-top: 1rem; }
+    .error-box { background: var(--pico-del-color); color: #fff; padding: 1rem; border-radius: var(--pico-border-radius); margin-bottom: 1rem; }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <nav>
+      <ul><li><a href="/">Back to Search</a></li></ul>
+      <ul><li><strong>OTAIP Reference OTA</strong></li></ul>
+    </nav>
+
+    <div id="error-container"></div>
+
+    <div class="results-header">
+      <h2 id="results-title">Search Results</h2>
+      <div class="sort-controls">
+        <select id="sort-by" aria-label="Sort results">
+          <option value="price">Sort by Price</option>
+          <option value="duration">Sort by Duration</option>
+          <option value="departure">Sort by Departure</option>
+        </select>
+      </div>
+    </div>
+
+    <div id="results-container"></div>
+    <div id="source-info" class="source-info"></div>
+  </main>
+
+  <script src="/app.js"></script>
+  <script>
+    const raw = sessionStorage.getItem('searchResults');
+    const paramsRaw = sessionStorage.getItem('searchParams');
+
+    if (!raw) {
+      window.location.href = '/';
+    } else {
+      const data = JSON.parse(raw);
+      const params = paramsRaw ? JSON.parse(paramsRaw) : {};
+
+      document.getElementById('results-title').textContent =
+        `${params.origin || '???'} → ${params.destination || '???'} — ${data.totalFound} offer${data.totalFound === 1 ? '' : 's'}`;
+
+      let offers = data.offers || [];
+
+      function renderOffers(offerList) {
+        const container = document.getElementById('results-container');
+
+        if (offerList.length === 0) {
+          container.innerHTML = '<div class="no-results"><p>No flights found for this route.</p><p><a href="/">Try another search</a></p></div>';
+          return;
+        }
+
+        container.innerHTML = offerList.map(offer => {
+          const seg = offer.itinerary.segments[0];
+          const lastSeg = offer.itinerary.segments[offer.itinerary.segments.length - 1];
+          const depTime = formatTime(seg.departure_time);
+          const arrTime = formatTime(lastSeg.arrival_time);
+          const duration = formatDuration(offer.itinerary.total_duration_minutes);
+          const stops = offer.itinerary.connection_count;
+          const stopsLabel = stops === 0 ? 'Direct' : `${stops} stop${stops > 1 ? 's' : ''}`;
+          const stopsClass = stops === 0 ? 'direct' : 'connecting';
+
+          return `
+            <article class="offer-card" onclick="viewOffer('${offer.offer_id}')">
+              <div class="offer-row">
+                <div class="carrier-info">
+                  <div>${seg.carrier} ${seg.flight_number}</div>
+                  <div style="font-size:0.85rem;color:var(--pico-muted-color)">${seg.aircraft || ''}</div>
+                  <span class="stops-badge ${stopsClass}">${stopsLabel}</span>
+                </div>
+                <div class="flight-times">
+                  <div class="times">${depTime} → ${arrTime}</div>
+                  <div class="meta">${duration} &middot; ${seg.origin} → ${lastSeg.destination}</div>
+                  <div class="meta">${offer.fare_basis ? offer.fare_basis.join(', ') : ''}</div>
+                </div>
+                <div class="price-info">
+                  <div class="total">${offer.price.currency} ${offer.price.total.toFixed(2)}</div>
+                  <div class="breakdown">Base: ${offer.price.base_fare.toFixed(2)} + Tax: ${offer.price.taxes.toFixed(2)}</div>
+                </div>
+              </div>
+            </article>
+          `;
+        }).join('');
+      }
+
+      renderOffers(offers);
+
+      // Source info
+      if (data.sources && data.sources.length > 0) {
+        document.getElementById('source-info').textContent =
+          `Sources: ${data.sources.join(', ')}`;
+      }
+
+      // Sorting
+      document.getElementById('sort-by').addEventListener('change', (e) => {
+        const sortedOffers = [...offers];
+        switch (e.target.value) {
+          case 'price':
+            sortedOffers.sort((a, b) => a.price.total - b.price.total);
+            break;
+          case 'duration':
+            sortedOffers.sort((a, b) => a.itinerary.total_duration_minutes - b.itinerary.total_duration_minutes);
+            break;
+          case 'departure':
+            sortedOffers.sort((a, b) => {
+              const aTime = new Date(a.itinerary.segments[0].departure_time).getTime();
+              const bTime = new Date(b.itinerary.segments[0].departure_time).getTime();
+              return aTime - bTime;
+            });
+            break;
+        }
+        renderOffers(sortedOffers);
+      });
+    }
+
+    function viewOffer(id) {
+      window.location.href = `/offer.html?id=${encodeURIComponent(id)}`;
+    }
+  </script>
+</body>
+</html>

--- a/examples/ota/src/__tests__/search.test.ts
+++ b/examples/ota/src/__tests__/search.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Integration tests for the OTAIP Reference OTA.
+ *
+ * Uses Fastify inject (no real HTTP) with MockDuffelAdapter.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { MockDuffelAdapter } from '@otaip/adapter-duffel';
+import { buildApp } from '../server.js';
+
+let app: FastifyInstance;
+const mockAdapter = new MockDuffelAdapter();
+
+beforeAll(async () => {
+  app = await buildApp({ adapter: mockAdapter, initResolver: false });
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+// ---------------------------------------------------------------------------
+// Search tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/search', () => {
+  it('returns offers for a valid search', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        origin: 'JFK',
+        destination: 'LAX',
+        date: '2025-06-15',
+        passengers: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.offers).toBeDefined();
+    expect(body.offers.length).toBeGreaterThan(0);
+    expect(body.totalFound).toBeGreaterThan(0);
+  });
+
+  it('returns error for invalid airport code format', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        origin: 'JFKX',
+        destination: 'LAX',
+        date: '2025-06-15',
+        passengers: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.error).toBe('Validation failed');
+    expect(body.details).toContain('origin must be a 3-letter IATA airport code');
+  });
+
+  it('returns 400 for missing required fields', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        origin: 'JFK',
+        // missing destination, date, passengers
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json();
+    expect(body.error).toBe('Validation failed');
+    expect(body.details.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns the correct number of offers for JFK-LAX', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        origin: 'JFK',
+        destination: 'LAX',
+        date: '2025-06-15',
+        passengers: 1,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // MockDuffelAdapter has 3 JFK-LAX offers (direct economy, connecting, business)
+    expect(body.totalFound).toBe(3);
+    expect(body.offers).toHaveLength(3);
+  });
+
+  it('includes source attribution', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        origin: 'JFK',
+        destination: 'LAX',
+        date: '2025-06-15',
+        passengers: 1,
+      },
+    });
+
+    const body = res.json();
+    expect(body.sources).toBeDefined();
+    expect(body.sources).toContain('duffel');
+  });
+
+  it('results are sorted by price by default', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        origin: 'JFK',
+        destination: 'LAX',
+        date: '2025-06-15',
+        passengers: 1,
+      },
+    });
+
+    const body = res.json();
+    const prices = body.offers.map(
+      (o: { price: { total: number } }) => o.price.total,
+    );
+
+    for (let i = 1; i < prices.length; i++) {
+      expect(prices[i]).toBeGreaterThanOrEqual(prices[i - 1]!);
+    }
+  });
+
+  it('search with cabinClass filter works', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        origin: 'JFK',
+        destination: 'LAX',
+        date: '2025-06-15',
+        passengers: 1,
+        cabinClass: 'business',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    // MockDuffelAdapter has 1 business class JFK-LAX offer
+    expect(body.offers.length).toBe(1);
+    expect(body.offers[0].itinerary.segments[0].cabin_class).toBe('business');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offer tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/offers/:id', () => {
+  it('returns offer details for a valid ID after search', async () => {
+    // First, search to populate the cache
+    await app.inject({
+      method: 'POST',
+      url: '/api/search',
+      payload: {
+        origin: 'JFK',
+        destination: 'LAX',
+        date: '2025-06-15',
+        passengers: 1,
+      },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/offers/mock-duffel-jfk-lax-1',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.offer).toBeDefined();
+    expect(body.offer.offer_id).toBe('mock-duffel-jfk-lax-1');
+    expect(body.fareRules).toBeDefined();
+  });
+
+  it('returns 404 for an unknown offer ID', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/offers/nonexistent-offer-id',
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = res.json();
+    expect(body.error).toContain('Offer not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Health test
+// ---------------------------------------------------------------------------
+
+describe('GET /health', () => {
+  it('returns 200 with status ok', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/health',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.status).toBe('ok');
+    expect(body.agents).toBeDefined();
+    expect(body.agents.initialized).toBe(true);
+    expect(body.adapter).toBe('duffel');
+  });
+});

--- a/examples/ota/src/config/adapters.ts
+++ b/examples/ota/src/config/adapters.ts
@@ -1,0 +1,23 @@
+/**
+ * Adapter configuration — selects DuffelAdapter or MockDuffelAdapter
+ * based on environment variables.
+ */
+
+import type { DistributionAdapter } from '@otaip/core';
+import { MockDuffelAdapter, DuffelAdapter } from '@otaip/adapter-duffel';
+
+/**
+ * Create the distribution adapter based on environment configuration.
+ *
+ * - If `DUFFEL_API_TOKEN` is set, uses the real DuffelAdapter.
+ * - Otherwise, falls back to MockDuffelAdapter with realistic test data.
+ */
+export function createAdapter(): DistributionAdapter {
+  const token = process.env['DUFFEL_API_TOKEN'];
+
+  if (token && token !== 'duffel_test_your_token_here') {
+    return new DuffelAdapter(token);
+  }
+
+  return new MockDuffelAdapter();
+}

--- a/examples/ota/src/routes/health.ts
+++ b/examples/ota/src/routes/health.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /health — health check endpoint.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { DistributionAdapter } from '@otaip/core';
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+export function registerHealthRoute(
+  app: FastifyInstance,
+  adapter: DistributionAdapter,
+): void {
+  app.get('/health', async (_request, reply) => {
+    let adapterAvailable = false;
+
+    try {
+      adapterAvailable = await adapter.isAvailable();
+    } catch {
+      adapterAvailable = false;
+    }
+
+    return reply.send({
+      status: 'ok',
+      agents: { initialized: true },
+      adapter: adapter.name,
+      adapterAvailable,
+    });
+  });
+}

--- a/examples/ota/src/routes/offers.ts
+++ b/examples/ota/src/routes/offers.ts
@@ -1,0 +1,27 @@
+/**
+ * GET /api/offers/:id — retrieve offer details by ID.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { OfferService } from '../services/offer-service.js';
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+export function registerOffersRoute(
+  app: FastifyInstance,
+  offerService: OfferService,
+): void {
+  app.get<{ Params: { id: string } }>('/api/offers/:id', async (request, reply) => {
+    const { id } = request.params;
+
+    const details = offerService.getOfferDetails(id);
+
+    if (!details) {
+      return reply.status(404).send({ error: `Offer not found: ${id}` });
+    }
+
+    return reply.send(details);
+  });
+}

--- a/examples/ota/src/routes/search.ts
+++ b/examples/ota/src/routes/search.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/search — flight search endpoint.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import type { SearchService } from '../services/search-service.js';
+
+// ---------------------------------------------------------------------------
+// Request body schema
+// ---------------------------------------------------------------------------
+
+interface SearchBody {
+  origin: string;
+  destination: string;
+  date: string;
+  returnDate?: string;
+  passengers: number;
+  cabinClass?: 'economy' | 'premium_economy' | 'business' | 'first';
+}
+
+const IATA_CODE_RE = /^[A-Z]{3}$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const VALID_CABINS = new Set(['economy', 'premium_economy', 'business', 'first']);
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+export function registerSearchRoute(
+  app: FastifyInstance,
+  searchService: SearchService,
+): void {
+  app.post<{ Body: SearchBody }>('/api/search', async (request, reply) => {
+    const body = request.body as SearchBody | undefined;
+
+    if (!body) {
+      return reply.status(400).send({ error: 'Request body is required' });
+    }
+
+    // Validate required fields
+    const errors: string[] = [];
+
+    if (!body.origin || typeof body.origin !== 'string') {
+      errors.push('origin is required and must be a string');
+    } else if (!IATA_CODE_RE.test(body.origin.toUpperCase())) {
+      errors.push('origin must be a 3-letter IATA airport code');
+    }
+
+    if (!body.destination || typeof body.destination !== 'string') {
+      errors.push('destination is required and must be a string');
+    } else if (!IATA_CODE_RE.test(body.destination.toUpperCase())) {
+      errors.push('destination must be a 3-letter IATA airport code');
+    }
+
+    if (!body.date || typeof body.date !== 'string') {
+      errors.push('date is required and must be a string');
+    } else if (!DATE_RE.test(body.date)) {
+      errors.push('date must be in YYYY-MM-DD format');
+    }
+
+    if (body.returnDate !== undefined && body.returnDate !== null) {
+      if (typeof body.returnDate !== 'string' || !DATE_RE.test(body.returnDate)) {
+        errors.push('returnDate must be in YYYY-MM-DD format');
+      }
+    }
+
+    if (body.passengers === undefined || body.passengers === null) {
+      errors.push('passengers is required');
+    } else if (typeof body.passengers !== 'number' || body.passengers < 1 || body.passengers > 9) {
+      errors.push('passengers must be a number between 1 and 9');
+    }
+
+    if (body.cabinClass !== undefined && !VALID_CABINS.has(body.cabinClass)) {
+      errors.push('cabinClass must be one of: economy, premium_economy, business, first');
+    }
+
+    if (errors.length > 0) {
+      return reply.status(400).send({ error: 'Validation failed', details: errors });
+    }
+
+    try {
+      const result = await searchService.search({
+        origin: body.origin.toUpperCase(),
+        destination: body.destination.toUpperCase(),
+        date: body.date,
+        returnDate: body.returnDate,
+        passengers: body.passengers,
+        cabinClass: body.cabinClass,
+      });
+
+      return reply.send(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+
+      if (message.startsWith('Invalid airport')) {
+        return reply.status(400).send({ error: message });
+      }
+
+      request.log.error({ err }, 'Search failed');
+      return reply.status(500).send({ error: 'Search failed', message });
+    }
+  });
+}

--- a/examples/ota/src/server.ts
+++ b/examples/ota/src/server.ts
@@ -1,0 +1,82 @@
+/**
+ * OTAIP Reference OTA — Fastify server.
+ *
+ * A reference flight search application that proves OTAIP works end to end.
+ * Sprint E covers search only; booking is Sprint F.
+ */
+
+import 'dotenv/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import Fastify from 'fastify';
+import fastifyStatic from '@fastify/static';
+import { createAdapter } from './config/adapters.js';
+import { SearchService } from './services/search-service.js';
+import { OfferService } from './services/offer-service.js';
+import { registerSearchRoute } from './routes/search.js';
+import { registerOffersRoute } from './routes/offers.js';
+import { registerHealthRoute } from './routes/health.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// App factory (exported for testing)
+// ---------------------------------------------------------------------------
+
+export interface BuildAppOptions {
+  /** Override the adapter (useful for testing with MockDuffelAdapter). */
+  adapter?: import('@otaip/core').DistributionAdapter;
+  /** Whether to initialize the airport resolver. Defaults to true. */
+  initResolver?: boolean;
+}
+
+export async function buildApp(options: BuildAppOptions = {}) {
+  const adapter = options.adapter ?? createAdapter();
+
+  const app = Fastify({ logger: true });
+
+  // Serve static frontend files
+  await app.register(fastifyStatic, {
+    root: join(__dirname, '..', 'public'),
+    prefix: '/',
+  });
+
+  // Build services
+  const searchService = new SearchService(adapter);
+  const offerService = new OfferService(searchService);
+
+  // Optionally initialize airport code resolver
+  if (options.initResolver !== false) {
+    await searchService.initializeResolver();
+  }
+
+  // Register routes
+  registerSearchRoute(app, searchService);
+  registerOffersRoute(app, offerService);
+  registerHealthRoute(app, adapter);
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Start server (only when run directly, not imported)
+// ---------------------------------------------------------------------------
+
+const isMainModule =
+  process.argv[1] &&
+  (process.argv[1].endsWith('server.ts') || process.argv[1].endsWith('server.js'));
+
+if (isMainModule) {
+  const port = Number(process.env['PORT'] ?? 3000);
+
+  const app = await buildApp();
+
+  try {
+    await app.listen({ port, host: '0.0.0.0' });
+    console.log(`\n  OTAIP Reference OTA running at http://localhost:${port}\n`);
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+}

--- a/examples/ota/src/services/offer-service.ts
+++ b/examples/ota/src/services/offer-service.ts
@@ -1,0 +1,53 @@
+/**
+ * Offer Service — retrieves cached offer details from search results.
+ *
+ * In Sprint E this is a simple cache lookup. Sprint F will add
+ * FareRuleAgent integration for enriched fare rule data.
+ */
+
+import type { SearchOffer } from '@otaip/core';
+import type { SearchService } from './search-service.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface OfferDetails {
+  offer: SearchOffer;
+  fareRules: FareRulesSummary;
+}
+
+export interface FareRulesSummary {
+  /** Sprint E: placeholder. Sprint F adds real fare rule agent data. */
+  available: boolean;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class OfferService {
+  private readonly searchService: SearchService;
+
+  constructor(searchService: SearchService) {
+    this.searchService = searchService;
+  }
+
+  /** Retrieve full offer details by offer ID. */
+  getOfferDetails(offerId: string): OfferDetails | undefined {
+    const offer = this.searchService.getOffer(offerId);
+
+    if (!offer) {
+      return undefined;
+    }
+
+    return {
+      offer,
+      fareRules: {
+        available: false,
+        message: 'Fare rules not yet available. Sprint F will integrate the FareRuleAgent.',
+      },
+    };
+  }
+}

--- a/examples/ota/src/services/search-service.ts
+++ b/examples/ota/src/services/search-service.ts
@@ -1,0 +1,141 @@
+/**
+ * Search Service — orchestrates adapter search with optional airport code validation.
+ *
+ * Caches returned offers in memory for the offer detail route.
+ */
+
+import type {
+  DistributionAdapter,
+  SearchRequest,
+  SearchOffer,
+  PassengerType,
+} from '@otaip/core';
+import { AirportCodeResolver } from '@otaip/agents-reference';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SearchParams {
+  origin: string;
+  destination: string;
+  date: string;
+  returnDate?: string;
+  passengers: number;
+  cabinClass?: 'economy' | 'premium_economy' | 'business' | 'first';
+}
+
+export interface SearchResult {
+  offers: SearchOffer[];
+  totalFound: number;
+  sources: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class SearchService {
+  private readonly adapter: DistributionAdapter;
+  private readonly offerCache = new Map<string, SearchOffer>();
+  private airportResolver: AirportCodeResolver | null = null;
+
+  constructor(adapter: DistributionAdapter) {
+    this.adapter = adapter;
+  }
+
+  /** Attempt to initialize the airport code resolver for validation. */
+  async initializeResolver(): Promise<void> {
+    try {
+      this.airportResolver = new AirportCodeResolver();
+      await this.airportResolver.initialize();
+    } catch {
+      // Reference data may not be available — skip validation
+      this.airportResolver = null;
+    }
+  }
+
+  /** Get a cached offer by ID. */
+  getOffer(offerId: string): SearchOffer | undefined {
+    return this.offerCache.get(offerId);
+  }
+
+  /** Search for flight offers. */
+  async search(params: SearchParams): Promise<SearchResult> {
+    // Validate airport codes if resolver is available
+    if (this.airportResolver) {
+      await this.validateAirportCode(params.origin, 'origin');
+      await this.validateAirportCode(params.destination, 'destination');
+    }
+
+    // Build the canonical search request
+    const request: SearchRequest = {
+      segments: [
+        {
+          origin: params.origin.toUpperCase(),
+          destination: params.destination.toUpperCase(),
+          departure_date: params.date,
+        },
+      ],
+      passengers: [{ type: 'ADT' as PassengerType, count: params.passengers }],
+      cabin_class: params.cabinClass,
+    };
+
+    // Add return segment if round trip
+    if (params.returnDate) {
+      request.segments.push({
+        origin: params.destination.toUpperCase(),
+        destination: params.origin.toUpperCase(),
+        departure_date: params.returnDate,
+      });
+    }
+
+    const response = await this.adapter.search(request);
+
+    // Sort by price (lowest first) as default
+    const sortedOffers = [...response.offers].sort(
+      (a, b) => a.price.total - b.price.total,
+    );
+
+    // Cache offers for detail lookup
+    for (const offer of sortedOffers) {
+      this.offerCache.set(offer.offer_id, offer);
+    }
+
+    // Collect unique sources
+    const sources = [...new Set(sortedOffers.map((o) => o.source))];
+
+    return {
+      offers: sortedOffers,
+      totalFound: sortedOffers.length,
+      sources,
+    };
+  }
+
+  /** Validate a single airport code using the resolver. */
+  private async validateAirportCode(
+    code: string,
+    field: string,
+  ): Promise<void> {
+    if (!this.airportResolver) return;
+
+    try {
+      const result = await this.airportResolver.execute({
+        data: { code: code.toUpperCase(), code_type: 'iata' },
+      });
+
+      if (result.data.resolved_airport === null) {
+        const suggestion = result.data.suggestion
+          ? ` Did you mean ${result.data.suggestion}?`
+          : '';
+        throw new Error(`Invalid airport code for ${field}: ${code}.${suggestion}`);
+      }
+    } catch (err) {
+      // If the error is our own validation error, rethrow
+      if (err instanceof Error && err.message.startsWith('Invalid airport')) {
+        throw err;
+      }
+      // Otherwise swallow — let the adapter handle it
+    }
+  }
+}

--- a/examples/ota/tsconfig.json
+++ b/examples/ota/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "./dist" },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/__tests__"]
+}

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -7,7 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -7,7 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,40 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  examples/ota:
+    dependencies:
+      '@fastify/static':
+        specifier: ^8.2.0
+        version: 8.3.0
+      '@otaip/adapter-duffel':
+        specifier: workspace:*
+        version: link:../../packages/adapters/duffel
+      '@otaip/agents-pricing':
+        specifier: workspace:*
+        version: link:../../packages/agents/pricing
+      '@otaip/agents-reference':
+        specifier: workspace:*
+        version: link:../../packages/agents/reference
+      '@otaip/agents-search':
+        specifier: workspace:*
+        version: link:../../packages/agents/search
+      '@otaip/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      dotenv:
+        specifier: ^17.4.0
+        version: 17.4.0
+      fastify:
+        specifier: ^5.3.3
+        version: 5.8.5
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+
   packages/adapters/duffel:
     dependencies:
       '@otaip/core':
@@ -485,6 +519,33 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@8.3.0':
+    resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
+
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
@@ -507,6 +568,10 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -519,6 +584,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -542,6 +611,9 @@ packages:
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
@@ -891,6 +963,9 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -928,6 +1003,13 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -989,6 +1071,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
@@ -1007,6 +1093,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -1037,6 +1127,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1155,17 +1249,35 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1184,6 +1296,10 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1197,6 +1313,10 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1232,6 +1352,12 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1280,6 +1406,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1294,6 +1424,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
@@ -1306,6 +1440,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
 
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
@@ -1329,6 +1466,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1419,6 +1559,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1442,9 +1586,18 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -1478,6 +1631,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -1497,6 +1654,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -1508,6 +1668,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -1521,6 +1685,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -1564,6 +1738,12 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1575,6 +1755,9 @@ packages:
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -1588,6 +1771,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1598,6 +1785,17 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
@@ -1613,8 +1811,22 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex2@5.1.0:
+    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
+    hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1628,6 +1840,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -1659,6 +1874,13 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1666,6 +1888,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1689,6 +1915,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1706,6 +1936,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -2025,6 +2259,48 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@8.3.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 0.5.4
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 11.1.0
+
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -2040,6 +2316,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@9.0.0': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2053,6 +2331,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lukeed/ms@2.0.2': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
@@ -2086,6 +2366,8 @@ snapshots:
   '@opentelemetry/api@1.9.1': {}
 
   '@oxc-project/types@0.122.0': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
@@ -2370,6 +2652,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abstract-logging@2.0.1: {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2406,6 +2690,13 @@ snapshots:
   any-promise@1.3.0: {}
 
   assertion-error@2.0.1: {}
+
+  atomic-sleep@1.0.0: {}
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
 
   balanced-match@4.0.4: {}
 
@@ -2463,6 +2754,10 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
@@ -2472,6 +2767,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cors@2.8.6:
     dependencies:
@@ -2495,6 +2792,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -2669,13 +2968,52 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
 
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
   fast-uri@3.1.0: {}
+
+  fastify-plugin@5.1.0: {}
+
+  fastify@5.8.5:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.0
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2696,6 +3034,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -2713,6 +3057,11 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   forwarded@0.2.0: {}
 
@@ -2751,6 +3100,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
@@ -2785,6 +3143,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.3.0: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -2794,6 +3154,10 @@ snapshots:
   is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
 
   jose@6.2.2: {}
 
@@ -2805,6 +3169,10 @@ snapshots:
     optional: true
 
   json-buffer@3.0.1: {}
+
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
 
   json-schema-to-ts@3.1.1:
     dependencies:
@@ -2827,6 +3195,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2887,6 +3261,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lru-cache@11.3.5: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2903,9 +3279,13 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@3.0.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
+
+  minipass@7.1.3: {}
 
   mlly@1.8.2:
     dependencies:
@@ -2934,6 +3314,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -2959,11 +3341,18 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 
@@ -2972,6 +3361,26 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
 
   pirates@4.0.7: {}
 
@@ -3000,6 +3409,10 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3010,6 +3423,8 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
+
+  quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
 
@@ -3022,11 +3437,19 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  real-require@0.2.0: {}
+
   require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  ret@0.5.0: {}
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
     dependencies:
@@ -3093,7 +3516,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  safe-buffer@5.2.1: {}
+
+  safe-regex2@5.1.0:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@7.7.4: {}
 
@@ -3121,6 +3554,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 
@@ -3160,9 +3595,17 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -3188,6 +3631,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3200,6 +3647,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - "packages/adapters/*"
   - "packages/cli"
   - "demo"
+  - "examples/*"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,12 +18,13 @@ export default defineConfig({
       '@otaip/agents-platform': resolve(__dirname, 'packages/agents-platform/src/index.ts'),
       '@otaip/connect': resolve(__dirname, 'packages/connect/src/index.ts'),
       '@otaip/adapter-duffel': resolve(__dirname, 'packages/adapters/duffel/src/index.ts'),
+      '@otaip/ota-example': resolve(__dirname, 'examples/ota/src/server.ts'),
     },
   },
   test: {
     globals: true,
     environment: 'node',
-    include: ['packages/*/src/**/__tests__/**/*.test.ts', 'packages/agents/*/src/**/__tests__/**/*.test.ts', 'packages/adapters/*/src/**/__tests__/**/*.test.ts'],
+    include: ['packages/*/src/**/__tests__/**/*.test.ts', 'packages/agents/*/src/**/__tests__/**/*.test.ts', 'packages/adapters/*/src/**/__tests__/**/*.test.ts', 'examples/*/src/**/__tests__/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Summary

Deployable flight search application at `examples/ota/` — fork it, add your Duffel token, run it. Proves OTAIP works end to end from browser to supplier API.

### Reference OTA
- **Fastify server** — `POST /api/search`, `GET /api/offers/:id`, `GET /health`
- **Services** — SearchService (AirportCodeResolver → AvailabilitySearch), OfferService (offer caching)
- **Adapter config** — DuffelAdapter when `DUFFEL_API_TOKEN` set, MockDuffelAdapter when not (works out of the box)
- **Frontend** — plain HTML + vanilla JS + Pico CSS (CDN). Search form, results with sort, offer details with price breakdown. No React, no build step.
- **10 integration tests** using Fastify inject + MockDuffelAdapter

### Monorepo fix: exports.types → src/index.ts
14 packages had `exports["."].types` pointing to `./dist/index.d.ts` (only exists after build). Changed all to `./src/index.ts` matching `@otaip/core`'s pattern. This makes `pnpm -r run typecheck` work without a prior build step.

### Version target
This will be released as v0.3.4 after merge.

## Test plan
- [x] 2891/2891 tests passing (10 new OTA tests). 0 failing.
- [x] Lint: 0 errors
- [x] 16/16 packages typecheck clean (including OTA example)
- [x] MockDuffelAdapter returns realistic flight data for JFK-LAX, LHR-CDG routes
- [ ] Reviewer: verify frontend HTML renders correctly in browser
- [ ] Reviewer: verify exports.types change doesn't break npm consumers (top-level `types` field still points to dist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)