### PR TITLE
fix(ci): release workflow must fail on test failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run tests and capture count
+      - name: Run tests
+        run: pnpm test 2>&1 | tee /tmp/test-output.log
+
+      - name: Capture test counts
         id: tests
         run: |
-          OUTPUT=$(pnpm test 2>&1 || true)
-          CLEAN=$(echo "$OUTPUT" | sed 's/\x1b\[[0-9;]*m//g')
+          CLEAN=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/test-output.log)
           TEST_COUNT=$(echo "$CLEAN" | sed -n 's/.*Tests  *\([0-9][0-9]*\) passed.*/\1/p' | tail -1)
           TEST_FILES=$(echo "$CLEAN" | sed -n 's/.*Test Files  *\([0-9][0-9]*\) passed.*/\1/p' | tail -1)
           echo "count=${TEST_COUNT:-0}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Codex review HIGH #1.

The previous \`Run tests and capture count\` step used \`pnpm test 2>&1 || true\`, swallowing test failures so a broken release could publish with a misleading "all green" count. Split into two steps:

1. **Run tests** — \`pnpm test 2>&1 | tee /tmp/test-output.log\`. Fails the job on non-zero exit (GitHub Actions default shell is \`bash -eo pipefail\`, so the pipe propagates pnpm's exit code).
2. **Capture test counts** — runs only when tests pass; parses the tee'd log.

## Test plan
- [x] YAML diff is minimal — only the test-running block changed
- [ ] Next release run on \`main\` exercises the new flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)