### PR TITLE
fix: remove invented domain logic from fare/change/refund/irrop engines

### DIFF
--- a/packages/agents/exchange/src/change-management/__tests__/change-management.test.ts
+++ b/packages/agents/exchange/src/change-management/__tests__/change-management.test.ts
@@ -2,11 +2,25 @@
  * Change Management — Unit Tests
  *
  * Agent 5.1: ATPCO Cat 31 voluntary change assessment.
+ *
+ * Tests pass Cat31 rules in via input.cat31_rules using the test fixture
+ * to exercise the apply-as-filed branch. Tests of the no-rules branch
+ * verify the ATPCO default (permitted at no charge / fee waived for
+ * involuntary changes).
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'node:module';
 import { ChangeManagement } from '../index.js';
-import type { ChangeManagementInput, OriginalTicketSummary, RequestedItinerary } from '../types.js';
+import type {
+  ChangeManagementInput,
+  Cat31Rules,
+  OriginalTicketSummary,
+  RequestedItinerary,
+} from '../types.js';
+
+const require = createRequire(import.meta.url);
+const TEST_CAT31_RULES = require('./fixtures/test-cat31-rules.json') as Cat31Rules;
 
 let agent: ChangeManagement;
 
@@ -62,12 +76,13 @@ function makeInput(overrides: Partial<ChangeManagementInput> = {}): ChangeManage
     original_ticket: makeOriginal(),
     requested_itinerary: makeRequested(),
     current_datetime: '2026-03-15T12:00:00Z',
+    cat31_rules: TEST_CAT31_RULES,
     ...overrides,
   };
 }
 
 describe('Change Management', () => {
-  describe('Basic change assessment', () => {
+  describe('Basic change assessment (with filed Cat31 rules)', () => {
     it('calculates fare difference (upgrade)', async () => {
       const result = await agent.execute({ data: makeInput() });
       expect(result.data.assessment.fare_difference).toBe('100.00');
@@ -78,7 +93,7 @@ describe('Change Management', () => {
       expect(result.data.assessment.additional_collection).toBe('100.00');
     });
 
-    it('includes change fee for restricted fare', async () => {
+    it('includes change fee for restricted fare per filed rule', async () => {
       const result = await agent.execute({ data: makeInput() });
       expect(Number(result.data.assessment.change_fee)).toBeGreaterThan(0);
     });
@@ -107,6 +122,34 @@ describe('Change Management', () => {
     });
   });
 
+  describe('ATPCO default — no Cat31 rules supplied', () => {
+    it('voluntary change with no rules: penalty = 0 (ATPCO default)', async () => {
+      const result = await agent.execute({
+        data: makeInput({ cat31_rules: undefined }),
+      });
+      expect(result.data.assessment.change_fee).toBe('0.00');
+      expect(result.data.assessment.fee_waived).toBe(false);
+      expect(result.data.assessment.summary).toContain('ATPCO default');
+    });
+
+    it('involuntary change with no rules: penalty = 0, fee_waived = true', async () => {
+      const result = await agent.execute({
+        data: makeInput({ cat31_rules: undefined, is_involuntary: true }),
+      });
+      expect(result.data.assessment.change_fee).toBe('0.00');
+      expect(result.data.assessment.fee_waived).toBe(true);
+      expect(result.data.assessment.summary).toContain('Involuntary');
+    });
+
+    it('involuntary change with rules: filed penalty still waived to 0', async () => {
+      const result = await agent.execute({
+        data: makeInput({ is_involuntary: true }),
+      });
+      expect(result.data.assessment.change_fee).toBe('0.00');
+      expect(result.data.assessment.fee_waived).toBe(true);
+    });
+  });
+
   describe('Fare difference scenarios', () => {
     it('zero fare difference when same fare', async () => {
       const input = makeInput({
@@ -125,7 +168,7 @@ describe('Change Management', () => {
       expect(result.data.assessment.fare_difference).toBe('-100.00');
     });
 
-    it('forfeits difference on non-refundable downgrade', async () => {
+    it('forfeits difference on non-refundable downgrade per filed rule', async () => {
       const input = makeInput({
         original_ticket: makeOriginal({ is_refundable: false }),
         requested_itinerary: makeRequested({ new_fare: '350.00', new_tax: '110.00' }),
@@ -144,11 +187,11 @@ describe('Change Management', () => {
     });
   });
 
-  describe('Free change window', () => {
+  describe('Free change window (per filed rule)', () => {
     it('free change within 24h of booking', async () => {
       const input = makeInput({
         original_ticket: makeOriginal({ booking_date: '2026-03-15T10:00:00Z' }),
-        current_datetime: '2026-03-15T20:00:00Z', // 10h after booking
+        current_datetime: '2026-03-15T20:00:00Z',
       });
       const result = await agent.execute({ data: input });
       expect(result.data.assessment.is_free_change).toBe(true);
@@ -159,13 +202,13 @@ describe('Change Management', () => {
     it('not free after 24h window', async () => {
       const input = makeInput({
         original_ticket: makeOriginal({ booking_date: '2026-03-01T10:00:00Z' }),
-        current_datetime: '2026-03-15T12:00:00Z', // 14 days after
+        current_datetime: '2026-03-15T12:00:00Z',
       });
       const result = await agent.execute({ data: input });
       expect(result.data.assessment.is_free_change).toBe(false);
     });
 
-    it('full-fare Y class has no change fee (always free)', async () => {
+    it('full-fare Y class has no change fee per filed rule', async () => {
       const input = makeInput({
         original_ticket: makeOriginal({ fare_basis: 'YOWUS' }),
       });
@@ -173,7 +216,7 @@ describe('Change Management', () => {
       expect(result.data.assessment.change_fee).toBe('0.00');
     });
 
-    it('business class has no change fee', async () => {
+    it('business class has no change fee per filed rule', async () => {
       const input = makeInput({
         original_ticket: makeOriginal({ fare_basis: 'COWUS' }),
       });
@@ -198,7 +241,7 @@ describe('Change Management', () => {
     });
   });
 
-  describe('Reject fares', () => {
+  describe('Reject fares (per filed reject_patterns)', () => {
     it('rejects change for BASIC economy', async () => {
       const input = makeInput({
         original_ticket: makeOriginal({ fare_basis: 'HOWBASIC' }),
@@ -222,6 +265,15 @@ describe('Change Management', () => {
       const result = await agent.execute({ data: input });
       expect(result.warnings).toBeDefined();
       expect(result.warnings![0]).toContain('not permitted');
+    });
+
+    it('does NOT reject BASIC fare when no Cat31 rules supplied', async () => {
+      const input = makeInput({
+        original_ticket: makeOriginal({ fare_basis: 'HOWBASIC' }),
+        cat31_rules: undefined,
+      });
+      const result = await agent.execute({ data: input });
+      expect(result.data.assessment.action).not.toBe('REJECT');
     });
   });
 

--- a/packages/agents/exchange/src/change-management/__tests__/fixtures/test-cat31-rules.json
+++ b/packages/agents/exchange/src/change-management/__tests__/fixtures/test-cat31-rules.json
@@ -1,5 +1,5 @@
 {
-  "description": "ATPCO Category 31 change fee rules by fare basis pattern. Based on common industry patterns.",
+  "description": "TEST FIXTURE — invented common-industry patterns. Do NOT use in production. Real Cat31 data must come from authoritative ATPCO feeds for the specific carrier/market/fare-basis. Used here only to exercise the engine's apply-as-filed branch.",
   "rules": [
     {
       "fare_basis_pattern": "^Y",

--- a/packages/agents/exchange/src/change-management/change-engine.ts
+++ b/packages/agents/exchange/src/change-management/change-engine.ts
@@ -1,29 +1,37 @@
 /**
  * Change Management Engine — ATPCO Cat 31 voluntary change assessment.
+ *
+ * No invented penalty amounts.
+ *
+ * - When `input.cat31_rules` is provided, the engine applies the filed
+ *   rules: pattern-match the fare basis, use the rule's penalty, free-
+ *   change window, and downgrade-forfeit flag.
+ * - When `input.cat31_rules` is absent, the engine uses the ATPCO
+ *   default per the project's domain spec: voluntary changes are
+ *   PERMITTED AT NO CHARGE; involuntary changes have the fee waived.
+ *
+ * The previous "$200 default" fallback was a CLAUDE.md violation and
+ * has been removed. Carrier-specific rules MUST flow in via input.
+ *
+ * // DOMAIN_QUESTION: per-carrier ATPCO Cat31 data ingestion pipeline.
  */
 
 import Decimal from 'decimal.js';
-import { createRequire } from 'node:module';
 import type {
   ChangeManagementInput,
   ChangeManagementOutput,
   ChangeAssessment,
   ChangeFeeRule,
   ChangeAction,
+  Cat31Rules,
 } from './types.js';
-
-const require = createRequire(import.meta.url);
-const rulesData = require('./data/change-fee-rules.json') as {
-  rules: ChangeFeeRule[];
-  reject_patterns: string[];
-};
 
 function currentTime(input: ChangeManagementInput): Date {
   return input.current_datetime ? new Date(input.current_datetime) : new Date();
 }
 
-function findMatchingRule(fareBasis: string): ChangeFeeRule | undefined {
-  for (const rule of rulesData.rules) {
+function findMatchingRule(rules: ChangeFeeRule[], fareBasis: string): ChangeFeeRule | undefined {
+  for (const rule of rules) {
     const re = new RegExp(rule.fare_basis_pattern);
     if (re.test(fareBasis)) {
       return rule;
@@ -32,8 +40,9 @@ function findMatchingRule(fareBasis: string): ChangeFeeRule | undefined {
   return undefined;
 }
 
-function isRejectFare(fareBasis: string): boolean {
-  return rulesData.reject_patterns.some((p) => new RegExp(p).test(fareBasis));
+function isRejectFare(rules: Cat31Rules | undefined, fareBasis: string): boolean {
+  if (!rules) return false;
+  return rules.reject_patterns.some((p) => new RegExp(p).test(fareBasis));
 }
 
 function isWithinFreeChangeWindow(
@@ -52,9 +61,10 @@ export function assessChange(input: ChangeManagementInput): ChangeManagementOutp
   const orig = input.original_ticket;
   const req = input.requested_itinerary;
   const currency = orig.base_fare_currency;
+  const isInvoluntary = input.is_involuntary === true;
 
-  // Check if fare basis is a reject type (BASIC, NR)
-  if (isRejectFare(orig.fare_basis)) {
+  // Reject path applies only when filed rules say so.
+  if (isRejectFare(input.cat31_rules, orig.fare_basis)) {
     const assessment: ChangeAssessment = {
       original_ticket_number: orig.ticket_number,
       action: 'REJECT',
@@ -68,18 +78,24 @@ export function assessChange(input: ChangeManagementInput): ChangeManagementOutp
       tax_difference: '0.00',
       total_due: '0.00',
       currency,
-      summary: `Change not permitted for fare basis ${orig.fare_basis}. This fare type does not allow voluntary changes.`,
+      summary: `Change not permitted for fare basis ${orig.fare_basis}. This fare type does not allow voluntary changes (filed Cat31 rejection).`,
       is_free_change: false,
     };
     return { assessment };
   }
 
-  const rule = findMatchingRule(orig.fare_basis);
+  const rule = input.cat31_rules
+    ? findMatchingRule(input.cat31_rules.rules, orig.fare_basis)
+    : undefined;
 
-  // Default rule if no match
-  const changeFeeAmount = rule ? new Decimal(rule.change_fee) : new Decimal('200.00');
-  const freeChangeHours = rule?.free_change_hours ?? 24;
-  const forfeitOnDowngrade = rule?.forfeit_difference_on_downgrade ?? true;
+  // Penalty source-of-truth:
+  //   1. Filed Cat31 rule for this fare basis  → rule.change_fee
+  //   2. No rule + involuntary                  → 0 (carrier-initiated)
+  //   3. No rule + voluntary                    → 0 (ATPCO default)
+  // The previous "$200 default when no rule" path was an invention.
+  const changeFeeAmount = rule ? new Decimal(rule.change_fee) : new Decimal('0.00');
+  const freeChangeHours = rule?.free_change_hours ?? 0;
+  const forfeitOnDowngrade = rule?.forfeit_difference_on_downgrade ?? false;
 
   // Check free change window
   const isFreeChange = isWithinFreeChangeWindow(orig.booking_date, now, freeChangeHours);
@@ -87,8 +103,9 @@ export function assessChange(input: ChangeManagementInput): ChangeManagementOutp
   // Check waiver code
   const hasWaiver = !!input.waiver_code;
 
-  // Effective change fee
-  const effectiveChangeFee = isFreeChange || hasWaiver ? new Decimal('0.00') : changeFeeAmount;
+  // Effective change fee: 0 if free window, waiver, or involuntary; else the filed amount.
+  const effectiveChangeFee =
+    isFreeChange || hasWaiver || isInvoluntary ? new Decimal('0.00') : changeFeeAmount;
 
   // Fare difference
   const originalFare = new Decimal(orig.base_fare);
@@ -113,7 +130,7 @@ export function assessChange(input: ChangeManagementInput): ChangeManagementOutp
   } else if (fareDifference.lessThan(0)) {
     // Downgrade
     if (!orig.is_refundable && forfeitOnDowngrade) {
-      // Non-refundable: forfeit the difference
+      // Non-refundable AND filed rule says forfeit: forfeit the difference
       forfeitedAmount = fareDifference.abs();
     }
     // Refundable fares: the negative difference would be credited (handled by agent 5.2)
@@ -131,8 +148,11 @@ export function assessChange(input: ChangeManagementInput): ChangeManagementOutp
 
   // Build summary
   const summaryParts: string[] = [];
+  if (isInvoluntary) summaryParts.push('Involuntary change — fee waived per carrier/regulatory practice.');
   if (isFreeChange) summaryParts.push('Free change (within booking window).');
   if (hasWaiver) summaryParts.push(`Waiver code ${input.waiver_code!} applied — penalty waived.`);
+  if (!rule && !input.cat31_rules)
+    summaryParts.push('No Cat31 rules supplied — applying ATPCO default (no charge).');
   if (effectiveChangeFee.greaterThan(0))
     summaryParts.push(`Change fee: ${currency} ${effectiveChangeFee.toFixed(2)}.`);
   if (additionalCollection.greaterThan(0))
@@ -147,8 +167,8 @@ export function assessChange(input: ChangeManagementInput): ChangeManagementOutp
     action,
     change_fee: effectiveChangeFee.toFixed(2),
     change_fee_currency: currency,
-    fee_waived: isFreeChange || hasWaiver,
-    waiver_code: input.waiver_code,
+    fee_waived: isFreeChange || hasWaiver || isInvoluntary,
+    ...(input.waiver_code !== undefined ? { waiver_code: input.waiver_code } : {}),
     fare_difference: fareDifference.toFixed(2),
     additional_collection: additionalCollection.toFixed(2),
     residual_value: residualValue.toFixed(2),

--- a/packages/agents/exchange/src/change-management/types.ts
+++ b/packages/agents/exchange/src/change-management/types.ts
@@ -102,6 +102,25 @@ export interface ChangeAssessment {
   is_free_change: boolean;
 }
 
+/**
+ * ATPCO Category 31 rule set, per carrier/market/fare-basis pattern.
+ *
+ * Real Cat31 data comes from authoritative ATPCO feeds. This engine no
+ * longer hardcodes "common industry pattern" rules — the caller supplies
+ * the rules to apply. When `cat31_rules` is omitted, the engine falls
+ * back to the ATPCO default for voluntary changes (permitted at no
+ * charge) per the user-supplied domain spec.
+ */
+export interface Cat31Rules {
+  /** Filed change-fee rules. First match wins. */
+  rules: ChangeFeeRule[];
+  /**
+   * Fare-basis patterns whose carrier filing rejects voluntary changes
+   * outright (basic-economy, certain non-rebookable fares).
+   */
+  reject_patterns: string[];
+}
+
 export interface ChangeManagementInput {
   /** Original ticket summary */
   original_ticket: OriginalTicketSummary;
@@ -111,6 +130,20 @@ export interface ChangeManagementInput {
   waiver_code?: string;
   /** Current date/time (ISO — defaults to now) */
   current_datetime?: string;
+  /**
+   * Whether this change is carrier-initiated (involuntary). When true,
+   * the change fee is waived to 0 and downstream callers should consult
+   * Agent 5.3 (involuntary-rebook) for regulatory entitlements.
+   */
+  is_involuntary?: boolean;
+  /**
+   * ATPCO Category 31 rules. When present → engine applies as filed.
+   * When absent → ATPCO default (voluntary: no charge; involuntary:
+   * waived). The engine never invents a penalty amount.
+   *
+   * // DOMAIN_QUESTION: per-carrier ATPCO Cat31 ingestion pipeline.
+   */
+  cat31_rules?: Cat31Rules;
 }
 
 export interface ChangeManagementOutput {

--- a/packages/agents/exchange/src/involuntary-rebook/__tests__/involuntary-rebook.test.ts
+++ b/packages/agents/exchange/src/involuntary-rebook/__tests__/involuntary-rebook.test.ts
@@ -294,12 +294,14 @@ describe('Involuntary Rebook', () => {
       expect(eu261.reduction_percent).toBe(0);
     });
 
-    it('applies 50% long-haul reduction (€300) for 3-4h delay', async () => {
+    it('applies Article 7(2) 50% rerouting reduction when alternative arrival within band', async () => {
       const input = makeInput({
         eu261_inputs: {
           distance_km: 6000,
-          arrival_delay_hours: 3.5,
+          arrival_delay_hours: 5,
           extraordinary_circumstances: false,
+          rerouting_offered: true,
+          rerouting_arrival_lateness_hours: 4,
         },
       });
       const result = await agent.execute({ data: input });

--- a/packages/agents/exchange/src/involuntary-rebook/__tests__/involuntary-rebook.test.ts
+++ b/packages/agents/exchange/src/involuntary-rebook/__tests__/involuntary-rebook.test.ts
@@ -1,7 +1,9 @@
 /**
  * Involuntary Rebook — Unit Tests
  *
- * Agent 5.3: Schedule change handling, protection logic, regulatory flags.
+ * Agent 5.3: Schedule change handling, protection logic, regulatory entitlements.
+ *
+ * Threshold and EU261 inputs are PASSED EXPLICITLY (no invented defaults).
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -62,6 +64,7 @@ function makeInput(overrides: Partial<InvoluntaryRebookInput> = {}): Involuntary
   return {
     original_pnr: makePnr(),
     schedule_change: makeChange(),
+    thresholds: { time_change_minutes: 60 },
     available_flights: [
       {
         carrier: 'BA',
@@ -100,13 +103,13 @@ function makeInput(overrides: Partial<InvoluntaryRebookInput> = {}): Involuntary
 
 describe('Involuntary Rebook', () => {
   describe('Trigger assessment', () => {
-    it('marks time change > 60min as involuntary', async () => {
+    it('marks time change > supplied threshold as involuntary', async () => {
       const result = await agent.execute({ data: makeInput() });
       expect(result.data.result.is_involuntary).toBe(true);
       expect(result.data.result.trigger).toBe('TIME_CHANGE');
     });
 
-    it('marks time change <= 60min as not involuntary', async () => {
+    it('marks time change <= supplied threshold as not involuntary', async () => {
       const input = makeInput({
         schedule_change: makeChange({ time_change_minutes: 30 }),
       });
@@ -121,6 +124,16 @@ describe('Involuntary Rebook', () => {
       });
       const result = await agent.execute({ data: input });
       expect(result.data.result.is_involuntary).toBe(true);
+    });
+
+    it('returns non-involuntary + DOMAIN_INPUT_REQUIRED warning when time threshold missing', async () => {
+      const input = makeInput({ thresholds: undefined });
+      const result = await agent.execute({ data: input });
+      expect(result.data.result.is_involuntary).toBe(false);
+      expect(result.warnings).toBeDefined();
+      expect(
+        result.warnings!.some((w) => w.includes('DOMAIN_INPUT_REQUIRED') && w.includes('time_change_minutes')),
+      ).toBe(true);
     });
 
     it('flight cancellation is always involuntary', async () => {
@@ -259,6 +272,55 @@ describe('Involuntary Rebook', () => {
       expect(eu261!.applies).toBe(true);
     });
 
+    it('reports DOMAIN_INPUT_REQUIRED when EU261 inputs are missing', async () => {
+      const result = await agent.execute({ data: makeInput() });
+      const eu261 = result.data.result.regulatory_flags.find((f) => f.framework === 'EU261')!;
+      expect(eu261.compensation_eur).toBeNull();
+      expect(eu261.missing_inputs).toBeDefined();
+      expect(eu261.missing_inputs).toContain('eu261_inputs.distance_km');
+    });
+
+    it('computes €600 for >3500km flight delayed 5h', async () => {
+      const input = makeInput({
+        eu261_inputs: {
+          distance_km: 6000,
+          arrival_delay_hours: 5,
+          extraordinary_circumstances: false,
+        },
+      });
+      const result = await agent.execute({ data: input });
+      const eu261 = result.data.result.regulatory_flags.find((f) => f.framework === 'EU261')!;
+      expect(eu261.compensation_eur).toBe('600.00');
+      expect(eu261.reduction_percent).toBe(0);
+    });
+
+    it('applies 50% long-haul reduction (€300) for 3-4h delay', async () => {
+      const input = makeInput({
+        eu261_inputs: {
+          distance_km: 6000,
+          arrival_delay_hours: 3.5,
+          extraordinary_circumstances: false,
+        },
+      });
+      const result = await agent.execute({ data: input });
+      const eu261 = result.data.result.regulatory_flags.find((f) => f.framework === 'EU261')!;
+      expect(eu261.compensation_eur).toBe('300.00');
+      expect(eu261.reduction_percent).toBe(50);
+    });
+
+    it('returns €0 under extraordinary circumstances', async () => {
+      const input = makeInput({
+        eu261_inputs: {
+          distance_km: 6000,
+          arrival_delay_hours: 5,
+          extraordinary_circumstances: true,
+        },
+      });
+      const result = await agent.execute({ data: input });
+      const eu261 = result.data.result.regulatory_flags.find((f) => f.framework === 'EU261')!;
+      expect(eu261.compensation_eur).toBe('0.00');
+    });
+
     it('flags EU261 for EU carrier regardless of route', async () => {
       const input = makeInput({
         original_pnr: makePnr({
@@ -297,41 +359,12 @@ describe('Involuntary Rebook', () => {
   });
 
   describe('Regulatory entitlements — US DOT', () => {
-    it('flags US DOT for US departure', async () => {
-      const input = makeInput({
-        original_pnr: makePnr({ departure_country: 'US' }),
-      });
-      const result = await agent.execute({ data: input });
-      const usDot = result.data.result.regulatory_flags.find((f) => f.framework === 'US_DOT');
-      expect(usDot!.applies).toBe(true);
-    });
-
-    it('flags US DOT for US arrival', async () => {
+    it('reports US DOT IDB as not applicable on rebook path (delays/cancels are not denied boarding)', async () => {
       const result = await agent.execute({ data: makeInput() });
       const usDot = result.data.result.regulatory_flags.find((f) => f.framework === 'US_DOT');
-      expect(usDot!.applies).toBe(true); // arrival_country: 'US'
-    });
-
-    it('does not flag US DOT for non-US route', async () => {
-      const input = makeInput({
-        original_pnr: makePnr({
-          departure_country: 'GB',
-          arrival_country: 'JP',
-          affected_segment: {
-            carrier: 'BA',
-            flight_number: '5',
-            origin: 'LHR',
-            destination: 'NRT',
-            departure_date: '2026-06-15',
-            departure_time: '11:00',
-            booking_class: 'Y',
-            fare_basis: 'YOWJP',
-          },
-        }),
-      });
-      const result = await agent.execute({ data: input });
-      const usDot = result.data.result.regulatory_flags.find((f) => f.framework === 'US_DOT');
+      expect(usDot).toBeDefined();
       expect(usDot!.applies).toBe(false);
+      expect(usDot!.reason).toMatch(/14 CFR §250/);
     });
   });
 

--- a/packages/agents/exchange/src/involuntary-rebook/index.ts
+++ b/packages/agents/exchange/src/involuntary-rebook/index.ts
@@ -44,9 +44,10 @@ export class InvoluntaryRebook implements Agent<InvoluntaryRebookInput, Involunt
 
     this.validateInput(input.data);
 
-    const result = processInvoluntaryRebook(input.data);
+    const engineOutput = processInvoluntaryRebook(input.data);
+    const result = { result: engineOutput.result };
 
-    const warnings: string[] = [];
+    const warnings: string[] = [...(engineOutput.warnings ?? [])];
     if (result.result.is_involuntary) {
       warnings.push(`Involuntary change detected: ${result.result.trigger}.`);
       for (const flag of result.result.regulatory_flags) {

--- a/packages/agents/exchange/src/involuntary-rebook/rebook-engine.ts
+++ b/packages/agents/exchange/src/involuntary-rebook/rebook-engine.ts
@@ -1,9 +1,26 @@
 /**
  * Involuntary Rebook Engine — trigger assessment, protection logic,
  * regulatory entitlements.
+ *
+ * EU261 compensation is delegated to @otaip/core regulations/eu261, which
+ * encodes the published Regulation (EC) No 261/2004 constants.
+ *
+ * US DOT 14 CFR §250 IDB applies only to involuntary denied boarding
+ * (oversales) — NOT to delays/cancellations. We therefore mark the US_DOT
+ * flag as not-applicable on the rebook path even when a US touchpoint
+ * exists, and reference the IDB module for callers who do hit oversales
+ * (Agent 6.5 Feedback & Complaint).
+ *
+ * // DOMAIN_QUESTION: per-carrier IRROP threshold catalogue
+ * // The 60-minute time-change threshold previously hardcoded here was
+ * // a CLAUDE.md violation. Different carriers define IRROP triggers
+ * // differently. Callers must supply `input.thresholds.time_change_minutes`
+ * // when assessing a TIME_CHANGE; without it we conservatively report
+ * // non-involuntary and emit a warning.
  */
 
 import { createRequire } from 'node:module';
+import { applyEU261 } from '@otaip/core';
 import type {
   InvoluntaryRebookInput,
   InvoluntaryRebookOutput,
@@ -18,19 +35,20 @@ const require = createRequire(import.meta.url);
 const euData = require('./data/eu-countries.json') as { countries: string[] };
 const EU_COUNTRIES = new Set(euData.countries);
 
-const DEFAULT_TIME_CHANGE_THRESHOLD = 60; // minutes
-
 // ---------------------------------------------------------------------------
 // Trigger assessment
 // ---------------------------------------------------------------------------
 
-function assessTrigger(input: InvoluntaryRebookInput): {
+interface TriggerAssessment {
   isInvoluntary: boolean;
   trigger: InvoluntaryTrigger;
-} {
+  /** Set when threshold input was needed but missing. */
+  missingThreshold?: boolean;
+}
+
+function assessTrigger(input: InvoluntaryRebookInput): TriggerAssessment {
   const sc = input.schedule_change;
-  const thresholds = input.thresholds ?? {};
-  const timeThreshold = thresholds.time_change_minutes ?? DEFAULT_TIME_CHANGE_THRESHOLD;
+  const threshold = input.thresholds?.time_change_minutes;
 
   if (input.is_passenger_no_show) {
     return { isInvoluntary: false, trigger: 'NO_SHOW' };
@@ -41,22 +59,20 @@ function assessTrigger(input: InvoluntaryRebookInput): {
       return { isInvoluntary: true, trigger: 'FLIGHT_CANCELLATION' };
 
     case 'TIME_CHANGE': {
+      if (threshold === undefined) {
+        return { isInvoluntary: false, trigger: 'TIME_CHANGE', missingThreshold: true };
+      }
       const minutes = sc.time_change_minutes ?? 0;
-      return {
-        isInvoluntary: minutes > timeThreshold,
-        trigger: 'TIME_CHANGE',
-      };
+      return { isInvoluntary: minutes > threshold, trigger: 'TIME_CHANGE' };
     }
 
     case 'ROUTING_CHANGE':
       return { isInvoluntary: true, trigger: 'ROUTING_CHANGE' };
 
-    case 'EQUIPMENT_DOWNGRADE': {
-      // Flag but not auto-involuntary
-      const isDowngrade = sc.original_is_widebody === true && sc.new_is_widebody === false;
+    case 'EQUIPMENT_DOWNGRADE':
+      // Equipment downgrade is flagged but not auto-involuntary — handled
+      // separately via downgrade compensation rules (Agent 6.5).
       return { isInvoluntary: false, trigger: 'EQUIPMENT_DOWNGRADE' };
-      void isDowngrade;
-    }
   }
 }
 
@@ -124,38 +140,78 @@ function buildProtectionOptions(input: InvoluntaryRebookInput): ProtectionOption
 // Regulatory entitlements
 // ---------------------------------------------------------------------------
 
-function assessRegulatory(input: InvoluntaryRebookInput): RegulatoryFlag[] {
+function assessRegulatory(
+  input: InvoluntaryRebookInput,
+  trigger: InvoluntaryTrigger,
+): RegulatoryFlag[] {
   const flags: RegulatoryFlag[] = [];
   const pnr = input.original_pnr;
 
-  // EU261/2004: applies if departing from EU OR if EU carrier regardless of destination
+  // EU261 jurisdiction: departing from EU/EEA, OR EU carrier (regardless of route).
   const departureIsEu = EU_COUNTRIES.has(pnr.departure_country);
   const isEuCarrier = pnr.is_eu_carrier;
+  const eu261Applies = departureIsEu || isEuCarrier;
 
-  if (departureIsEu || isEuCarrier) {
-    flags.push({
-      framework: 'EU261',
-      applies: true,
-      reason: departureIsEu
-        ? `Departure from EU/EEA country (${pnr.departure_country}).`
-        : `EU carrier (${pnr.affected_segment.carrier}) — EU261 applies regardless of route.`,
-    });
-  } else {
+  if (!eu261Applies) {
     flags.push({
       framework: 'EU261',
       applies: false,
       reason: 'Non-EU departure and non-EU carrier — EU261 does not apply.',
     });
+  } else {
+    const eu = input.eu261_inputs ?? {};
+    const flightCancelled = trigger === 'FLIGHT_CANCELLATION';
+    const missing: string[] = [];
+    if (eu.distance_km === undefined) missing.push('eu261_inputs.distance_km');
+    if (!flightCancelled && eu.arrival_delay_hours === undefined) {
+      missing.push('eu261_inputs.arrival_delay_hours');
+    }
+    if (eu.extraordinary_circumstances === undefined) {
+      missing.push('eu261_inputs.extraordinary_circumstances');
+    }
+    if (flightCancelled && eu.notice_days_before_departure === undefined) {
+      missing.push('eu261_inputs.notice_days_before_departure');
+    }
+
+    const reasonPrefix = departureIsEu
+      ? `Departure from EU/EEA country (${pnr.departure_country}).`
+      : `EU carrier (${pnr.affected_segment.carrier}) — EU261 applies regardless of route.`;
+
+    if (missing.length > 0) {
+      flags.push({
+        framework: 'EU261',
+        applies: true,
+        reason: `${reasonPrefix} Compensation not computed — see missing_inputs.`,
+        compensation_eur: null,
+        reduction_percent: 0,
+        missing_inputs: missing,
+      });
+    } else {
+      const result = applyEU261({
+        distanceKm: eu.distance_km!,
+        arrivalDelayHours: flightCancelled ? 0 : eu.arrival_delay_hours!,
+        extraordinaryCircumstances: eu.extraordinary_circumstances!,
+        flightCancelled,
+        ...(flightCancelled ? { noticeDaysBeforeDeparture: eu.notice_days_before_departure } : {}),
+      });
+      flags.push({
+        framework: 'EU261',
+        applies: true,
+        reason: `${reasonPrefix} ${result.reason}`,
+        compensation_eur: result.eligible ? result.compensationEur : '0.00',
+        reduction_percent: result.reductionPercent,
+      });
+    }
   }
 
-  // US DOT: applies if departure from or arrival to US
-  const usInvolved = pnr.departure_country === 'US' || pnr.arrival_country === 'US';
+  // US DOT 14 CFR §250 — IDB (oversales) ONLY. Delays/cancellations are
+  // not denied-boarding events. We surface this as not-applicable on the
+  // rebook path even when the route touches the US.
   flags.push({
     framework: 'US_DOT',
-    applies: usInvolved,
-    reason: usInvolved
-      ? `US departure or arrival — DOT consumer protection applies.`
-      : 'No US touchpoint — US DOT rules do not apply.',
+    applies: false,
+    reason:
+      'US DOT 14 CFR §250 covers involuntary denied boarding (oversales) only — not delays or cancellations. See Agent 6.5 (Feedback & Complaint) for IDB handling.',
   });
 
   return flags;
@@ -165,17 +221,22 @@ function assessRegulatory(input: InvoluntaryRebookInput): RegulatoryFlag[] {
 // Main engine
 // ---------------------------------------------------------------------------
 
-export function processInvoluntaryRebook(input: InvoluntaryRebookInput): InvoluntaryRebookOutput {
-  const { isInvoluntary, trigger } = assessTrigger(input);
+export function processInvoluntaryRebook(
+  input: InvoluntaryRebookInput,
+): InvoluntaryRebookOutput & { warnings?: string[] } {
+  const assessment = assessTrigger(input);
+  const { isInvoluntary, trigger } = assessment;
   const isNoShow = input.is_passenger_no_show === true;
 
   const protectionOptions = isInvoluntary ? buildProtectionOptions(input) : [];
   const protectionPath: ProtectionPath =
     protectionOptions.length > 0 ? protectionOptions[0]!.path : 'NONE_AVAILABLE';
 
-  const regulatoryFlags = isInvoluntary ? assessRegulatory(input) : [];
+  const regulatoryFlags = isInvoluntary ? assessRegulatory(input, trigger) : [];
 
-  // Original routing credit: passenger retains original fare basis when rebooked involuntarily
+  // Original routing credit: passenger retains original fare basis when
+  // rebooked involuntarily. Carrier-specific implementation varies — this
+  // flag merely indicates entitlement, not the calculated residual.
   const originalRoutingCredit = isInvoluntary && !isNoShow;
 
   // Build summary
@@ -199,10 +260,28 @@ export function processInvoluntaryRebook(input: InvoluntaryRebookInput): Involun
     if (originalRoutingCredit) {
       summaryParts.push('Original routing credit: passenger retains original fare basis.');
     }
+  } else if (assessment.missingThreshold) {
+    summaryParts.push(
+      'TIME_CHANGE assessment requires input.thresholds.time_change_minutes (carrier-specific). Treating as non-involuntary pending input.',
+    );
   } else {
     summaryParts.push(
       `Schedule change does not meet involuntary threshold (trigger: ${trigger.replace('_', ' ').toLowerCase()}).`,
     );
+  }
+
+  const warnings: string[] = [];
+  if (assessment.missingThreshold) {
+    warnings.push(
+      'DOMAIN_INPUT_REQUIRED: thresholds.time_change_minutes is required for TIME_CHANGE assessment. See @otaip/core domain/types.ts.',
+    );
+  }
+  for (const flag of regulatoryFlags) {
+    if (flag.applies && flag.missing_inputs && flag.missing_inputs.length > 0) {
+      warnings.push(
+        `DOMAIN_INPUT_REQUIRED: ${flag.framework} compensation needs ${flag.missing_inputs.join(', ')}.`,
+      );
+    }
   }
 
   const result: InvoluntaryRebookResult = {
@@ -216,5 +295,5 @@ export function processInvoluntaryRebook(input: InvoluntaryRebookInput): Involun
     summary: summaryParts.join(' '),
   };
 
-  return { result };
+  return warnings.length > 0 ? { result, warnings } : { result };
 }

--- a/packages/agents/exchange/src/involuntary-rebook/rebook-engine.ts
+++ b/packages/agents/exchange/src/involuntary-rebook/rebook-engine.ts
@@ -193,6 +193,10 @@ function assessRegulatory(
         extraordinaryCircumstances: eu.extraordinary_circumstances!,
         flightCancelled,
         ...(flightCancelled ? { noticeDaysBeforeDeparture: eu.notice_days_before_departure } : {}),
+        ...(eu.rerouting_offered !== undefined ? { reroutingOffered: eu.rerouting_offered } : {}),
+        ...(eu.rerouting_arrival_lateness_hours !== undefined
+          ? { reroutingArrivalLatenessHours: eu.rerouting_arrival_lateness_hours }
+          : {}),
       });
       flags.push({
         framework: 'EU261',

--- a/packages/agents/exchange/src/involuntary-rebook/types.ts
+++ b/packages/agents/exchange/src/involuntary-rebook/types.ts
@@ -175,6 +175,10 @@ export interface InvoluntaryRebookInput {
     extraordinary_circumstances?: boolean;
     /** For cancellations: how many days before departure was the passenger notified? */
     notice_days_before_departure?: number;
+    /** Article 7(2): carrier offered rerouting whose arrival is within band threshold. */
+    rerouting_offered?: boolean;
+    /** Hours by which rerouted arrival exceeds original scheduled arrival. */
+    rerouting_arrival_lateness_hours?: number;
   };
 }
 

--- a/packages/agents/exchange/src/involuntary-rebook/types.ts
+++ b/packages/agents/exchange/src/involuntary-rebook/types.ts
@@ -93,6 +93,19 @@ export interface RegulatoryFlag {
   applies: boolean;
   /** Reason */
   reason: string;
+  /**
+   * For EU261: computed compensation per passenger when all required inputs
+   * are available. Null when applies=true but compensation cannot be
+   * computed (missing distance/delay/etc) — see `missing_inputs`.
+   */
+  compensation_eur?: string | null;
+  /** For EU261 reductions (e.g. long-haul 50% under Article 7(2)(c)). */
+  reduction_percent?: number;
+  /**
+   * Names of required inputs that were not supplied, preventing
+   * computation. See @otaip/core domain/types.ts.
+   */
+  missing_inputs?: string[];
 }
 
 export interface InvoluntaryRebookResult {
@@ -130,15 +143,39 @@ export interface InvoluntaryRebookInput {
     is_alliance_partner: boolean;
     is_interline: boolean;
   }>;
-  /** Involuntary thresholds (overrides) */
+  /**
+   * Involuntary trigger thresholds. NO defaults — different carriers define
+   * IRROP triggers differently (60min, 90min, any misconnect). The trigger
+   * may be based on departure delay or arrival delay. Caller must supply
+   * the carrier-specific threshold for TIME_CHANGE assessments. If absent
+   * for a TIME_CHANGE, the engine cannot decide and returns the change as
+   * non-involuntary with a warning.
+   *
+   * // DOMAIN_QUESTION: per-carrier IRROP threshold catalogue (issue tracker).
+   */
   thresholds?: {
-    /** Minutes of departure time change that triggers involuntary (default: 60) */
+    /** Minutes of departure time change that triggers involuntary. REQUIRED for TIME_CHANGE. */
     time_change_minutes?: number;
-    /** Hours within which same carrier must be available (default: 6) */
+    /** Hours within which same carrier must be available. */
     same_carrier_window_hours?: number;
   };
   /** Whether passenger missed original flight (no-show) */
   is_passenger_no_show?: boolean;
+  /**
+   * Inputs required to compute EU261 compensation. When omitted but EU261
+   * applies, the regulatory flag is set with `compensation_eur: null` and
+   * `missing_inputs` listing what is needed.
+   */
+  eu261_inputs?: {
+    /** Great-circle distance origin → final destination (km). */
+    distance_km?: number;
+    /** Arrival delay at the FINAL destination, in hours. */
+    arrival_delay_hours?: number;
+    /** Carrier asserts extraordinary circumstances exemption. */
+    extraordinary_circumstances?: boolean;
+    /** For cancellations: how many days before departure was the passenger notified? */
+    notice_days_before_departure?: number;
+  };
 }
 
 export interface InvoluntaryRebookOutput {

--- a/packages/agents/pricing/src/fare-construction/__tests__/fare-construction.test.ts
+++ b/packages/agents/pricing/src/fare-construction/__tests__/fare-construction.test.ts
@@ -298,7 +298,7 @@ describe('Fare Construction', () => {
     });
   });
 
-  describe('HIP detection', () => {
+  describe('HIP single-component', () => {
     it('detects no HIP for simple direct fare', async () => {
       const result = await agent.execute({
         data: {
@@ -316,12 +316,18 @@ describe('Fare Construction', () => {
         },
       });
 
+      if ('status' in result.data && result.data.status === 'DOMAIN_INPUT_REQUIRED') {
+        throw new Error('Expected normal output');
+      }
       expect(result.data.hip_check.detected).toBe(false);
+      expect(result.data.hip_check.missing_inputs).toBeUndefined();
     });
   });
 
   describe('BHC detection', () => {
-    it('detects backhaul when revisiting a city', async () => {
+    it('reports BHC undetected with DOMAIN_INPUT_REQUIRED for multi-component fares', async () => {
+      // Real BHC requires geographic-direction analysis. Simple
+      // city-revisited heuristics were a CLAUDE.md violation and removed.
       const result = await agent.execute({
         data: {
           journey_type: 'CT',
@@ -359,8 +365,46 @@ describe('Fare Construction', () => {
         },
       });
 
-      expect(result.data.bhc_check.detected).toBe(true);
-      expect(result.data.bhc_check.description).toContain('LHR');
+      if ('status' in result.data && result.data.status === 'DOMAIN_INPUT_REQUIRED') {
+        throw new Error('Expected normal output, got DOMAIN_INPUT_REQUIRED');
+      }
+      expect(result.data.bhc_check.detected).toBe(false);
+      expect(result.data.bhc_check.missing_inputs).toBeDefined();
+      expect(result.data.bhc_check.missing_inputs!.length).toBeGreaterThan(0);
+      expect(result.warnings!.some((w) => w.includes('DOMAIN_INPUT_REQUIRED (BHC)'))).toBe(true);
+    });
+  });
+
+  describe('HIP detection', () => {
+    it('reports HIP undetected with DOMAIN_INPUT_REQUIRED for multi-component fares', async () => {
+      const result = await agent.execute({
+        data: {
+          journey_type: 'OW',
+          components: [
+            {
+              origin: 'JFK',
+              destination: 'LHR',
+              carrier: 'BA',
+              fare_basis: 'Y',
+              nuc_amount: '500.00',
+            },
+            {
+              origin: 'LHR',
+              destination: 'CDG',
+              carrier: 'AF',
+              fare_basis: 'Y',
+              nuc_amount: '200.00',
+            },
+          ],
+          selling_currency: 'USD',
+        },
+      });
+      if ('status' in result.data && result.data.status === 'DOMAIN_INPUT_REQUIRED') {
+        throw new Error('Expected normal output, got DOMAIN_INPUT_REQUIRED');
+      }
+      expect(result.data.hip_check.detected).toBe(false);
+      expect(result.data.hip_check.missing_inputs).toBeDefined();
+      expect(result.warnings!.some((w) => w.includes('DOMAIN_INPUT_REQUIRED (HIP)'))).toBe(true);
     });
   });
 
@@ -412,7 +456,9 @@ describe('Fare Construction', () => {
       expect(new Decimal(result.data.local_amount_raw).toFixed(2)).toBe(expected.toFixed(2));
     });
 
-    it('falls back to ROE 1.0 for unknown currency', async () => {
+    it('returns DOMAIN_INPUT_REQUIRED for unknown currency (no ROE fallback)', async () => {
+      // Previous behaviour silently fell back to 1.0, producing wrong fares.
+      // Now refuses to construct without an authoritative ROE.
       const result = await agent.execute({
         data: {
           journey_type: 'OW',
@@ -429,7 +475,13 @@ describe('Fare Construction', () => {
         },
       });
 
-      expect(result.data.roe).toBe('1.000000');
+      expect('status' in result.data && result.data.status).toBe('DOMAIN_INPUT_REQUIRED');
+      if ('status' in result.data && result.data.status === 'DOMAIN_INPUT_REQUIRED') {
+        expect(result.data.missing).toContain('roe_table_entry:XYZ');
+        expect(result.data.references).toContain('IATA monthly ROE publication');
+      }
+      expect(result.confidence).toBe(0);
+      expect(result.warnings!.some((w) => w.includes('DOMAIN_INPUT_REQUIRED'))).toBe(true);
     });
   });
 

--- a/packages/agents/pricing/src/fare-construction/fare-engine.ts
+++ b/packages/agents/pricing/src/fare-construction/fare-engine.ts
@@ -2,13 +2,29 @@
  * Fare Construction Engine — 12-step pipeline.
  *
  * All financial math uses decimal.js.
+ *
+ * // DOMAIN_QUESTION: ROE source-of-truth
+ * // ROE values are published by IATA monthly. Hardcoded ROE values produce
+ * // wrong fares immediately for any currency that drifts. The previous
+ * // 1.0 fallback was a CLAUDE.md violation. We now refuse to construct
+ * // fares for currencies whose ROE is not in the input data and instead
+ * // return DOMAIN_INPUT_REQUIRED listing the missing ROE.
+ *
+ * // DOMAIN_QUESTION: HIP/BHC fare lookup
+ * // Real HIP/BHC detection requires per-carrier filed fares between every
+ * // intermediate point in the routing. The simplified heuristics that
+ * // previously lived here (per-mile rate comparison and string-matching
+ * // city revisits) were CLAUDE.md violations. We now report these checks
+ * // as undetected with `missing_inputs` listing the lookup data needed.
  */
 
 import { Decimal } from 'decimal.js';
 import { createRequire } from 'node:module';
+import { domainInputRequired, isDomainInputRequired } from '@otaip/core';
+import type { DomainInputRequired } from '@otaip/core';
 import type {
   FareConstructionInput,
-  FareConstructionOutput,
+  FareConstructionResult,
   MileageCheck,
   MileageSurcharge,
   HipCheck,
@@ -16,6 +32,8 @@ import type {
   CtmCheck,
   AuditStep,
 } from './types.js';
+
+export { isDomainInputRequired };
 
 // ---------------------------------------------------------------------------
 // Data loading
@@ -82,7 +100,7 @@ function iataRound(amount: Decimal, unit: string): Decimal {
 // Pipeline steps
 // ---------------------------------------------------------------------------
 
-export function constructFare(input: FareConstructionInput): FareConstructionOutput {
+export function constructFare(input: FareConstructionInput): FareConstructionResult {
   const audit: AuditStep[] = [];
   let stepNum = 0;
 
@@ -191,67 +209,59 @@ export function constructFare(input: FareConstructionInput): FareConstructionOut
   );
 
   // Step 6: HIP check (Higher Intermediate Point)
-  // TODO: [NEEDS DOMAIN INPUT] Real HIP detection requires intermediate point fare comparison
+  // Real HIP detection requires per-airline filed fares between every
+  // intermediate point in the routing. Without that lookup data, we
+  // report `detected: false` and surface the missing inputs. We do NOT
+  // apply per-mile-rate heuristics — those are not the published ATPCO
+  // HIP comparison rule.
+  const hipMissing: string[] = [];
+  if (input.components.length > 1) {
+    for (let i = 0; i < input.components.length - 1; i++) {
+      const comp = input.components[i]!;
+      hipMissing.push(`intermediate_point_fares:${comp.origin}-${comp.destination}`);
+    }
+  }
   const hipCheck: HipCheck = {
     detected: false,
     hip_point: null,
     hip_nuc: null,
-    description: 'HIP check not applicable (no intermediate point fares in dataset)',
+    description:
+      hipMissing.length > 0
+        ? 'HIP check skipped — intermediate-point fare lookup data not provided.'
+        : 'HIP check not applicable for single-component fare.',
+    ...(hipMissing.length > 0 ? { missing_inputs: hipMissing } : {}),
   };
-
-  // Simple HIP detection: check if any intermediate segment has a higher per-mile fare
-  if (input.components.length > 1) {
-    for (let i = 0; i < input.components.length - 1; i++) {
-      const comp = input.components[i]!;
-      const cp = findMileage(comp.origin, comp.destination);
-      if (cp && cp.tpm > 0) {
-        const perMile = new Decimal(comp.nuc_amount).div(cp.tpm);
-        // Check against overall per-mile rate
-        const overallPerMile = totalTpm > 0 ? totalNuc.div(totalTpm) : new Decimal(0);
-        if (perMile.gt(overallPerMile.mul('1.1'))) {
-          hipCheck.detected = true;
-          hipCheck.hip_point = comp.destination;
-          hipCheck.hip_nuc = comp.nuc_amount;
-          hipCheck.description = `HIP detected at ${comp.destination}: segment fare NUC ${comp.nuc_amount} exceeds proportional rate`;
-          break;
-        }
-      }
-    }
-  }
 
   addStep(
     'HIP Check',
     hipCheck.description,
     'fare components',
-    hipCheck.detected ? 'HIP detected' : 'no HIP',
+    hipMissing.length > 0 ? 'skipped — domain input required' : 'no HIP',
   );
 
   // Step 7: BHC check (Backhaul Check)
-  // TODO: [NEEDS DOMAIN INPUT] Real BHC detection requires geographic direction analysis
+  // Real BHC requires geographic direction analysis (great-circle bearing
+  // of each fare component vs. intended journey direction). Simple "city
+  // revisited" string matching is not the published BHC rule. We report
+  // `detected: false` and list the missing inputs.
+  const bhcMissing =
+    input.components.length > 1
+      ? ['geographic_direction_analysis:fare_components']
+      : [];
   const bhcCheck: BhcCheck = {
     detected: false,
-    description: 'Backhaul check: no backhaul detected',
+    description:
+      bhcMissing.length > 0
+        ? 'Backhaul check skipped — geographic direction analysis data not provided.'
+        : 'Backhaul check not applicable for single-component fare.',
+    ...(bhcMissing.length > 0 ? { missing_inputs: bhcMissing } : {}),
   };
-
-  // Simple BHC: detect if journey goes "backwards" (origin appears again)
-  if (input.components.length > 1) {
-    const visited = new Set<string>();
-    visited.add(input.components[0]!.origin);
-    for (const comp of input.components) {
-      if (visited.has(comp.destination) && comp.destination !== input.components[0]!.origin) {
-        bhcCheck.detected = true;
-        bhcCheck.description = `Backhaul detected: ${comp.destination} visited more than once`;
-        break;
-      }
-      visited.add(comp.destination);
-    }
-  }
 
   addStep(
     'BHC Check',
     bhcCheck.description,
     'routing',
-    bhcCheck.detected ? 'BHC detected' : 'no BHC',
+    bhcMissing.length > 0 ? 'skipped — domain input required' : 'no BHC',
   );
 
   // Step 8: CTM check (Circle Trip Minimum)
@@ -277,25 +287,31 @@ export function constructFare(input: FareConstructionInput): FareConstructionOut
   );
 
   // Step 9: Get ROE
+  // No fallback. ROE values are published by IATA monthly. Returning
+  // anything else (especially 1.0) silently produces wrong fares for
+  // every non-USD currency. If ROE is missing → DomainInputRequired.
   const roe = getRoe(input.selling_currency);
   if (!roe) {
-    // Fallback to USD ROE of 1.0
     addStep(
       'ROE Lookup',
-      `No ROE found for ${input.selling_currency}, using 1.0`,
+      `No ROE for ${input.selling_currency} — refusing to construct fare.`,
       input.selling_currency,
-      '1.000000',
+      'DOMAIN_INPUT_REQUIRED',
     );
-  } else {
-    addStep(
-      'ROE Lookup',
-      `ROE for ${input.selling_currency}`,
-      input.selling_currency,
-      roe.toFixed(6),
-    );
+    return domainInputRequired({
+      missing: [`roe_table_entry:${input.selling_currency}`],
+      description: `No ROE entry for ${input.selling_currency}. Construction halted to avoid producing an incorrect local-currency fare.`,
+      references: ['IATA monthly ROE publication', 'ATPCO Fare Construction guide'],
+    });
   }
+  addStep(
+    'ROE Lookup',
+    `ROE for ${input.selling_currency}`,
+    input.selling_currency,
+    roe.toFixed(6),
+  );
 
-  const effectiveRoe = roe ?? new Decimal(1);
+  const effectiveRoe = roe;
 
   // Step 10: NUC × ROE = local currency
   const localRaw = totalNuc.mul(effectiveRoe);

--- a/packages/agents/pricing/src/fare-construction/fare-engine.ts
+++ b/packages/agents/pricing/src/fare-construction/fare-engine.ts
@@ -21,7 +21,6 @@
 import { Decimal } from 'decimal.js';
 import { createRequire } from 'node:module';
 import { domainInputRequired, isDomainInputRequired } from '@otaip/core';
-import type { DomainInputRequired } from '@otaip/core';
 import type {
   FareConstructionInput,
   FareConstructionResult,

--- a/packages/agents/pricing/src/fare-construction/index.ts
+++ b/packages/agents/pricing/src/fare-construction/index.ts
@@ -10,15 +10,23 @@
  */
 
 import type { Agent, AgentInput, AgentOutput, AgentHealthStatus } from '@otaip/core';
-import { AgentNotInitializedError, AgentInputValidationError } from '@otaip/core';
-import type { FareConstructionInput, FareConstructionOutput, JourneyType } from './types.js';
+import {
+  AgentNotInitializedError,
+  AgentInputValidationError,
+  isDomainInputRequired,
+} from '@otaip/core';
+import type {
+  FareConstructionInput,
+  FareConstructionResult,
+  JourneyType,
+} from './types.js';
 import { constructFare } from './fare-engine.js';
 
 const VALID_JOURNEY_TYPES = new Set<JourneyType>(['OW', 'RT', 'CT']);
 const IATA_CODE_RE = /^[A-Z]{3}$/i;
 const CURRENCY_RE = /^[A-Z]{3}$/;
 
-export class FareConstruction implements Agent<FareConstructionInput, FareConstructionOutput> {
+export class FareConstruction implements Agent<FareConstructionInput, FareConstructionResult> {
   readonly id = '2.2';
   readonly name = 'Fare Construction';
   readonly version = '0.1.0';
@@ -31,7 +39,7 @@ export class FareConstruction implements Agent<FareConstructionInput, FareConstr
 
   async execute(
     input: AgentInput<FareConstructionInput>,
-  ): Promise<AgentOutput<FareConstructionOutput>> {
+  ): Promise<AgentOutput<FareConstructionResult>> {
     if (!this.initialized) {
       throw new AgentNotInitializedError(this.id);
     }
@@ -39,6 +47,25 @@ export class FareConstruction implements Agent<FareConstructionInput, FareConstr
     this.validateInput(input.data);
 
     const result = constructFare(input.data);
+
+    if (isDomainInputRequired(result)) {
+      return {
+        data: result,
+        confidence: 0,
+        warnings: [
+          `DOMAIN_INPUT_REQUIRED: ${result.description}`,
+          ...result.missing.map((m) => `missing: ${m}`),
+        ],
+        metadata: {
+          agent_id: this.id,
+          agent_version: this.version,
+          journey_type: input.data.journey_type,
+          component_count: input.data.components.length,
+          currency: input.data.selling_currency,
+          status: 'DOMAIN_INPUT_REQUIRED',
+        },
+      };
+    }
 
     const warnings: string[] = [];
     if (result.mileage_exceeded) {
@@ -51,6 +78,16 @@ export class FareConstruction implements Agent<FareConstructionInput, FareConstr
     }
     if (result.bhc_check.detected) {
       warnings.push(result.bhc_check.description);
+    }
+    if (result.hip_check.missing_inputs && result.hip_check.missing_inputs.length > 0) {
+      warnings.push(
+        `DOMAIN_INPUT_REQUIRED (HIP): ${result.hip_check.missing_inputs.join(', ')}`,
+      );
+    }
+    if (result.bhc_check.missing_inputs && result.bhc_check.missing_inputs.length > 0) {
+      warnings.push(
+        `DOMAIN_INPUT_REQUIRED (BHC): ${result.bhc_check.missing_inputs.join(', ')}`,
+      );
     }
 
     const missingMileage = result.mileage_checks.filter((m) => !m.data_available);
@@ -134,6 +171,7 @@ export class FareConstruction implements Agent<FareConstructionInput, FareConstr
 export type {
   FareConstructionInput,
   FareConstructionOutput,
+  FareConstructionResult,
   FareComponent,
   JourneyType,
   MileageCheck,

--- a/packages/agents/pricing/src/fare-construction/types.ts
+++ b/packages/agents/pricing/src/fare-construction/types.ts
@@ -3,7 +3,16 @@
  *
  * Agent 2.2: NUC × ROE fare construction with mileage validation,
  * HIP/BHC/CTM checks, surcharges, and IATA rounding.
+ *
+ * Output is `FareConstructionResult` — a discriminated union that may be
+ * either a successful `FareConstructionOutput` or a `DomainInputRequired`
+ * sentinel when authoritative inputs (ROE, intermediate-point fare
+ * lookups, etc.) are unavailable.
  */
+
+import type { DomainInputRequired } from '@otaip/core';
+
+export type FareConstructionResult = FareConstructionOutput | DomainInputRequired;
 
 export type JourneyType = 'OW' | 'RT' | 'CT';
 
@@ -52,6 +61,13 @@ export interface HipCheck {
   hip_nuc: string | null;
   /** Description */
   description: string;
+  /**
+   * Set when intermediate-point fare lookup data was not provided. Each
+   * entry names a missing input (e.g. 'intermediate_point_fares:JFK-LON').
+   * Real HIP detection requires per-airline filed fares between every
+   * intermediate point pair — see ATPCO Fare Construction guide.
+   */
+  missing_inputs?: string[];
 }
 
 export interface BhcCheck {
@@ -59,6 +75,13 @@ export interface BhcCheck {
   detected: boolean;
   /** Description */
   description: string;
+  /**
+   * Set when geographic-direction analysis data was not provided. Real
+   * BHC detection compares fare-component directionality against great-
+   * circle bearing of the intended journey, which requires geographic
+   * direction analysis beyond simple "city revisited" string matching.
+   */
+  missing_inputs?: string[];
 }
 
 export interface CtmCheck {

--- a/packages/agents/settlement/src/feedback-complaint/__tests__/feedback-complaint.test.ts
+++ b/packages/agents/settlement/src/feedback-complaint/__tests__/feedback-complaint.test.ts
@@ -216,7 +216,7 @@ describe('Feedback & Complaint Agent', () => {
   });
 
   describe('US DOT compensation — DENIED_BOARDING (primary)', () => {
-    it('domestic <2h delay: 200% capped at $775', async () => {
+    it('domestic 1-2h late: 200% capped at $1075', async () => {
       const result = await agent.execute({
         data: {
           operation: 'calculateCompensation',
@@ -232,21 +232,21 @@ describe('Feedback & Complaint Agent', () => {
       expect(result.data.compensation!.currency).toBe('USD');
     });
 
-    it('domestic <2h delay: caps at $775', async () => {
+    it('domestic 1-2h late: caps at $1075', async () => {
       const result = await agent.execute({
         data: {
           operation: 'calculateCompensation',
           regulation: 'US_DOT',
           complaintType: 'DENIED_BOARDING',
-          fareAmount: '500.00',
+          fareAmount: '700.00',
           delayMinutes: 90,
           isDomestic: true,
         },
       });
-      expect(result.data.compensation!.finalAmount).toBe('775.00');
+      expect(result.data.compensation!.finalAmount).toBe('1075.00');
     });
 
-    it('domestic >=2h delay: 400% capped at $1550', async () => {
+    it('domestic >2h late: 400% capped at $2150', async () => {
       const result = await agent.execute({
         data: {
           operation: 'calculateCompensation',
@@ -260,21 +260,21 @@ describe('Feedback & Complaint Agent', () => {
       expect(result.data.compensation!.finalAmount).toBe('1200.00');
     });
 
-    it('domestic >=2h delay: caps at $1550', async () => {
+    it('domestic >2h late: caps at $2150', async () => {
       const result = await agent.execute({
         data: {
           operation: 'calculateCompensation',
           regulation: 'US_DOT',
           complaintType: 'DENIED_BOARDING',
-          fareAmount: '500.00',
+          fareAmount: '800.00',
           delayMinutes: 180,
           isDomestic: true,
         },
       });
-      expect(result.data.compensation!.finalAmount).toBe('1550.00');
+      expect(result.data.compensation!.finalAmount).toBe('2150.00');
     });
 
-    it('international <4h delay: 200% capped at $775', async () => {
+    it('international 1-4h late: 200% capped at $1075', async () => {
       const result = await agent.execute({
         data: {
           operation: 'calculateCompensation',
@@ -289,21 +289,21 @@ describe('Feedback & Complaint Agent', () => {
       expect(result.data.compensation!.finalAmount).toBe('600.00');
     });
 
-    it('international <4h delay: caps at $775', async () => {
+    it('international 1-4h late: caps at $1075', async () => {
       const result = await agent.execute({
         data: {
           operation: 'calculateCompensation',
           regulation: 'US_DOT',
           complaintType: 'DENIED_BOARDING',
-          fareAmount: '500.00',
+          fareAmount: '600.00',
           delayMinutes: 200,
           isDomestic: false,
         },
       });
-      expect(result.data.compensation!.finalAmount).toBe('775.00');
+      expect(result.data.compensation!.finalAmount).toBe('1075.00');
     });
 
-    it('international >=4h delay: 400% capped at $1550', async () => {
+    it('international >4h late: 400% capped at $2150', async () => {
       const result = await agent.execute({
         data: {
           operation: 'calculateCompensation',
@@ -317,18 +317,18 @@ describe('Feedback & Complaint Agent', () => {
       expect(result.data.compensation!.finalAmount).toBe('1200.00');
     });
 
-    it('international >=4h delay: caps at $1550', async () => {
+    it('international >4h late: caps at $2150', async () => {
       const result = await agent.execute({
         data: {
           operation: 'calculateCompensation',
           regulation: 'US_DOT',
           complaintType: 'DENIED_BOARDING',
-          fareAmount: '500.00',
+          fareAmount: '1000.00',
           delayMinutes: 300,
           isDomestic: false,
         },
       });
-      expect(result.data.compensation!.finalAmount).toBe('1550.00');
+      expect(result.data.compensation!.finalAmount).toBe('2150.00');
     });
 
     it('defaults to domestic when isDomestic not specified', async () => {

--- a/packages/agents/settlement/src/feedback-complaint/index.ts
+++ b/packages/agents/settlement/src/feedback-complaint/index.ts
@@ -8,7 +8,12 @@
  */
 
 import type { Agent, AgentInput, AgentOutput, AgentHealthStatus } from '@otaip/core';
-import { AgentNotInitializedError, AgentInputValidationError } from '@otaip/core';
+import {
+  AgentNotInitializedError,
+  AgentInputValidationError,
+  applyEU261,
+  applyUsDotIdb,
+} from '@otaip/core';
 import Decimal from 'decimal.js';
 import type {
   FeedbackComplaintInput,
@@ -99,6 +104,35 @@ function determinePriority(complaintType: ComplaintType, regulation: Regulation)
 
 function todayISO(): string {
   return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * EU261 Article 7 base compensation by distance band — mirrors the
+ * @otaip/core EU261_BANDS constants and is re-derived here to keep the
+ * tests' baseAmount transparent (pre-reduction).
+ */
+function bandBaseByDistance(distanceKm: number): Decimal {
+  if (distanceKm < 1500) return new Decimal('250');
+  if (distanceKm <= 3500) return new Decimal('400');
+  return new Decimal('600');
+}
+
+/**
+ * Article 7(2) rerouting reduction — band thresholds 2h/3h/4h.
+ * Returns 50 when reduction applies, 0 otherwise.
+ */
+function computeReroutingReduction(
+  distanceKm: number,
+  data: FeedbackComplaintInput,
+): number {
+  if (!data.alternativeOffered) return 0;
+  let threshold: number;
+  if (distanceKm < 1500) threshold = 2;
+  else if (distanceKm <= 3500) threshold = 3;
+  else threshold = 4;
+  const lateness = data.alternativeArrivalDelayHours;
+  if (lateness === undefined) return 0;
+  return lateness <= threshold ? 50 : 0;
 }
 
 export class FeedbackComplaintAgent implements Agent<
@@ -286,7 +320,7 @@ export class FeedbackComplaintAgent implements Agent<
     return { dotRecord };
   }
 
-  // --- EU261 compensation (secondary) ---
+  // --- EU261 compensation (delegates to @otaip/core regulations/eu261) ---
 
   private calculateEU261(data: FeedbackComplaintInput): CompensationResult {
     const distanceKm = data.distanceKm ?? 0;
@@ -294,44 +328,59 @@ export class FeedbackComplaintAgent implements Agent<
     const currency = 'EUR';
     const delayMinutes = this.getDelayMinutes(data);
 
-    // DELAY — not eligible if < 180 minutes
     if (complaintType === 'DELAY') {
-      if (delayMinutes < 180) {
-        return {
-          eligible: false,
-          regulation: 'EU261',
-          baseAmount: '0.00',
-          finalAmount: '0.00',
-          currency,
-          reductionPercent: 0,
-          notes: 'Delay under 180 minutes is not eligible for EU261 compensation.',
-        };
-      }
-
-      const baseAmount = this.eu261BaseByDistance(distanceKm);
-      return this.applyEU261Reduction(
-        baseAmount,
+      const result = applyEU261({
         distanceKm,
-        data,
+        arrivalDelayHours: delayMinutes / 60,
+        extraordinaryCircumstances: false,
+        flightCancelled: false,
+        ...(data.alternativeOffered !== undefined ? { reroutingOffered: data.alternativeOffered } : {}),
+        ...(data.alternativeArrivalDelayHours !== undefined
+          ? { reroutingArrivalLatenessHours: data.alternativeArrivalDelayHours }
+          : {}),
+      });
+      const baseAmount = bandBaseByDistance(distanceKm);
+      return {
+        eligible: result.eligible,
+        regulation: 'EU261',
+        baseAmount: baseAmount.toFixed(2),
+        finalAmount: result.compensationEur,
         currency,
-        `EU261 delay compensation for ${distanceKm}km, ${delayMinutes}min delay.`,
-      );
+        reductionPercent: result.reductionPercent,
+        notes: `EU261 delay (${distanceKm}km, ${delayMinutes}min). ${result.reason}`,
+      };
     }
 
-    // CANCELLATION
     if (complaintType === 'CANCELLATION') {
-      const baseAmount = this.eu261BaseByDistance(distanceKm);
-      return this.applyEU261Reduction(
-        baseAmount,
+      // Cancellation cash compensation under Article 5(1)(c). Notice <14 days
+      // assumed when not provided (worst-case for carrier liability).
+      const result = applyEU261({
         distanceKm,
-        data,
+        arrivalDelayHours: 0,
+        extraordinaryCircumstances: false,
+        flightCancelled: true,
+        noticeDaysBeforeDeparture: 0,
+        ...(data.alternativeOffered !== undefined ? { reroutingOffered: data.alternativeOffered } : {}),
+        ...(data.alternativeArrivalDelayHours !== undefined
+          ? { reroutingArrivalLatenessHours: data.alternativeArrivalDelayHours }
+          : {}),
+      });
+      const baseAmount = bandBaseByDistance(distanceKm);
+      return {
+        eligible: result.eligible,
+        regulation: 'EU261',
+        baseAmount: baseAmount.toFixed(2),
+        finalAmount: result.compensationEur,
         currency,
-        `EU261 cancellation compensation for ${distanceKm}km.`,
-      );
+        reductionPercent: result.reductionPercent,
+        notes: `EU261 cancellation (${distanceKm}km). ${result.reason}`,
+      };
     }
 
-    // DOWNGRADE — 30%/50%/75% of fare by distance
     if (complaintType === 'DOWNGRADE') {
+      // Article 10(2): downgrade reimbursement is 30%/50%/75% of the price of
+      // the ticket for the affected segment, by distance band. This is
+      // published law and is the only fixed scaling allowed.
       const farePaid = data.farePaid
         ? new Decimal(data.farePaid)
         : data.fareAmount
@@ -353,20 +402,28 @@ export class FeedbackComplaintAgent implements Agent<
         finalAmount: amount,
         currency,
         reductionPercent: 0,
-        notes: `EU261 downgrade: ${percent}% of fare for ${distanceKm}km.`,
+        notes: `EU261 Article 10(2) downgrade: ${percent}% of fare (${distanceKm}km band).`,
       };
     }
 
-    // DENIED_BOARDING
     if (complaintType === 'DENIED_BOARDING') {
-      const baseAmount = this.eu261BaseByDistance(distanceKm);
-      return this.applyEU261Reduction(
-        baseAmount,
-        distanceKm,
-        data,
+      // Article 4: denied boarding compensation uses Article 7 amounts.
+      // No delay trigger applies — compensation is owed on denial itself.
+      const baseAmount = bandBaseByDistance(distanceKm);
+      const reduction = computeReroutingReduction(distanceKm, data);
+      const finalAmount =
+        reduction > 0 ? baseAmount.mul(100 - reduction).div(100) : baseAmount;
+      return {
+        eligible: true,
+        regulation: 'EU261',
+        baseAmount: baseAmount.toFixed(2),
+        finalAmount: finalAmount.toFixed(2),
         currency,
-        `EU261 denied boarding compensation for ${distanceKm}km.`,
-      );
+        reductionPercent: reduction,
+        notes: `EU261 Article 4 denied boarding (${distanceKm}km).${
+          reduction > 0 ? ' 50% reduction under Article 7(2).' : ''
+        }`,
+      };
     }
 
     return {
@@ -380,74 +437,18 @@ export class FeedbackComplaintAgent implements Agent<
     };
   }
 
-  private eu261BaseByDistance(distanceKm: number): Decimal {
-    if (distanceKm < 1500) {
-      return new Decimal('250');
-    }
-    if (distanceKm <= 3500) {
-      return new Decimal('400');
-    }
-    return new Decimal('600');
-  }
-
-  /**
-   * EU261 50% reduction: alternativeOffered AND arrival within threshold.
-   * Thresholds by distance band: <1500km → 2h, 1500-3500km → 3h, >3500km → 4h.
-   */
-  private applyEU261Reduction(
-    baseAmount: Decimal,
-    distanceKm: number,
-    data: FeedbackComplaintInput,
-    currency: string,
-    baseNotes: string,
-  ): CompensationResult {
-    let reductionPercent = 0;
-    let finalAmount = baseAmount;
-    let notes = baseNotes;
-
-    if (data.alternativeOffered) {
-      // Determine arrival threshold by distance band
-      let arrivalThresholdHours: number;
-      if (distanceKm < 1500) {
-        arrivalThresholdHours = 2;
-      } else if (distanceKm <= 3500) {
-        arrivalThresholdHours = 3;
-      } else {
-        arrivalThresholdHours = 4;
-      }
-
-      const altArrivalDelay = data.alternativeArrivalDelayHours ?? Infinity;
-      if (altArrivalDelay <= arrivalThresholdHours) {
-        reductionPercent = 50;
-        finalAmount = baseAmount.mul(50).div(100);
-        notes += ` 50% reduction applied (alternative offered, arrival within ${arrivalThresholdHours}h of original).`;
-      }
-    }
-
-    return {
-      eligible: true,
-      regulation: 'EU261',
-      baseAmount: baseAmount.toFixed(2),
-      finalAmount: finalAmount.toFixed(2),
-      currency,
-      reductionPercent,
-      notes,
-    };
-  }
-
-  // --- US DOT compensation (primary) ---
-
   private getDelayMinutes(data: FeedbackComplaintInput): number {
     if (data.delayMinutes !== undefined) return data.delayMinutes;
     if (data.delayHours !== undefined) return Math.round(data.delayHours * 60);
     return 0;
   }
 
+  // --- US DOT compensation (delegates to @otaip/core regulations/us-dot-idb) ---
+
   private calculateUSDOT(data: FeedbackComplaintInput): CompensationResult {
     const complaintType = data.complaintType ?? 'DENIED_BOARDING';
     const currency = 'USD';
 
-    // DELAY — US DOT does not mandate delay compensation
     if (complaintType === 'DELAY') {
       return {
         eligible: false,
@@ -461,7 +462,6 @@ export class FeedbackComplaintAgent implements Agent<
       };
     }
 
-    // CANCELLATION — US DOT requires refund/rebooking, no mandated cash compensation
     if (complaintType === 'CANCELLATION') {
       return {
         eligible: false,
@@ -474,7 +474,6 @@ export class FeedbackComplaintAgent implements Agent<
       };
     }
 
-    // DOWNGRADE — full refund required
     if (complaintType === 'DOWNGRADE') {
       const fare = data.fareAmount
         ? new Decimal(data.fareAmount)
@@ -492,7 +491,6 @@ export class FeedbackComplaintAgent implements Agent<
       };
     }
 
-    // DENIED_BOARDING — full implementation
     if (complaintType === 'DENIED_BOARDING') {
       const fare = data.fareAmount
         ? new Decimal(data.fareAmount)
@@ -502,37 +500,26 @@ export class FeedbackComplaintAgent implements Agent<
       const delayMinutes = this.getDelayMinutes(data);
       const isDomestic = data.isDomestic ?? true;
 
-      // Thresholds: domestic <2h / >=2h, international <4h / >=4h
-      const lowThreshold = isDomestic ? 120 : 240;
+      const result = applyUsDotIdb({
+        isDomestic,
+        substituteArrivalLateMinutes: delayMinutes,
+        oneWayFareUsd: fare.toString(),
+      });
 
-      if (delayMinutes < lowThreshold) {
-        // 200% of fare, cap $775
-        const raw = Decimal.min(fare.mul(2), new Decimal('775'));
-        return {
-          eligible: true,
-          regulation: 'US_DOT',
-          baseAmount: fare.mul(2).toFixed(2),
-          finalAmount: raw.toFixed(2),
-          currency,
-          reductionPercent: 0,
-          notes: `US DOT denied boarding: 200% of fare ($${fare.toFixed(2)}), capped at $775.00. ${isDomestic ? 'Domestic' : 'International'} delay ${delayMinutes}min < ${lowThreshold}min threshold.`,
-        };
-      }
+      // baseAmount reflects pre-cap multiplier × fare for transparency.
+      const baseAmount = fare.mul(result.band.multiplier).toFixed(2);
 
-      // >= threshold: 400% of fare, cap $1550
-      const raw = Decimal.min(fare.mul(4), new Decimal('1550'));
       return {
-        eligible: true,
+        eligible: result.eligible,
         regulation: 'US_DOT',
-        baseAmount: fare.mul(4).toFixed(2),
-        finalAmount: raw.toFixed(2),
+        baseAmount,
+        finalAmount: result.compensationUsd,
         currency,
         reductionPercent: 0,
-        notes: `US DOT denied boarding: 400% of fare ($${fare.toFixed(2)}), capped at $1550.00. ${isDomestic ? 'Domestic' : 'International'} delay ${delayMinutes}min >= ${lowThreshold}min threshold.`,
+        notes: result.reason,
       };
     }
 
-    // Other types not covered by US DOT
     return {
       eligible: false,
       regulation: 'US_DOT',

--- a/packages/agents/settlement/src/refund-processing/__tests__/fixtures/test-cat33-rules.json
+++ b/packages/agents/settlement/src/refund-processing/__tests__/fixtures/test-cat33-rules.json
@@ -1,5 +1,5 @@
 {
-  "description": "ATPCO Category 33 refund penalty rules by fare basis pattern. Order matters — more specific patterns first.",
+  "description": "TEST FIXTURE — invented common-industry patterns. Do NOT use in production. Real Cat33 data must come from authoritative ATPCO feeds. Used only to exercise the engine's apply-as-filed branch.",
   "rules": [
     {
       "fare_basis_pattern": ".*BASIC$",

--- a/packages/agents/settlement/src/refund-processing/__tests__/refund-processing.test.ts
+++ b/packages/agents/settlement/src/refund-processing/__tests__/refund-processing.test.ts
@@ -5,8 +5,17 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'node:module';
 import { RefundProcessing } from '../index.js';
-import type { RefundProcessingInput, TaxItem, CouponRefundItem } from '../types.js';
+import type {
+  RefundProcessingInput,
+  TaxItem,
+  CouponRefundItem,
+  Cat33Rules,
+} from '../types.js';
+
+const require = createRequire(import.meta.url);
+const TEST_CAT33_RULES = require('./fixtures/test-cat33-rules.json') as Cat33Rules;
 
 let agent: RefundProcessing;
 
@@ -41,6 +50,7 @@ function makeInput(overrides: Partial<RefundProcessingInput> = {}): RefundProces
     is_refundable: true,
     settlement_system: 'BSP',
     current_date: '2026-04-01',
+    cat33_rules: TEST_CAT33_RULES,
     ...overrides,
   };
 }
@@ -89,6 +99,37 @@ describe('Refund Processing', () => {
     it('lists all coupons as refunded', async () => {
       const result = await agent.execute({ data: makeInput() });
       expect(result.data.refund.audit.coupons_refunded).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe('ATPCO default — no Cat33 rules supplied', () => {
+    it('voluntary refund with no rules: penalty = 0, full base refund', async () => {
+      const result = await agent.execute({
+        data: makeInput({ cat33_rules: undefined }),
+      });
+      expect(result.data.refund.penalty_applied).toBe('0.00');
+      expect(result.data.refund.base_fare_refund).toBe('450.00');
+    });
+
+    it('involuntary refund with no rules: penalty = 0, full refund regardless of fare basis', async () => {
+      const result = await agent.execute({
+        data: makeInput({
+          cat33_rules: undefined,
+          is_involuntary: true,
+          fare_basis: 'HOWBASIC',
+          is_refundable: false,
+        }),
+      });
+      expect(result.data.refund.penalty_applied).toBe('0.00');
+      expect(result.data.refund.base_fare_refund).toBe('450.00');
+    });
+
+    it('involuntary refund with rules: penalty still waived to 0', async () => {
+      const result = await agent.execute({
+        data: makeInput({ is_involuntary: true, fare_basis: 'EOWUS' }),
+      });
+      expect(result.data.refund.penalty_applied).toBe('0.00');
+      expect(result.data.refund.base_fare_refund).toBe('450.00');
     });
   });
 

--- a/packages/agents/settlement/src/refund-processing/refund-engine.ts
+++ b/packages/agents/settlement/src/refund-processing/refund-engine.ts
@@ -1,10 +1,23 @@
 /**
  * Refund Processing Engine — penalty calc, commission recall,
  * tax refund, conjunction handling, BSP/ARC reporting.
+ *
+ * No invented penalty amounts.
+ *
+ * - When `input.cat33_rules` is provided, the engine applies the filed
+ *   rules: pattern-match the fare basis, use the rule's penalty and
+ *   forfeit-base-fare flag.
+ * - When `input.cat33_rules` is absent, the engine uses the ATPCO
+ *   default per the project's domain spec: voluntary refunds incur NO
+ *   penalty; involuntary refunds are full refunds.
+ *
+ * The previous "$200 default penalty" fallback was a CLAUDE.md
+ * violation and has been removed.
+ *
+ * // DOMAIN_QUESTION: per-carrier ATPCO Cat33 data ingestion pipeline.
  */
 
 import Decimal from 'decimal.js';
-import { createRequire } from 'node:module';
 import type {
   RefundProcessingInput,
   RefundProcessingOutput,
@@ -14,12 +27,8 @@ import type {
   TaxItem,
   BspRefundFields,
   ArcRefundFields,
+  Cat33Rules,
 } from './types.js';
-
-const require = createRequire(import.meta.url);
-const rulesData = require('./data/refund-penalty-rules.json') as {
-  rules: RefundPenaltyRule[];
-};
 
 function sumTaxes(taxes: TaxItem[]): Decimal {
   let total = new Decimal(0);
@@ -29,8 +38,12 @@ function sumTaxes(taxes: TaxItem[]): Decimal {
   return total;
 }
 
-function findPenaltyRule(fareBasis: string): RefundPenaltyRule | undefined {
-  for (const rule of rulesData.rules) {
+function findPenaltyRule(
+  rules: Cat33Rules | undefined,
+  fareBasis: string,
+): RefundPenaltyRule | undefined {
+  if (!rules) return undefined;
+  for (const rule of rules.rules) {
     if (new RegExp(rule.fare_basis_pattern).test(fareBasis)) {
       return rule;
     }
@@ -87,7 +100,8 @@ function buildArcFields(
 export function processRefund(input: RefundProcessingInput): RefundProcessingOutput {
   const originalBase = new Decimal(input.base_fare);
   const originalTax = sumTaxes(input.taxes);
-  const rule = findPenaltyRule(input.fare_basis);
+  const rule = findPenaltyRule(input.cat33_rules, input.fare_basis);
+  const isInvoluntary = input.is_involuntary === true;
 
   const hasWaiver = !!input.waiver_code;
 
@@ -99,19 +113,27 @@ export function processRefund(input: RefundProcessingInput): RefundProcessingOut
 
   switch (input.refund_type) {
     case 'FULL': {
-      // Full refund — all unused coupons
-      if (rule?.forfeit_base_fare && !hasWaiver && !input.is_refundable) {
-        // Non-refundable: base fare forfeited, taxes still refundable
-        baseFareRefund = new Decimal(0);
-        penalty = new Decimal(0);
-      } else if (hasWaiver) {
-        // Waiver bypasses penalty
+      // Full refund — all unused coupons.
+      // Penalty source-of-truth:
+      //   - involuntary               → 0 (carrier-initiated)
+      //   - waiver code present       → 0 (waiver bypasses penalty)
+      //   - filed forfeit_base_fare   → entire base forfeited
+      //   - filed penalty_amount      → that amount
+      //   - no rule + voluntary       → 0 (ATPCO default, no invention)
+      if (isInvoluntary || hasWaiver) {
         baseFareRefund = originalBase;
         penalty = new Decimal(0);
-      } else {
-        const penaltyAmount = rule ? new Decimal(rule.penalty_amount) : new Decimal('200.00');
+      } else if (rule?.forfeit_base_fare && !input.is_refundable) {
+        baseFareRefund = new Decimal(0);
+        penalty = new Decimal(0);
+      } else if (rule) {
+        const penaltyAmount = new Decimal(rule.penalty_amount);
         penalty = Decimal.min(penaltyAmount, originalBase);
         baseFareRefund = originalBase.minus(penalty);
+      } else {
+        // No rule supplied → ATPCO default for voluntary refund: no penalty.
+        baseFareRefund = originalBase;
+        penalty = new Decimal(0);
       }
       taxRefund = originalTax;
       taxBreakdown = input.taxes;
@@ -120,7 +142,7 @@ export function processRefund(input: RefundProcessingInput): RefundProcessingOut
     }
 
     case 'PARTIAL': {
-      // Partial refund — specific coupons only
+      // Partial refund — specific coupons only.
       const refundableCoupons = (input.coupons_to_refund ?? []).filter((c) => c.refundable);
       const couponRatio =
         input.total_coupons > 0
@@ -129,16 +151,20 @@ export function processRefund(input: RefundProcessingInput): RefundProcessingOut
 
       const proratedBase = originalBase.times(couponRatio).toDecimalPlaces(2);
 
-      if (rule?.forfeit_base_fare && !hasWaiver && !input.is_refundable) {
-        baseFareRefund = new Decimal(0);
-        penalty = new Decimal(0);
-      } else if (hasWaiver) {
+      if (isInvoluntary || hasWaiver) {
         baseFareRefund = proratedBase;
         penalty = new Decimal(0);
-      } else {
-        const penaltyAmount = rule ? new Decimal(rule.penalty_amount) : new Decimal('200.00');
+      } else if (rule?.forfeit_base_fare && !input.is_refundable) {
+        baseFareRefund = new Decimal(0);
+        penalty = new Decimal(0);
+      } else if (rule) {
+        const penaltyAmount = new Decimal(rule.penalty_amount);
         penalty = Decimal.min(penaltyAmount, proratedBase);
         baseFareRefund = proratedBase.minus(penalty);
+      } else {
+        // No rule supplied → ATPCO default: no penalty on prorated portion.
+        baseFareRefund = proratedBase;
+        penalty = new Decimal(0);
       }
 
       // Prorate taxes
@@ -173,12 +199,12 @@ export function processRefund(input: RefundProcessingInput): RefundProcessingOut
   // Audit trail
   const audit: RefundAuditTrail = {
     original_ticket_number: input.ticket_number,
-    conjunction_tickets: input.conjunction_tickets,
+    ...(input.conjunction_tickets !== undefined ? { conjunction_tickets: input.conjunction_tickets } : {}),
     refund_type: input.refund_type,
     original_base_fare: originalBase.toFixed(2),
     original_total_tax: originalTax.toFixed(2),
     penalty_applied: penalty.toFixed(2),
-    waiver_code: input.waiver_code,
+    ...(input.waiver_code !== undefined ? { waiver_code: input.waiver_code } : {}),
     base_fare_refunded: baseFareRefund.toFixed(2),
     tax_refunded: taxRefund.toFixed(2),
     commission_recalled: commissionRecalled.toFixed(2),
@@ -205,9 +231,9 @@ export function processRefund(input: RefundProcessingInput): RefundProcessingOut
     total_refund: totalRefund.toFixed(2),
     commission_recalled: commissionRecalled.toFixed(2),
     net_refund: netRefund.toFixed(2),
-    waiver_code: input.waiver_code,
-    bsp_fields: bspFields,
-    arc_fields: arcFields,
+    ...(input.waiver_code !== undefined ? { waiver_code: input.waiver_code } : {}),
+    ...(bspFields !== undefined ? { bsp_fields: bspFields } : {}),
+    ...(arcFields !== undefined ? { arc_fields: arcFields } : {}),
     audit,
   };
 

--- a/packages/agents/settlement/src/refund-processing/types.ts
+++ b/packages/agents/settlement/src/refund-processing/types.ts
@@ -51,6 +51,21 @@ export interface RefundPenaltyRule {
   notes: string;
 }
 
+/**
+ * ATPCO Category 33 rule set for refunds.
+ *
+ * Real Cat33 data comes from authoritative ATPCO feeds. This engine no
+ * longer hardcodes fallback "industry pattern" rules — when no rule
+ * matches and no rules are supplied, the engine uses the ATPCO default
+ * (permitted at no charge for voluntary refunds; full refund for
+ * involuntary).
+ *
+ * // DOMAIN_QUESTION: per-carrier ATPCO Cat33 ingestion pipeline.
+ */
+export interface Cat33Rules {
+  rules: RefundPenaltyRule[];
+}
+
 export interface BspRefundFields {
   /** Original ticket number */
   original_ticket_number: string;
@@ -172,6 +187,17 @@ export interface RefundProcessingInput {
   settlement_system: SettlementSystem;
   /** Current date (ISO — for reporting) */
   current_date?: string;
+  /**
+   * Whether this refund is carrier-initiated (involuntary). When true,
+   * no penalty is deducted regardless of the filed Cat33 rules.
+   */
+  is_involuntary?: boolean;
+  /**
+   * ATPCO Category 33 rules. When present → engine applies as filed.
+   * When absent → ATPCO default (voluntary: no penalty; involuntary:
+   * full refund). The engine never invents a penalty amount.
+   */
+  cat33_rules?: Cat33Rules;
 }
 
 export interface RefundProcessingOutput {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "decimal.js": "^10.6.0",
     "zod": "^4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,0 +1,2 @@
+export type { DomainInputRequired } from './types.js';
+export { domainInputRequired, isDomainInputRequired } from './types.js';

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared "needs domain input" result type for engines that cannot proceed
+ * without authoritative travel-domain data (ATPCO Cat 31/33 rules,
+ * IATA ROE tables, regulatory inputs, etc.).
+ *
+ * Engines must NOT invent fares, penalties, compensation amounts, or
+ * mileage values. When required inputs are absent and no published
+ * regulatory default applies, return DomainInputRequired instead of
+ * synthesizing a result.
+ */
+
+export interface DomainInputRequired {
+  status: 'DOMAIN_INPUT_REQUIRED';
+  /** Machine-readable list of missing inputs (e.g. ['atpco_cat31_rules', 'roe_table_entry:EUR']). */
+  missing: string[];
+  /** Human-readable explanation. */
+  description: string;
+  /** Authoritative references that would supply the missing inputs. */
+  references: string[];
+}
+
+export function domainInputRequired(args: {
+  missing: string[];
+  description: string;
+  references: string[];
+}): DomainInputRequired {
+  return { status: 'DOMAIN_INPUT_REQUIRED', ...args };
+}
+
+export function isDomainInputRequired(
+  value: unknown,
+): value is DomainInputRequired {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { status?: unknown }).status === 'DOMAIN_INPUT_REQUIRED'
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,29 @@ export { DEFAULT_RETRY_CONFIG, withRetry, computeDelay } from './retry/index.js'
 export { fetchWithRetry } from './http/index.js';
 export type { FetchWithRetryOptions } from './http/index.js';
 
+export type { DomainInputRequired } from './domain/index.js';
+export { domainInputRequired, isDomainInputRequired } from './domain/index.js';
+
+export {
+  EU261_BANDS,
+  EU261_DELAY_TRIGGER_HOURS,
+  EU261_LONGHAUL_PARTIAL_REDUCTION,
+  EU261_CANCELLATION_NOTICE_DAYS,
+  EU261_REFUND_CHOICE_DELAY_HOURS,
+  applyEU261,
+  greatCircleDistanceKm,
+  US_DOT_IDB_DOMESTIC,
+  US_DOT_IDB_INTERNATIONAL,
+  applyUsDotIdb,
+} from './regulations/index.js';
+export type {
+  EU261Input,
+  EU261Result,
+  UsDotIdbInput,
+  UsDotIdbResult,
+  UsDotIdbBand,
+} from './regulations/index.js';
+
 export type {
   LoopPhase,
   ToolCall,

--- a/packages/core/src/regulations/__tests__/eu261.test.ts
+++ b/packages/core/src/regulations/__tests__/eu261.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { applyEU261, greatCircleDistanceKm } from '../eu261.js';
+
+describe('applyEU261 — delay path', () => {
+  it('pays €250 for short-haul ≤1500km with 3h+ delay', () => {
+    const r = applyEU261({
+      distanceKm: 1200,
+      arrivalDelayHours: 3,
+      extraordinaryCircumstances: false,
+      flightCancelled: false,
+    });
+    expect(r.eligible).toBe(true);
+    expect(r.compensationEur).toBe('250.00');
+    expect(r.reductionPercent).toBe(0);
+  });
+
+  it('pays €400 for medium-haul 1500-3500km with 3h+ delay', () => {
+    const r = applyEU261({
+      distanceKm: 3000,
+      arrivalDelayHours: 4,
+      extraordinaryCircumstances: false,
+      flightCancelled: false,
+    });
+    expect(r.compensationEur).toBe('400.00');
+  });
+
+  it('pays €600 for long-haul >3500km with 4h+ delay', () => {
+    const r = applyEU261({
+      distanceKm: 6000,
+      arrivalDelayHours: 5,
+      extraordinaryCircumstances: false,
+      flightCancelled: false,
+    });
+    expect(r.compensationEur).toBe('600.00');
+  });
+
+  it('reduces long-haul by 50% (€300) when delay is 3-4h', () => {
+    const r = applyEU261({
+      distanceKm: 6000,
+      arrivalDelayHours: 3.5,
+      extraordinaryCircumstances: false,
+      flightCancelled: false,
+    });
+    expect(r.compensationEur).toBe('300.00');
+    expect(r.reductionPercent).toBe(50);
+  });
+
+  it('returns ineligible when delay < 3h', () => {
+    const r = applyEU261({
+      distanceKm: 1200,
+      arrivalDelayHours: 2,
+      extraordinaryCircumstances: false,
+      flightCancelled: false,
+    });
+    expect(r.eligible).toBe(false);
+    expect(r.compensationEur).toBe('0.00');
+  });
+});
+
+describe('applyEU261 — cancellation path', () => {
+  it('owes compensation when notified < 14 days', () => {
+    const r = applyEU261({
+      distanceKm: 1200,
+      arrivalDelayHours: 0,
+      extraordinaryCircumstances: false,
+      flightCancelled: true,
+      noticeDaysBeforeDeparture: 7,
+    });
+    expect(r.eligible).toBe(true);
+    expect(r.compensationEur).toBe('250.00');
+  });
+
+  it('safe-harbours when notified ≥ 14 days', () => {
+    const r = applyEU261({
+      distanceKm: 1200,
+      arrivalDelayHours: 0,
+      extraordinaryCircumstances: false,
+      flightCancelled: true,
+      noticeDaysBeforeDeparture: 14,
+    });
+    expect(r.eligible).toBe(false);
+  });
+});
+
+describe('applyEU261 — extraordinary circumstances', () => {
+  it('exempts the carrier even when delay is severe', () => {
+    const r = applyEU261({
+      distanceKm: 6000,
+      arrivalDelayHours: 10,
+      extraordinaryCircumstances: true,
+      flightCancelled: false,
+    });
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/Extraordinary circumstances/);
+  });
+});
+
+describe('applyEU261 — refund choice', () => {
+  it('flags refund choice when delay ≥ 5h', () => {
+    const r = applyEU261({
+      distanceKm: 1200,
+      arrivalDelayHours: 5,
+      extraordinaryCircumstances: false,
+      flightCancelled: false,
+    });
+    expect(r.refundChoiceAvailable).toBe(true);
+  });
+});
+
+describe('greatCircleDistanceKm', () => {
+  it('returns 0 for identical points', () => {
+    const d = greatCircleDistanceKm(
+      { latitude: 51.4775, longitude: -0.4614 },
+      { latitude: 51.4775, longitude: -0.4614 },
+    );
+    expect(d).toBeCloseTo(0, 3);
+  });
+
+  it('approximates LHR-JFK at ~5540km', () => {
+    const d = greatCircleDistanceKm(
+      { latitude: 51.4775, longitude: -0.4614 },
+      { latitude: 40.6413, longitude: -73.7781 },
+    );
+    expect(d).toBeGreaterThan(5500);
+    expect(d).toBeLessThan(5600);
+  });
+});

--- a/packages/core/src/regulations/__tests__/eu261.test.ts
+++ b/packages/core/src/regulations/__tests__/eu261.test.ts
@@ -34,15 +34,43 @@ describe('applyEU261 — delay path', () => {
     expect(r.compensationEur).toBe('600.00');
   });
 
-  it('reduces long-haul by 50% (€300) when delay is 3-4h', () => {
+  it('Article 7(2) rerouting reduction: 50% (€300) when alternative arrival within 4h on long-haul', () => {
     const r = applyEU261({
       distanceKm: 6000,
       arrivalDelayHours: 3.5,
       extraordinaryCircumstances: false,
       flightCancelled: false,
+      reroutingOffered: true,
+      reroutingArrivalLatenessHours: 4,
     });
     expect(r.compensationEur).toBe('300.00');
     expect(r.reductionPercent).toBe(50);
+  });
+
+  it('Article 7(2) rerouting reduction: 50% (€125) when alternative arrival within 2h on short-haul', () => {
+    const r = applyEU261({
+      distanceKm: 1000,
+      arrivalDelayHours: 4,
+      extraordinaryCircumstances: false,
+      flightCancelled: false,
+      reroutingOffered: true,
+      reroutingArrivalLatenessHours: 1.5,
+    });
+    expect(r.compensationEur).toBe('125.00');
+    expect(r.reductionPercent).toBe(50);
+  });
+
+  it('no reduction when rerouting arrival exceeds band threshold', () => {
+    const r = applyEU261({
+      distanceKm: 1000,
+      arrivalDelayHours: 4,
+      extraordinaryCircumstances: false,
+      flightCancelled: false,
+      reroutingOffered: true,
+      reroutingArrivalLatenessHours: 2.5,
+    });
+    expect(r.compensationEur).toBe('250.00');
+    expect(r.reductionPercent).toBe(0);
   });
 
   it('returns ineligible when delay < 3h', () => {

--- a/packages/core/src/regulations/__tests__/us-dot-idb.test.ts
+++ b/packages/core/src/regulations/__tests__/us-dot-idb.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { applyUsDotIdb } from '../us-dot-idb.js';
+
+describe('applyUsDotIdb — domestic', () => {
+  it('owes nothing when substitute arrives within 60min', () => {
+    const r = applyUsDotIdb({ isDomestic: true, substituteArrivalLateMinutes: 45, oneWayFareUsd: 300 });
+    expect(r.eligible).toBe(false);
+    expect(r.compensationUsd).toBe('0.00');
+  });
+
+  it('owes 200% capped at $1075 when 1-2h late', () => {
+    const r = applyUsDotIdb({ isDomestic: true, substituteArrivalLateMinutes: 90, oneWayFareUsd: 300 });
+    expect(r.eligible).toBe(true);
+    expect(r.compensationUsd).toBe('600.00');
+  });
+
+  it('caps 200% at $1075', () => {
+    const r = applyUsDotIdb({ isDomestic: true, substituteArrivalLateMinutes: 90, oneWayFareUsd: 700 });
+    expect(r.compensationUsd).toBe('1075.00');
+  });
+
+  it('owes 400% capped at $2150 when >2h late', () => {
+    const r = applyUsDotIdb({ isDomestic: true, substituteArrivalLateMinutes: 180, oneWayFareUsd: 300 });
+    expect(r.compensationUsd).toBe('1200.00');
+  });
+
+  it('caps 400% at $2150', () => {
+    const r = applyUsDotIdb({ isDomestic: true, substituteArrivalLateMinutes: 180, oneWayFareUsd: 800 });
+    expect(r.compensationUsd).toBe('2150.00');
+  });
+
+  it('treats no-rerouting as highest band', () => {
+    const r = applyUsDotIdb({ isDomestic: true, substituteArrivalLateMinutes: Infinity, oneWayFareUsd: 300 });
+    expect(r.compensationUsd).toBe('1200.00');
+  });
+});
+
+describe('applyUsDotIdb — international', () => {
+  it('owes nothing when substitute arrives within 60min', () => {
+    const r = applyUsDotIdb({ isDomestic: false, substituteArrivalLateMinutes: 45, oneWayFareUsd: 1000 });
+    expect(r.compensationUsd).toBe('0.00');
+  });
+
+  it('owes 200% (capped) when 1-4h late', () => {
+    const r = applyUsDotIdb({ isDomestic: false, substituteArrivalLateMinutes: 180, oneWayFareUsd: 600 });
+    expect(r.compensationUsd).toBe('1075.00');
+  });
+
+  it('owes 400% (capped) when >4h late', () => {
+    const r = applyUsDotIdb({ isDomestic: false, substituteArrivalLateMinutes: 300, oneWayFareUsd: 1000 });
+    expect(r.compensationUsd).toBe('2150.00');
+  });
+});

--- a/packages/core/src/regulations/eu261.ts
+++ b/packages/core/src/regulations/eu261.ts
@@ -1,0 +1,176 @@
+/**
+ * EU Regulation 261/2004 — passenger compensation for delays, cancellations,
+ * and denied boarding on flights departing from the EU/EEA, or operated by
+ * an EU/EEA carrier into the EU/EEA.
+ *
+ * Source: Regulation (EC) No 261/2004 of the European Parliament and Council
+ * (11 February 2004). Articles referenced: 5 (cancellation), 6 (delay),
+ * 7 (right to compensation), 8 (right to refund/rerouting), 9 (right to care).
+ *
+ * Constants below are PUBLISHED LAW. They are stable and intentionally
+ * hardcoded. Do not adjust without a regulatory amendment citation.
+ */
+
+import Decimal from 'decimal.js';
+
+/** Distance bands and compensation amounts (Article 7). */
+export const EU261_BANDS = [
+  { maxDistanceKm: 1500, compensationEur: 250, careDelayHours: 2 },
+  { maxDistanceKm: 3500, compensationEur: 400, careDelayHours: 3 },
+  { maxDistanceKm: Number.POSITIVE_INFINITY, compensationEur: 600, careDelayHours: 4 },
+] as const;
+
+/** Arrival delay (in hours) at the final destination that triggers compensation (Sturgeon line). */
+export const EU261_DELAY_TRIGGER_HOURS = 3;
+
+/**
+ * For flights >3500 km whose arrival delay is between 3 and 4 hours, the
+ * carrier may reduce compensation by 50% (Article 7(2)(c)).
+ */
+export const EU261_LONGHAUL_PARTIAL_REDUCTION = {
+  distanceKm: 3500,
+  delayHoursMin: 3,
+  delayHoursMax: 4,
+  reductionPct: 50,
+} as const;
+
+/** Cancellation compensation is owed when notice was given less than 14 days before departure. */
+export const EU261_CANCELLATION_NOTICE_DAYS = 14;
+
+/** Above this delay the passenger may choose a full refund instead of rerouting (Article 6(1)(iii)). */
+export const EU261_REFUND_CHOICE_DELAY_HOURS = 5;
+
+export interface EU261Input {
+  /** Great-circle distance between origin and final destination (kilometres). */
+  distanceKm: number;
+  /** Arrival delay at the FINAL destination, in hours. */
+  arrivalDelayHours: number;
+  /** Whether the carrier invokes the "extraordinary circumstances" exemption (weather, ATC, security). */
+  extraordinaryCircumstances: boolean;
+  /** Was the flight cancelled? */
+  flightCancelled: boolean;
+  /** For cancellations: how many days before scheduled departure was the passenger notified? */
+  noticeDaysBeforeDeparture?: number;
+}
+
+export interface EU261Result {
+  eligible: boolean;
+  /** Compensation per passenger, in EUR (Decimal-safe string). */
+  compensationEur: string;
+  /** Reduction percentage applied (0 or 50). */
+  reductionPercent: number;
+  /** Right-to-care threshold (hours) for the applicable distance band. */
+  careDelayHours: number;
+  /** Whether the passenger may opt for a full refund (>=5h delay). */
+  refundChoiceAvailable: boolean;
+  /** Plain-English explanation. */
+  reason: string;
+}
+
+function bandFor(distanceKm: number): (typeof EU261_BANDS)[number] {
+  for (const band of EU261_BANDS) {
+    if (distanceKm <= band.maxDistanceKm) return band;
+  }
+  // Unreachable — last band is +Infinity.
+  return EU261_BANDS[EU261_BANDS.length - 1]!;
+}
+
+/**
+ * Apply EU261/2004 to a single passenger journey.
+ *
+ * Pure function: callers are responsible for determining EU jurisdiction
+ * (departure from EU/EEA, or EU carrier inbound to EU/EEA).
+ */
+export function applyEU261(input: EU261Input): EU261Result {
+  const band = bandFor(input.distanceKm);
+
+  if (input.extraordinaryCircumstances) {
+    return {
+      eligible: false,
+      compensationEur: '0.00',
+      reductionPercent: 0,
+      careDelayHours: band.careDelayHours,
+      refundChoiceAvailable: input.arrivalDelayHours >= EU261_REFUND_CHOICE_DELAY_HOURS,
+      reason:
+        'Extraordinary circumstances exemption (Article 5(3)): weather, ATC, security, or other event outside the carrier\'s control.',
+    };
+  }
+
+  // Cancellation path: compensation owed when notice < 14 days.
+  if (input.flightCancelled) {
+    const notice = input.noticeDaysBeforeDeparture ?? 0;
+    if (notice >= EU261_CANCELLATION_NOTICE_DAYS) {
+      return {
+        eligible: false,
+        compensationEur: '0.00',
+        reductionPercent: 0,
+        careDelayHours: band.careDelayHours,
+        refundChoiceAvailable: true,
+        reason: `Cancellation notified ${notice} days before departure — no compensation owed (Article 5(1)(c) safe harbour ≥${EU261_CANCELLATION_NOTICE_DAYS} days).`,
+      };
+    }
+    return {
+      eligible: true,
+      compensationEur: new Decimal(band.compensationEur).toFixed(2),
+      reductionPercent: 0,
+      careDelayHours: band.careDelayHours,
+      refundChoiceAvailable: true,
+      reason: `Cancellation notified ${notice} days before departure — €${band.compensationEur} per passenger (distance band ≤${band.maxDistanceKm}km).`,
+    };
+  }
+
+  // Delay path: arrival delay must reach the trigger.
+  if (input.arrivalDelayHours < EU261_DELAY_TRIGGER_HOURS) {
+    return {
+      eligible: false,
+      compensationEur: '0.00',
+      reductionPercent: 0,
+      careDelayHours: band.careDelayHours,
+      refundChoiceAvailable: input.arrivalDelayHours >= EU261_REFUND_CHOICE_DELAY_HOURS,
+      reason: `Arrival delay ${input.arrivalDelayHours}h is below the ${EU261_DELAY_TRIGGER_HOURS}h compensation trigger.`,
+    };
+  }
+
+  let amount = new Decimal(band.compensationEur);
+  let reduction = 0;
+  let reasonExtra = '';
+
+  if (
+    input.distanceKm > EU261_LONGHAUL_PARTIAL_REDUCTION.distanceKm &&
+    input.arrivalDelayHours >= EU261_LONGHAUL_PARTIAL_REDUCTION.delayHoursMin &&
+    input.arrivalDelayHours < EU261_LONGHAUL_PARTIAL_REDUCTION.delayHoursMax
+  ) {
+    reduction = EU261_LONGHAUL_PARTIAL_REDUCTION.reductionPct;
+    amount = amount.mul(100 - reduction).div(100);
+    reasonExtra = ` Reduced by ${reduction}% under Article 7(2)(c) (>${EU261_LONGHAUL_PARTIAL_REDUCTION.distanceKm}km, ${EU261_LONGHAUL_PARTIAL_REDUCTION.delayHoursMin}-${EU261_LONGHAUL_PARTIAL_REDUCTION.delayHoursMax}h delay).`;
+  }
+
+  return {
+    eligible: true,
+    compensationEur: amount.toFixed(2),
+    reductionPercent: reduction,
+    careDelayHours: band.careDelayHours,
+    refundChoiceAvailable: input.arrivalDelayHours >= EU261_REFUND_CHOICE_DELAY_HOURS,
+    reason: `Arrival delay ${input.arrivalDelayHours}h ≥ ${EU261_DELAY_TRIGGER_HOURS}h trigger; distance band ≤${band.maxDistanceKm}km → €${band.compensationEur}.${reasonExtra}`,
+  };
+}
+
+/**
+ * Great-circle distance in kilometres between two lat/lon points (haversine).
+ * Pure geometry — used to compute the EU261 distance band.
+ */
+export function greatCircleDistanceKm(
+  origin: { latitude: number; longitude: number },
+  destination: { latitude: number; longitude: number },
+): number {
+  const R = 6371; // mean Earth radius in km
+  const toRad = (deg: number): number => (deg * Math.PI) / 180;
+  const dLat = toRad(destination.latitude - origin.latitude);
+  const dLon = toRad(destination.longitude - origin.longitude);
+  const lat1 = toRad(origin.latitude);
+  const lat2 = toRad(destination.latitude);
+  const a =
+    Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}

--- a/packages/core/src/regulations/eu261.ts
+++ b/packages/core/src/regulations/eu261.ts
@@ -51,6 +51,15 @@ export interface EU261Input {
   flightCancelled: boolean;
   /** For cancellations: how many days before scheduled departure was the passenger notified? */
   noticeDaysBeforeDeparture?: number;
+  /**
+   * Article 7(2) rerouting reduction inputs. When the carrier offers
+   * rerouting whose arrival exceeds the originally scheduled arrival by
+   * no more than the band threshold (2h ≤1500km, 3h 1500-3500km,
+   * 4h >3500km), compensation may be reduced by 50%.
+   */
+  reroutingOffered?: boolean;
+  /** Hours by which the rerouted arrival exceeds the original scheduled arrival. */
+  reroutingArrivalLatenessHours?: number;
 }
 
 export interface EU261Result {
@@ -109,13 +118,20 @@ export function applyEU261(input: EU261Input): EU261Result {
         reason: `Cancellation notified ${notice} days before departure — no compensation owed (Article 5(1)(c) safe harbour ≥${EU261_CANCELLATION_NOTICE_DAYS} days).`,
       };
     }
+    let amount = new Decimal(band.compensationEur);
+    const reduction = computeReroutingReduction(input, band);
+    let reasonExtra = '';
+    if (reduction > 0) {
+      amount = amount.mul(100 - reduction).div(100);
+      reasonExtra = ` Reduced by ${reduction}% under Article 7(2) (rerouting offered within band threshold).`;
+    }
     return {
       eligible: true,
-      compensationEur: new Decimal(band.compensationEur).toFixed(2),
-      reductionPercent: 0,
+      compensationEur: amount.toFixed(2),
+      reductionPercent: reduction,
       careDelayHours: band.careDelayHours,
       refundChoiceAvailable: true,
-      reason: `Cancellation notified ${notice} days before departure — €${band.compensationEur} per passenger (distance band ≤${band.maxDistanceKm}km).`,
+      reason: `Cancellation notified ${notice} days before departure — €${band.compensationEur} per passenger (distance band ≤${band.maxDistanceKm}km).${reasonExtra}`,
     };
   }
 
@@ -131,20 +147,24 @@ export function applyEU261(input: EU261Input): EU261Result {
     };
   }
 
+  return buildDelayResult(input, band);
+}
+
+/**
+ * Build the eligible delay/cancellation compensation result, applying
+ * Article 7(2) rerouting reduction when applicable.
+ */
+function buildDelayResult(
+  input: EU261Input,
+  band: (typeof EU261_BANDS)[number],
+): EU261Result {
   let amount = new Decimal(band.compensationEur);
-  let reduction = 0;
+  const reduction = computeReroutingReduction(input, band);
   let reasonExtra = '';
-
-  if (
-    input.distanceKm > EU261_LONGHAUL_PARTIAL_REDUCTION.distanceKm &&
-    input.arrivalDelayHours >= EU261_LONGHAUL_PARTIAL_REDUCTION.delayHoursMin &&
-    input.arrivalDelayHours < EU261_LONGHAUL_PARTIAL_REDUCTION.delayHoursMax
-  ) {
-    reduction = EU261_LONGHAUL_PARTIAL_REDUCTION.reductionPct;
+  if (reduction > 0) {
     amount = amount.mul(100 - reduction).div(100);
-    reasonExtra = ` Reduced by ${reduction}% under Article 7(2)(c) (>${EU261_LONGHAUL_PARTIAL_REDUCTION.distanceKm}km, ${EU261_LONGHAUL_PARTIAL_REDUCTION.delayHoursMin}-${EU261_LONGHAUL_PARTIAL_REDUCTION.delayHoursMax}h delay).`;
+    reasonExtra = ` Reduced by ${reduction}% under Article 7(2) (rerouting offered within band threshold).`;
   }
-
   return {
     eligible: true,
     compensationEur: amount.toFixed(2),
@@ -153,6 +173,24 @@ export function applyEU261(input: EU261Input): EU261Result {
     refundChoiceAvailable: input.arrivalDelayHours >= EU261_REFUND_CHOICE_DELAY_HOURS,
     reason: `Arrival delay ${input.arrivalDelayHours}h ≥ ${EU261_DELAY_TRIGGER_HOURS}h trigger; distance band ≤${band.maxDistanceKm}km → €${band.compensationEur}.${reasonExtra}`,
   };
+}
+
+/**
+ * Article 7(2) rerouting reduction: 50% if the carrier offers re-routing
+ * whose arrival is within the band-specific threshold of the original
+ * scheduled arrival.
+ */
+function computeReroutingReduction(
+  input: EU261Input,
+  band: (typeof EU261_BANDS)[number],
+): number {
+  if (!input.reroutingOffered) return 0;
+  const lateness = input.reroutingArrivalLatenessHours;
+  if (lateness === undefined) return 0;
+  if (lateness <= band.careDelayHours) {
+    return EU261_LONGHAUL_PARTIAL_REDUCTION.reductionPct;
+  }
+  return 0;
 }
 
 /**

--- a/packages/core/src/regulations/index.ts
+++ b/packages/core/src/regulations/index.ts
@@ -1,0 +1,17 @@
+export {
+  EU261_BANDS,
+  EU261_DELAY_TRIGGER_HOURS,
+  EU261_LONGHAUL_PARTIAL_REDUCTION,
+  EU261_CANCELLATION_NOTICE_DAYS,
+  EU261_REFUND_CHOICE_DELAY_HOURS,
+  applyEU261,
+  greatCircleDistanceKm,
+} from './eu261.js';
+export type { EU261Input, EU261Result } from './eu261.js';
+
+export {
+  US_DOT_IDB_DOMESTIC,
+  US_DOT_IDB_INTERNATIONAL,
+  applyUsDotIdb,
+} from './us-dot-idb.js';
+export type { UsDotIdbInput, UsDotIdbResult, UsDotIdbBand } from './us-dot-idb.js';

--- a/packages/core/src/regulations/us-dot-idb.ts
+++ b/packages/core/src/regulations/us-dot-idb.ts
@@ -1,0 +1,99 @@
+/**
+ * US DOT 14 CFR Part 250 — Oversales / denied boarding compensation.
+ *
+ * Effective 2025-01-22. APPLIES ONLY TO INVOLUNTARY DENIED BOARDING due to
+ * oversales — does NOT cover delays or cancellations.
+ *
+ * Source: 14 CFR §250.5 — "Amount of denied boarding compensation."
+ * https://www.ecfr.gov/current/title-14/chapter-II/subchapter-A/part-250
+ *
+ * Constants below are PUBLISHED LAW. They are stable until DOT amends the rule.
+ */
+
+import Decimal from 'decimal.js';
+
+export interface UsDotIdbBand {
+  /** Inclusive upper bound on substitute-transport arrival lateness (minutes). */
+  maxLateMinutes: number;
+  /** Multiplier applied to the one-way fare. */
+  multiplier: number;
+  /** Maximum compensation cap in USD (0 means no compensation). */
+  capUsd: number;
+}
+
+/** Domestic flights (within the United States). */
+export const US_DOT_IDB_DOMESTIC: readonly UsDotIdbBand[] = [
+  { maxLateMinutes: 60, multiplier: 0, capUsd: 0 },
+  { maxLateMinutes: 120, multiplier: 2, capUsd: 1075 },
+  { maxLateMinutes: Number.POSITIVE_INFINITY, multiplier: 4, capUsd: 2150 },
+];
+
+/** International flights to/from the United States. */
+export const US_DOT_IDB_INTERNATIONAL: readonly UsDotIdbBand[] = [
+  { maxLateMinutes: 60, multiplier: 0, capUsd: 0 },
+  { maxLateMinutes: 240, multiplier: 2, capUsd: 1075 },
+  { maxLateMinutes: Number.POSITIVE_INFINITY, multiplier: 4, capUsd: 2150 },
+];
+
+export interface UsDotIdbInput {
+  /** True for flights wholly within the US; false for international. */
+  isDomestic: boolean;
+  /**
+   * Lateness of the substitute transport's arrival vs. originally scheduled
+   * arrival, in minutes. If the carrier offers no rerouting at all, pass
+   * Infinity to land in the highest band.
+   */
+  substituteArrivalLateMinutes: number;
+  /** One-way fare actually paid for the affected segment, in USD. */
+  oneWayFareUsd: string | number;
+}
+
+export interface UsDotIdbResult {
+  eligible: boolean;
+  /** Compensation amount in USD (Decimal-safe string). */
+  compensationUsd: string;
+  /** The matched band, for audit. */
+  band: UsDotIdbBand;
+  /** Plain-English explanation. */
+  reason: string;
+}
+
+function bandFor(
+  table: readonly UsDotIdbBand[],
+  lateMinutes: number,
+): UsDotIdbBand {
+  for (const band of table) {
+    if (lateMinutes <= band.maxLateMinutes) return band;
+  }
+  return table[table.length - 1]!;
+}
+
+/**
+ * Compute denied-boarding compensation under 14 CFR §250.5.
+ *
+ * Pure function: callers are responsible for confirming this was an
+ * involuntary denied-boarding due to oversales, not a delay or cancel.
+ */
+export function applyUsDotIdb(input: UsDotIdbInput): UsDotIdbResult {
+  const table = input.isDomestic ? US_DOT_IDB_DOMESTIC : US_DOT_IDB_INTERNATIONAL;
+  const band = bandFor(table, input.substituteArrivalLateMinutes);
+  const fare = new Decimal(input.oneWayFareUsd);
+
+  if (band.multiplier === 0) {
+    return {
+      eligible: false,
+      compensationUsd: '0.00',
+      band,
+      reason: `Substitute transport arrives within ${band.maxLateMinutes}min — no compensation owed under 14 CFR §250.5(a).`,
+    };
+  }
+
+  const raw = fare.mul(band.multiplier);
+  const capped = Decimal.min(raw, new Decimal(band.capUsd));
+  return {
+    eligible: true,
+    compensationUsd: capped.toFixed(2),
+    band,
+    reason: `${band.multiplier * 100}% of one-way fare ($${fare.toFixed(2)}), capped at $${band.capUsd}. ${input.isDomestic ? 'Domestic' : 'International'} substitute lateness ${input.substituteArrivalLateMinutes}min.`,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.0.0
         version: 1.9.1
+      decimal.js:
+        specifier: ^10.6.0
+        version: 10.6.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary
Codex review HIGH #3, #4, #5 — three CLAUDE.md violations across 5 engines.

This PR removes invented travel-domain values and replaces them with either authoritative-input-driven logic or published-law constants. Six logical commits — review one at a time.

### Foundations (commit 1)
- New \`@otaip/core\` exports:
  - \`DomainInputRequired\` discriminated union + helpers (\`domainInputRequired\`, \`isDomainInputRequired\`)
  - \`regulations/eu261.ts\` — EC 261/2004 published constants and \`applyEU261()\` (distance bands €250/€400/€600, 3h Sturgeon trigger, Article 7(2) rerouting reduction, 14-day cancellation safe harbour, extraordinary-circumstances exemption)
  - \`regulations/us-dot-idb.ts\` — 14 CFR §250.5 (effective 2025-01-22) bands for involuntary denied boarding only ($1,075 / $2,150 caps)
  - \`greatCircleDistanceKm\` haversine helper
- decimal.js promoted to a \`@otaip/core\` dep

### Involuntary Rebook (commit 2 — HIGH #5)
- Remove the hardcoded 60-min IRROP threshold. Caller now supplies \`thresholds.time_change_minutes\`; absent → non-involuntary + DOMAIN_INPUT_REQUIRED warning.
- Replace invented EU261 logic with \`applyEU261\`. New \`eu261_inputs\` accepts distance/delay/extraordinary/notice/rerouting. When jurisdiction applies but inputs absent → flag carries \`compensation_eur: null\` + \`missing_inputs\`.
- Clarify US DOT 14 CFR §250 applies to denied boarding only — rebook flag now correctly reports not-applicable and points to Agent 6.5.

### Feedback & Complaint (commit 3 — HIGH #5)
- Replace ~250 lines of inline EU261/DOT compensation math with calls to the new core regulation modules.
- US DOT IDB caps updated to current $1,075 / $2,150 (was pre-2025 $775 / $1,550).
- Article 10(2) downgrade reimbursement (30/50/75%) kept inline — published law not covered by Article 7 helper.

### Fare Construction (commit 4 — HIGH #3)
- **Remove** ROE 1.0 fallback. Engine now returns \`DomainInputRequired\` listing \`roe_table_entry:<currency>\` when ROE missing — no more silent multiply-by-1.
- **Remove** simplified HIP per-mile-rate heuristic. Step now reports \`detected: false\` with \`missing_inputs: ['intermediate_point_fares:...']\`.
- **Remove** simplified BHC city-revisited heuristic. Same DOMAIN_INPUT_REQUIRED treatment.
- **Keep** the EMS mileage formula (5%/5%, max 25%) — confirmed IATA standard.
- Output type widened to \`FareConstructionResult = FareConstructionOutput | DomainInputRequired\`. Agent wrapper handles both branches.

### Change Management + Refund Processing (commit 5 — HIGH #4)
Both engines previously fell back to a $200 penalty when no filed rule matched. Per the user-supplied domain spec:
- When \`cat31_rules\` / \`cat33_rules\` ARE supplied → apply as filed
- When absent + voluntary → permitted at no charge (penalty = 0)
- When absent + involuntary → fee waived to 0 (regulatory comp via Agent 5.3)

Data files moved to \`__tests__/fixtures/\` with TEST FIXTURE banners. Existing tests pass them explicitly to exercise the apply-as-filed branch. New tests cover the ATPCO-default branch.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` — succeeds
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm test\` — 3,075 passed (3 skipped)
- [x] 18 new tests for EU261 + US DOT IDB modules
- [x] 5 new EU261 compensation tests in involuntary-rebook
- [x] 3 new ATPCO-default tests in change-management; 3 in refund-processing
- [x] Updated DOT IDB cap tests in feedback-complaint to current $1,075/$2,150

🤖 Generated with [Claude Code](https://claude.com/claude-code)