### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.5.1 — Sprint G: ONE Order Ready — PNR + Orders Coexist
+
+Native Offers & Orders data model in `@otaip/core`, aligned with IATA AIDM 24.1 terminology. PNR and Order models coexist through a unified `BookingReference` bridge — agents accept either and let the adapter decide the underlying model.
+
+### Added
+
+- **Order/Offer types** — `Offer`, `OfferItem`, `Order`, `OrderItem`, `Service` (atomic unit: flight, seat, baggage, meal, lounge, insurance, ancillary), `OrderPassenger` with `TravelDocument` + `LoyaltyInfo`, `TicketDocument` (ET, EMD-A, EMD-S), `OrderPayment`, `Money` (decimal string + ISO 4217)
+- **AIDM 24.1 message names** — `OrderCreate`, `OrderRetrieve`, `OrderChange`, `OrderCancel` on the `OrderOperations` interface. Adapters that support ONE Order implement this directly.
+- **OrderEvent** — event-driven status changes for Orders (`order.created`, `order.confirmed`, `order.ticketed`, `order.changed`, `order.cancelled`, `order.payment_received`, `order.payment_failed`, `order.refunded`). Queue management stays PNR-only.
+- **BookingReference bridge** — `PnrReference | OrderReference` union type with constructors (`createPnrReference`, `createOrderReference`), type guards (`isPnrReference`, `isOrderReference`), accessors (`getBookingIdentifier`, `getBookingOwner`), and `pnrPassengerToOrderPassenger()` converter.
+- **Zod schemas** for every Order/Offer type — ready for `zodToJsonSchema()` LLM tool generation.
+- **docs/offers-and-orders.md** — explains the dual model, AIDM alignment, bridge utilities, and Sprint H roadmap (Navitaire as OOSD adapter target).
+
+### Design decisions
+
+- JSON, not XML. AIDM concepts, not the AIDM XML schema.
+- Queue management stays PNR-only. Orders use `OrderEvent`.
+- No agent modifications in this release — types and bridge only. Agent integration via `BookingReference` lands in Sprint H.
+- Navitaire is the target OOSD adapter for Sprint H — they're ONE Order certified and the adapter already exists.
+
+### Tests
+
+- 47 new tests (30 schema validation + 17 bridge utilities). 2952 total passing, 0 failing.
+
 ## 0.5.0 — Sprint F: Reference OTA — Book, Pay, Fly
 
 The reference OTA is now a complete booking application. Users can search flights, select an offer, enter passenger details, pay, and receive a ticket — the full travel e-commerce lifecycle running on OTAIP agents.

--- a/examples/ota/package.json
+++ b/examples/ota/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/ota-example",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump 0.5.0 → 0.5.1 + CHANGELOG for Sprint G (Offers & Orders data model).

Once merged, release workflow auto-creates `v0.5.1` GitHub release.

## What's in 0.5.1

See [CHANGELOG.md](CHANGELOG.md):
- AIDM 24.1 aligned Order/Offer types + OrderOperations interface
- BookingReference bridge (PNR ↔ Order coexistence)
- OrderEvent for event-driven status (no queues for Orders)
- Zod schemas for every type
- 47 new tests (2952 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)