### PR TITLE
fix: harden outbound HTTP in trippro/sabre/navitaire/duffel

### DIFF
--- a/packages/adapters/duffel/src/duffel-adapter.ts
+++ b/packages/adapters/duffel/src/duffel-adapter.ts
@@ -20,6 +20,7 @@ import type {
   PriceResponse,
   PriceBreakdown,
 } from '@otaip/core';
+import { fetchWithRetry } from '@otaip/core';
 import Decimal from 'decimal.js';
 
 const DUFFEL_BASE_URL = 'https://api.duffel.com';
@@ -367,7 +368,7 @@ export class DuffelAdapter implements DistributionAdapter {
 
     let response: Response;
     try {
-      response = await fetch(url, {
+      response = await fetchWithRetry(url, {
         method,
         headers,
         body: body ? JSON.stringify(body) : undefined,

--- a/packages/connect/src/suppliers/navitaire/auth.ts
+++ b/packages/connect/src/suppliers/navitaire/auth.ts
@@ -6,6 +6,7 @@
  *   - PUT  /api/auth/v1/token       — refresh before expiry
  */
 
+import { fetchWithRetry } from '@otaip/core';
 import type { NavitaireConfig } from './config.js';
 
 interface CachedToken {
@@ -44,7 +45,7 @@ export class NavitaireAuth {
   private async createToken(): Promise<string> {
     const url = `${this.baseUrl}/api/auth/v1/token/user`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithRetry(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -70,7 +71,7 @@ export class NavitaireAuth {
 
     const url = `${this.baseUrl}/api/auth/v1/token`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithRetry(url, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/connect/src/suppliers/sabre/auth.ts
+++ b/packages/connect/src/suppliers/sabre/auth.ts
@@ -5,6 +5,7 @@
  * Tokens are cached in memory and refreshed automatically before expiry.
  */
 
+import { fetchWithRetry } from '@otaip/core';
 import type { SabreConfig } from './config.js';
 import { getBaseUrl } from './config.js';
 
@@ -40,7 +41,7 @@ export class SabreAuth {
   private async fetchToken(): Promise<string> {
     const url = `${this.baseUrl}/v2/auth/token`;
 
-    const response = await fetch(url, {
+    const response = await fetchWithRetry(url, {
       method: 'POST',
       headers: {
         Authorization: `Basic ${this.credentials}`,

--- a/packages/connect/src/suppliers/trippro/config.ts
+++ b/packages/connect/src/suppliers/trippro/config.ts
@@ -5,9 +5,11 @@
 import { z } from 'zod';
 import { validateConfig } from '../../config.js';
 
-export const TRIPPRO_DEFAULT_SEARCH_URL = 'http://mas.trippro.com/resources/v2/Flights/search';
+// HTTPS by default. To use plain HTTP for local dev/testing, override the
+// URL via TripProConfig.searchUrl / calendarSearchUrl explicitly.
+export const TRIPPRO_DEFAULT_SEARCH_URL = 'https://mas.trippro.com/resources/v2/Flights/search';
 export const TRIPPRO_DEFAULT_CALENDAR_SEARCH_URL =
-  'http://mas.trippro.com/resources/v3/calendarsearch';
+  'https://mas.trippro.com/resources/v3/calendarsearch';
 export const TRIPPRO_DEFAULT_REPRICE_URL =
   'https://map.trippro.com/resources/api/v3/repriceitinerary';
 export const TRIPPRO_DEFAULT_BOOK_URL =

--- a/packages/connect/src/suppliers/trippro/soap-client.ts
+++ b/packages/connect/src/suppliers/trippro/soap-client.ts
@@ -3,6 +3,8 @@
  * Uses raw XML templates — no SOAP client library.
  */
 
+import { fetchWithRetry } from '@otaip/core';
+
 export async function soapRequest(
   wsdlUrl: string,
   action: string,
@@ -19,7 +21,7 @@ export async function soapRequest(
   </soap:Body>
 </soap:Envelope>`;
 
-  const response = await fetch(wsdlUrl, {
+  const response = await fetchWithRetry(wsdlUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'text/xml; charset=utf-8',

--- a/packages/core/src/http/__tests__/fetch-with-retry.test.ts
+++ b/packages/core/src/http/__tests__/fetch-with-retry.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchWithRetry } from '../fetch-with-retry.js';
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(impl: typeof fetch): void {
+  globalThis.fetch = impl as typeof fetch;
+}
+
+function restore(): void {
+  globalThis.fetch = originalFetch;
+}
+
+describe('fetchWithRetry', () => {
+  afterEach(restore);
+
+  it('returns the response on first success', async () => {
+    const fn = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+    mockFetch(fn);
+
+    const res = await fetchWithRetry('https://example.test/');
+    expect(res.status).toBe(200);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 5xx until success', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 503 }))
+      .mockResolvedValueOnce(new Response('', { status: 502 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    mockFetch(fn);
+
+    const res = await fetchWithRetry('https://example.test/', {}, { retry: { baseDelayMs: 1, maxRetries: 3 } });
+    expect(res.status).toBe(200);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries on 429', async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    mockFetch(fn);
+
+    const res = await fetchWithRetry('https://example.test/', {}, { retry: { baseDelayMs: 1, maxRetries: 2 } });
+    expect(res.status).toBe(200);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry 4xx other than 429', async () => {
+    const fn = vi.fn().mockResolvedValue(new Response('', { status: 404 }));
+    mockFetch(fn);
+
+    const res = await fetchWithRetry('https://example.test/', {}, { retry: { baseDelayMs: 1, maxRetries: 3 } });
+    expect(res.status).toBe(404);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the last 5xx after exhausting retries', async () => {
+    const fn = vi.fn().mockResolvedValue(new Response('', { status: 502 }));
+    mockFetch(fn);
+
+    const res = await fetchWithRetry(
+      'https://example.test/',
+      {},
+      { retry: { baseDelayMs: 1, maxRetries: 2 } },
+    );
+    expect(res.status).toBe(502);
+    expect(fn).toHaveBeenCalledTimes(3); // 1 + 2 retries
+  });
+
+  it('retries on network errors (TypeError)', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    mockFetch(fn);
+
+    const res = await fetchWithRetry('https://example.test/', {}, { retry: { baseDelayMs: 1, maxRetries: 2 } });
+    expect(res.status).toBe(200);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts after timeout and counts as a retryable error', async () => {
+    let callCount = 0;
+    mockFetch((_url, init) => {
+      callCount++;
+      // Never resolve until aborted.
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        signal?.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+
+    const res = await fetchWithRetry(
+      'https://example.test/',
+      {},
+      { timeoutMs: 5, retry: { baseDelayMs: 1, maxRetries: 1 } },
+    ).catch((e) => e as Error);
+
+    // After 1 + 1 retries both abort. Final result is a thrown error.
+    expect(callCount).toBe(2);
+    expect((res as Error).name).toBe('AbortError');
+  });
+
+  it('does not retry non-retryable errors (e.g. SyntaxError)', async () => {
+    const fn = vi.fn().mockRejectedValue(new SyntaxError('bad'));
+    mockFetch(fn);
+
+    await expect(
+      fetchWithRetry('https://example.test/', {}, { retry: { baseDelayMs: 1, maxRetries: 3 } }),
+    ).rejects.toBeInstanceOf(SyntaxError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/http/fetch-with-retry.ts
+++ b/packages/core/src/http/fetch-with-retry.ts
@@ -1,0 +1,94 @@
+/**
+ * Hardened fetch wrapper: AbortController timeout + retry on 5xx/429/network errors.
+ *
+ * Use this for all outbound HTTP calls in adapters. It centralizes:
+ *   - Per-request timeout (AbortController)
+ *   - Retry policy (delegates to withRetry)
+ *   - Retryable-error classification (5xx, 429, network/timeout)
+ */
+
+import { withRetry } from '../retry/retry.js';
+import type { RetryConfig } from '../retry/types.js';
+
+export interface FetchWithRetryOptions {
+  /** Timeout per attempt in milliseconds. Default: 30_000. */
+  timeoutMs?: number;
+  /** Retry configuration overrides (merged with DEFAULT_RETRY_CONFIG). */
+  retry?: Partial<RetryConfig>;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * A Response is retryable when status is 5xx or 429 (rate limit).
+ * 4xx other than 429 is a client error and should not retry.
+ */
+function isRetryableResponse(response: Response): boolean {
+  return response.status >= 500 || response.status === 429;
+}
+
+/**
+ * Network/timeout/abort errors are retryable. Anything else thrown by fetch
+ * (e.g. type errors from invalid args) is a programmer error and not retried.
+ */
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    if (error.name === 'AbortError') return true;
+    if (error.name === 'TimeoutError') return true;
+    // node fetch surfaces network failures as TypeError with cause set.
+    if (error.name === 'TypeError') return true;
+  }
+  return false;
+}
+
+/**
+ * Carries a non-retryable Response back through withRetry. We throw a
+ * sentinel error wrapping the response so withRetry can decide whether to
+ * retry, then unwrap on success.
+ */
+class HttpRetryableResponseError extends Error {
+  constructor(public readonly response: Response) {
+    super(`HTTP ${response.status} ${response.statusText}`);
+    this.name = 'HttpRetryableResponseError';
+  }
+}
+
+/**
+ * Fetch with timeout + retry. Returns the Response on success (any 2xx-4xx
+ * that we won't retry). Throws on exhaustion or non-retryable failure.
+ *
+ * Callers still inspect `response.ok` themselves — this wrapper does not
+ * convert 4xx into errors, only retries 5xx/429.
+ */
+export async function fetchWithRetry(
+  input: string | URL,
+  init: RequestInit = {},
+  options: FetchWithRetryOptions = {},
+): Promise<Response> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const attempt = async (): Promise<Response> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(input, { ...init, signal: controller.signal });
+      if (isRetryableResponse(response)) {
+        throw new HttpRetryableResponseError(response);
+      }
+      return response;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  try {
+    return await withRetry(attempt, options.retry, (err) => {
+      if (err instanceof HttpRetryableResponseError) return true;
+      return isRetryableError(err);
+    });
+  } catch (err) {
+    // Unwrap the sentinel so callers see the underlying Response.
+    if (err instanceof HttpRetryableResponseError) return err.response;
+    throw err;
+  }
+}

--- a/packages/core/src/http/index.ts
+++ b/packages/core/src/http/index.ts
@@ -1,0 +1,2 @@
+export { fetchWithRetry } from './fetch-with-retry.js';
+export type { FetchWithRetryOptions } from './fetch-with-retry.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,9 @@ export type {
 export type { RetryConfig, IsRetryable } from './retry/index.js';
 export { DEFAULT_RETRY_CONFIG, withRetry, computeDelay } from './retry/index.js';
 
+export { fetchWithRetry } from './http/index.js';
+export type { FetchWithRetryOptions } from './http/index.js';
+
 export type {
   LoopPhase,
   ToolCall,


### PR DESCRIPTION
## Summary
Codex review HIGH #2.

Auth/transport paths in TripPro, Sabre, Navitaire and Duffel were calling raw \`fetch()\` with no timeout, no retry, and (for TripPro search/calendar) plain HTTP defaults. Hung connections would block forever; transient 5xx/429s would surface as hard failures.

### Changes
- **New** \`@otaip/core\` \`fetchWithRetry(input, init?, options?)\` — wraps \`fetch\` with:
  - \`AbortController\` per attempt (default 30s timeout)
  - Retry on 5xx, 429, and network/abort errors via \`withRetry\`
  - 4xx other than 429 returned as-is (caller still inspects \`response.ok\`)
- **TripPro config**: \`searchUrl\` / \`calendarSearchUrl\` defaults now \`https://\` (were \`http://\`). Reprice/book were already https. Comment notes how to override for local dev.
- **TripPro SOAP client, Sabre auth, Navitaire create+refresh, Duffel \`request\`**: now route through \`fetchWithRetry\`.
- **8 new tests** for \`fetchWithRetry\` covering success, 5xx retry, 429 retry, 4xx no-retry, exhaustion (returns last response), network-error retry, abort on timeout, non-retryable error.

### What did NOT change
- Adapter response parsing / error wrapping (still callers' responsibility)
- Rate limiter behavior
- Existing 3,034 tests — all still pass

## Test plan
- [x] \`pnpm install --frozen-lockfile\` — succeeds
- [x] \`pnpm -r run typecheck\` — passes
- [x] \`pnpm run lint\` — passes
- [x] \`pnpm test\` — 3,042 tests pass (3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)