### PR TITLE
v0.6.2 — Reference OTA multi-adapter fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 > **Versioning policy:** Pre-v1.0, every release is a patch bump (`0.6.0 → 0.6.1 → 0.6.2 → …`). See [VERSIONING.md](VERSIONING.md) for the full policy and an explanation of the early-history version jumps (0.3.4 → 0.5.0 → 0.5.1 → 0.6.0) that predate this rule.
 
+## 0.6.2 — Reference OTA Multi-Adapter Fixes
+
+Three bugs in the Sprint H multi-adapter integration caught by Codex review, plus the follow-up to make booking adapter-aware. No behavior change to the single-adapter path; no breaking changes to public interfaces.
+
+### Fixed
+
+- **`buildApp()` now wires `MultiSearchService` into the search route** — `?multi=true` was previously unreachable in production. When the `ADAPTERS` env var is set, a `MultiSearchService` is constructed automatically; test callers can inject one via `buildApp({ multiSearch })`.
+- **Multi-adapter search now caches its offers** — `GET /api/offers/:id` and `POST /api/book` no longer 404 on offers returned from the multi path. New `SearchService.cacheOffers()` is called from the multi branch.
+- **`returnDate` preserved on the multi path** — round-trip requests now reach adapters with both segments. Previously the return leg was silently dropped.
+- **Adapter-aware booking routing** — bookings now route back to the adapter that produced the offer. An offer from a search-only adapter (no `book()` method) is rejected with HTTP `409` and the adapter name, not silently routed to the default adapter. New `AdapterNotBookableError` + `SearchService.getOfferAdapterSource()` + `BookingService(defaultAdapter, searchService, bookingAdapters?)` registry param.
+- **Stale `adapterSource` cleared on re-cache** — a single-adapter search after a multi-adapter search no longer leaves a stale source entry behind that would misroute a subsequent booking.
+
+### Documented
+
+- `offer_id` collision semantics within a `MultiSearchService.search()` call are explicitly last-write-wins. Production deployments that need stronger guarantees should namespace IDs with `adapterSource` at the aggregation boundary.
+
+### Tests
+
+- 12 new tests in `examples/ota/src/__tests__/search.test.ts` pinning each fix. **3034 total passing**, 0 failing.
+
 ## 0.6.1 — Stub Replacements: HotelCarSearch, AITravelAdvisor, SelfServiceRebooking, WaitlistManagement
 
 Four stub agents replaced with real implementations. No new agents; no breaking changes to public interfaces. Existing imports continue to work.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The full airline and hotel booking lifecycle — search, pricing, booking, ticketing, exchange, refund, and BSP/ARC settlement — modeled as typed, testable agents with a pipeline contract system that prevents LLM hallucinations at every step.
 
-**76 agents. 6 distribution adapters. 14 pipeline-contracted agents. 3,022 tests. TypeScript strict.**
+**76 agents. 6 distribution adapters. 14 pipeline-contracted agents. 3,034 tests. TypeScript strict.**
 
 OTAIP agents encode real industry logic: ATPCO fare rules (Categories 1-33), NUC/ROE fare construction with HIP/BHC/CTM checks, BSP HOT file reconciliation, ADM prevention (9 pre-ticketing checks), NDC/EDIFACT normalization, IRROPS rebooking with EU261 and US DOT compliance, void window enforcement, married segment integrity, and payment-to-ticketing state machines with BSP finality rules.
 
@@ -14,7 +14,7 @@ pnpm add @otaip/core @otaip/agents-booking @otaip/connect
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/telivity-otaip/otaip/actions/workflows/ci.yml/badge.svg)](https://github.com/telivity-otaip/otaip/actions)
-[![Tests](https://img.shields.io/badge/tests-3022%20passing-brightgreen)](https://github.com/telivity-otaip/otaip/actions)
+[![Tests](https://img.shields.io/badge/tests-3034%20passing-brightgreen)](https://github.com/telivity-otaip/otaip/actions)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",


### PR DESCRIPTION
## Summary

Tags PR #71's fixes for a GitHub release.

- Bumps root version `0.6.1 → 0.6.2`
- CHANGELOG.md — new `## 0.6.2` entry describing the three multi-adapter bugfixes + adapter-aware booking routing + stale-source clearing
- README.md — test badge + stat line refreshed to 3,034

## Test plan

- [x] `pnpm test` — 3034 passing
- [x] `pnpm lint` — clean
- [x] `pnpm -r run typecheck` — 16/16

Once merged, the release workflow auto-tags and publishes `v0.6.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)