### PR TITLE
chore: release v0.6.0 — build plan complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.6.0 — Sprint H: Multi-Adapter, OOSD-Native, Full Distribution
+
+The mid-term build plan is complete. Navitaire gains native ONE Order operations, Duffel bridges its order model to OTAIP's AIDM-aligned types, and the Reference OTA searches multiple adapters in parallel with source attribution.
+
+### Added
+
+- **Navitaire OrderOperations** — `NavitaireOrderOperations` class implements the full AIDM 24.1 `OrderOperations` interface: `orderCreate`, `orderRetrieve`, `orderChange`, `orderCancel`, `orderViewHistory`. Mock in-memory implementation with `NAV-ORD-*` IDs, status lifecycle, and `OrderEvent` tracking. Navitaire is ONE Order certified; this lets OTAIP speak to them natively.
+- **Duffel Order Bridge** — `DuffelOrderBridge` class bridges Duffel's native order model to OTAIP's AIDM-aligned `Order` types. `DFL-ORD-*` IDs, double-cancel prevention, passenger/payment/offer-item mapping.
+- **ChannelCapability Order fields** — `supportsOrders?: boolean` and `orderOperations?: ('create' | 'retrieve' | 'change' | 'cancel')[]` on `ChannelCapability`. `GdsNdcRouter` can use these to decide PNR vs Order path per channel.
+- **Multi-adapter search in Reference OTA** — `MultiSearchService` fans out search requests to multiple `DistributionAdapter` instances via `Promise.allSettled`, merges results with `adapterSource` attribution, includes per-source status with timing and error reporting. Activated via `ADAPTERS` env var (comma-separated) or `?multi=true` query param.
+- **Updated capability manifests** — Navitaire and Duffel now declare `supportsOrders: true` and the full set of order operations.
+- **docs/adapters/oosd-navitaire.md** — Navitaire ONE Order adapter documentation.
+- **docs/offers-and-orders.md** — updated with Sprint H completion section.
+
+### Tests
+
+- 33 new tests (15 Navitaire + 10 Duffel + 8 multi-search). 2985 total passing, 0 failing.
+
+### Build plan complete
+
+| Sprint | Version | Delivered |
+|---|---|---|
+| A | v0.3.2 | Pipeline validator, 9 agent contracts, capability registry |
+| B | v0.3.2.1 | Tool bridge, catalog generator, EventStore, PnrRetrieval |
+| C | v0.3.3 | Fallback chain, governance agents, CLI |
+| D+E | v0.3.4 | Docs overhaul, Reference OTA search flow |
+| F | v0.5.0 | Reference OTA booking, payment, ticketing |
+| G | v0.5.1 | Offers & Orders data model (AIDM 24.1) |
+| H | v0.6.0 | OOSD-native adapters, multi-adapter search |
+
+Final stats: **76 agents, 2985 tests, 16 workspace packages, 6 adapters, 14 contracted agents, 2 OOSD-native adapters.**
+
 ## 0.5.1 — Sprint G: ONE Order Ready — PNR + Orders Coexist
 
 Native Offers & Orders data model in `@otaip/core`, aligned with IATA AIDM 24.1 terminology. PNR and Order models coexist through a unified `BookingReference` bridge — agents accept either and let the adapter decide the underlying model.

--- a/examples/ota/package.json
+++ b/examples/ota/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/ota-example",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump 0.5.1 → 0.6.0 + CHANGELOG for Sprint H (OOSD-native adapters + multi-adapter search).

**This release completes the mid-term build plan (Sprints A through H).**

Once merged, release workflow auto-creates the `v0.6.0` GitHub release.

## What's in 0.6.0

See [CHANGELOG.md](CHANGELOG.md):
- Navitaire `OrderOperations` — native ONE Order support
- Duffel Order Bridge — AIDM-aligned order model
- `ChannelCapability` Order fields (supportsOrders, orderOperations)
- Multi-adapter search in Reference OTA with source attribution
- 33 new tests (2985 total)

## Build plan complete

| Sprint | Version | Delivered |
|---|---|---|
| A | v0.3.2 | Pipeline validator, 9 contracts, capability registry |
| B | v0.3.2.1 | Tool bridge, catalog generator, EventStore, PnrRetrieval |
| C | v0.3.3 | Fallback chain, governance agents, CLI |
| D+E | v0.3.4 | Docs overhaul, Reference OTA search flow |
| F | v0.5.0 | Reference OTA booking, payment, ticketing |
| G | v0.5.1 | Offers & Orders (AIDM 24.1) |
| **H** | **v0.6.0** | **OOSD-native, multi-adapter** |

**Final: 76 agents · 2985 tests · 16 packages · 6 adapters · 2 OOSD-native.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)