### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.3.4 — Sprint D+E: Docs Overhaul + Reference OTA
+
+Two sprints shipped together: Sprint D rewrites all documentation so the platform's scope is visible at a glance. Sprint E ships a deployable reference OTA that proves OTAIP works end to end — fork it, add your Duffel token, search real flights.
+
+### Sprint D — Documentation Overhaul
+
+- **README.md rewrite** — 6-adapter comparison table with exact test counts (456 total), 75-agent domain overview across 12 stages, pipeline contract system explanation, CLI usage examples, "Build on OTAIP" section
+- **docs/architecture.md** — 4 Mermaid diagrams: high-level architecture, pipeline gate sequence, tool bridge flow, EventStore integration
+- **docs/agents.md** — complete table of all 75 agents with ID, class name, description, contract status (14 contracted)
+- **docs/getting-started.md** — clone to working demo in 5 minutes
+- **docs/adapters/{amadeus,sabre,navitaire,trippro,duffel,haip}.md** — 6 adapter docs with capabilities, auth, config, usage, test counts, limitations
+- **Agent ID collision fix** — PluginManager keeps 9.5, governance agents renumbered to 9.6-9.9
+
+### Sprint E — Reference OTA: Search Flow
+
+- **Fastify server** (`examples/ota/`) — `POST /api/search`, `GET /api/offers/:id`, `GET /health`
+- **Services** — SearchService orchestrates AirportCodeResolver → AvailabilitySearch; OfferService caches offer details
+- **Adapter config** — DuffelAdapter when `DUFFEL_API_TOKEN` is set, MockDuffelAdapter when not (works out of the box with zero config)
+- **Frontend** — plain HTML + vanilla JS + Pico CSS via CDN. Search form with IATA validation, results page with sort-by-price/duration/departure, offer details with price breakdown. No React, no build step.
+- **10 integration tests** using Fastify inject + MockDuffelAdapter
+
+### Monorepo fix
+
+- **exports.types → src/index.ts** — 14 packages had `exports["."].types` pointing to `./dist/index.d.ts` (only exists after build). Changed all to `./src/index.ts` matching `@otaip/core`'s pattern. `pnpm -r run typecheck` now works without a prior build step.
+
+### Tests
+
+- 2891 total passing (10 new OTA tests + 2881 existing), 0 failing
+
 ## 0.3.3 — Sprint C: Governance Agents, Fallback Chain, CLI
 
 The OTAIP build plan is now complete. Sprint C ships the final three steps: the fallback chain engine for automatic channel recovery, four governance agents that monitor the platform's own performance, and a CLI tool for zero-code developer access.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump 0.3.3 → 0.3.4 + CHANGELOG for Sprint D (docs overhaul) and Sprint E (reference OTA search flow).

Once merged, release workflow auto-creates `v0.3.4` GitHub release.

## What's in 0.3.4

See [CHANGELOG.md](CHANGELOG.md):
- README rewrite + 9 documentation files (architecture, agents, getting-started, 6 adapter docs)
- Reference OTA at `examples/ota/` — Fastify + plain HTML, works with mock data out of the box
- Agent ID collision fix (governance agents → 9.6-9.9)
- Monorepo exports.types fix (14 packages)
- 2891 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)