### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.0 — Sprint F: Reference OTA — Book, Pay, Fly
+
+The reference OTA is now a complete booking application. Users can search flights, select an offer, enter passenger details, pay, and receive a ticket — the full travel e-commerce lifecycle running on OTAIP agents.
+
+### Added
+
+- **Booking flow** — `POST /api/book` creates a booking from a search offer with passenger details (title, name, DOB, gender) and contact info. Validates the offer exists in the search cache before booking. Returns a booking reference.
+- **Payment flow** — `POST /api/pay` processes a mock payment against a booking reference. Structured for future Stripe integration (PaymentService abstraction) but ships with a mock that always succeeds. No external payment SDK dependency.
+- **Ticketing flow (Option B)** — `POST /api/ticket` checks booking status first. If already ticketed, returns existing ticket numbers (idempotent). If not, generates mock 13-digit ticket numbers and updates status. Ticketed bookings cannot be cancelled.
+- **Booking management** — `GET /api/booking/:ref` retrieves booking details. `POST /api/cancel` cancels confirmed (not yet ticketed) bookings.
+- **4 frontend pages** — passenger details form (`book.html`), payment summary + Pay Now (`payment.html`), full confirmation with tickets + itinerary (`confirmation.html`), booking lookup + cancel (`manage.html`). Plain HTML + vanilla JS + Pico CSS.
+- **OtaAdapter interface** — extends `DistributionAdapter` with `book()`, `getBooking()`, `cancelBooking()`. MockOtaAdapter extends MockDuffelAdapter with in-memory booking store, reference generation, and status lifecycle (confirmed → ticketed/cancelled).
+- **14 integration tests** — booking CRUD, payment, idempotent ticketing, cancellation rules, 2 full end-to-end flows (search → book → pay → ticket, search → book → cancel).
+
+### Tests
+
+- 2905 total passing (14 new + 2891 existing), 0 failing
+
 ## 0.3.4 — Sprint D+E: Docs Overhaul + Reference OTA
 
 Two sprints shipped together: Sprint D rewrites all documentation so the platform's scope is visible at a glance. Sprint E ships a deployable reference OTA that proves OTAIP works end to end — fork it, add your Duffel token, search real flights.

--- a/examples/ota/package.json
+++ b/examples/ota/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/ota-example",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump 0.3.4 → 0.5.0 + CHANGELOG for Sprint F (reference OTA booking, payment, ticketing).

Once merged, release workflow auto-creates `v0.5.0` GitHub release.

## What's in 0.5.0

See [CHANGELOG.md](CHANGELOG.md) — complete booking flow in the reference OTA:
- Book, pay, ticket, manage, cancel endpoints
- OtaAdapter interface + MockOtaAdapter
- 4 frontend pages
- 14 new tests (2905 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)