### PR TITLE
fix: gds-ndc-router routes per-transaction, not per-airline

### DIFF
--- a/packages/agents/booking/src/gds-ndc-router/__tests__/gds-ndc-router.test.ts
+++ b/packages/agents/booking/src/gds-ndc-router/__tests__/gds-ndc-router.test.ts
@@ -24,6 +24,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'DL', origin: 'JFK', destination: 'LAX' }],
+          transaction_type: 'shopping',
           include_fallbacks: true,
         },
       });
@@ -38,6 +39,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'UA', origin: 'SFO', destination: 'LHR' }],
+          transaction_type: 'shopping',
           include_fallbacks: true,
         },
       });
@@ -50,6 +52,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'EK', origin: 'DXB', destination: 'LHR' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -62,6 +65,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'AS', origin: 'SEA', destination: 'LAX' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -75,6 +79,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
           include_fallbacks: true,
         },
       });
@@ -90,6 +95,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'LH', origin: 'FRA', destination: 'JFK' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -103,6 +109,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'AA', origin: 'DFW', destination: 'LHR' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -115,6 +122,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'SQ', origin: 'SIN', destination: 'LHR' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -128,6 +136,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'WN', origin: 'LAX', destination: 'LAS' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -140,6 +149,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'FR', origin: 'STN', destination: 'DUB' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -151,6 +161,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'WN', origin: 'LAX', destination: 'LAS' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -172,6 +183,7 @@ describe('GDS/NDC Router', () => {
               destination: 'SYD',
             },
           ],
+          transaction_type: 'shopping',
           include_fallbacks: true,
         },
       });
@@ -193,6 +205,7 @@ describe('GDS/NDC Router', () => {
               destination: 'JFK',
             },
           ],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -212,6 +225,7 @@ describe('GDS/NDC Router', () => {
               destination: 'SYD',
             },
           ],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -227,6 +241,7 @@ describe('GDS/NDC Router', () => {
         data: {
           segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
           preferred_channel: 'GDS',
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -239,6 +254,7 @@ describe('GDS/NDC Router', () => {
         data: {
           segments: [{ marketing_carrier: 'DL', origin: 'JFK', destination: 'LAX' }],
           preferred_gds: 'SABRE',
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -252,6 +268,7 @@ describe('GDS/NDC Router', () => {
         data: {
           segments: [{ marketing_carrier: 'WN', origin: 'LAX', destination: 'LAS' }],
           preferred_channel: 'GDS',
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -266,6 +283,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
           include_fallbacks: true,
         },
       });
@@ -278,6 +296,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -294,6 +313,7 @@ describe('GDS/NDC Router', () => {
             { marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' },
             { marketing_carrier: 'BA', origin: 'JFK', destination: 'LHR' },
           ],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -309,6 +329,7 @@ describe('GDS/NDC Router', () => {
             { marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' },
             { marketing_carrier: 'WN', origin: 'JFK', destination: 'LAX' },
           ],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -324,6 +345,7 @@ describe('GDS/NDC Router', () => {
             { marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' },
             { marketing_carrier: 'DL', origin: 'JFK', destination: 'LAX' },
           ],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -340,6 +362,7 @@ describe('GDS/NDC Router', () => {
           segments: [
             { marketing_carrier: 'DL', origin: 'JFK', destination: 'LAX', flight_number: '100' },
           ],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -353,6 +376,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -366,6 +390,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -375,23 +400,165 @@ describe('GDS/NDC Router', () => {
   });
 
   describe('Unknown carrier', () => {
-    it('defaults to GDS via AMADEUS for unknown carrier', async () => {
+    it('returns DOMAIN_INPUT_REQUIRED for unknown carrier (no invented default)', async () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'ZZ', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
 
+      expect(result.data.routings[0]!.domain_input_required).toBe(true);
+      expect(result.data.routings[0]!.missing_inputs).toBeDefined();
+      expect(result.warnings!.some((w) => w.includes('DOMAIN_INPUT_REQUIRED'))).toBe(true);
+    });
+
+    it('uses caller-supplied capability_overrides for unknown carrier', async () => {
+      const result = await agent.execute({
+        data: {
+          segments: [{ marketing_carrier: 'ZZ', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
+          capability_overrides: {
+            ZZ: {
+              shopping: {
+                name: 'Unknown Carrier',
+                channels: ['GDS'],
+                channel_priority: ['GDS'],
+                ndc_version: null,
+                gds_preference: 'SABRE',
+                ndc_capable: false,
+                ndc_provider_id: null,
+              },
+            },
+          },
+          include_fallbacks: false,
+        },
+      });
+      expect(result.data.routings[0]!.domain_input_required).toBeUndefined();
       expect(result.data.routings[0]!.primary_channel).toBe('GDS');
-      expect(result.data.routings[0]!.gds_system).toBe('AMADEUS');
+      expect(result.data.routings[0]!.gds_system).toBe('SABRE');
+    });
+  });
+
+  describe('Per-transaction routing (CLAUDE.md compliance)', () => {
+    it('returns DOMAIN_INPUT_REQUIRED for group transactions on NDC carrier', async () => {
+      // Built-in carrier defaults cover shopping/booking only. Groups
+      // routinely need GDS for NDC carriers.
+      const result = await agent.execute({
+        data: {
+          segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'group',
+          include_fallbacks: false,
+        },
+      });
+      expect(result.data.routings[0]!.domain_input_required).toBe(true);
+      expect(result.data.routings[0]!.missing_inputs![0]).toContain('group');
+    });
+
+    it('routes BA group transaction via GDS when override supplied', async () => {
+      const result = await agent.execute({
+        data: {
+          segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'group',
+          capability_overrides: {
+            BA: {
+              group: {
+                name: 'British Airways',
+                channels: ['GDS'],
+                channel_priority: ['GDS'],
+                ndc_version: null,
+                gds_preference: 'AMADEUS',
+                ndc_capable: false,
+                ndc_provider_id: null,
+              },
+            },
+          },
+          include_fallbacks: false,
+        },
+      });
+      expect(result.data.routings[0]!.domain_input_required).toBeUndefined();
+      expect(result.data.routings[0]!.primary_channel).toBe('GDS');
+    });
+
+    it('returns DOMAIN_INPUT_REQUIRED for servicing of an NDC carrier without override', async () => {
+      const result = await agent.execute({
+        data: {
+          segments: [{ marketing_carrier: 'LH', origin: 'FRA', destination: 'JFK' }],
+          transaction_type: 'servicing',
+          include_fallbacks: false,
+        },
+      });
+      expect(result.data.routings[0]!.domain_input_required).toBe(true);
+    });
+
+    it('returns DOMAIN_INPUT_REQUIRED for corporate transactions without override', async () => {
+      const result = await agent.execute({
+        data: {
+          segments: [{ marketing_carrier: 'AA', origin: 'DFW', destination: 'LHR' }],
+          transaction_type: 'corporate',
+          include_fallbacks: false,
+        },
+      });
+      expect(result.data.routings[0]!.domain_input_required).toBe(true);
+    });
+
+    it('caller override beats built-in default for shopping', async () => {
+      const result = await agent.execute({
+        data: {
+          segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
+          capability_overrides: {
+            BA: {
+              shopping: {
+                name: 'British Airways',
+                channels: ['GDS'],
+                channel_priority: ['GDS'],
+                ndc_version: null,
+                gds_preference: 'SABRE',
+                ndc_capable: false,
+                ndc_provider_id: null,
+              },
+            },
+          },
+          include_fallbacks: false,
+        },
+      });
+      // Built-in default is NDC for BA; override forces GDS/SABRE.
+      expect(result.data.routings[0]!.primary_channel).toBe('GDS');
+      expect(result.data.routings[0]!.gds_system).toBe('SABRE');
     });
   });
 
   describe('Input validation', () => {
     it('rejects empty segments', async () => {
       await expect(
-        agent.execute({ data: { segments: [], include_fallbacks: false } }),
+        agent.execute({
+          data: { segments: [], transaction_type: 'shopping', include_fallbacks: false },
+        }),
+      ).rejects.toThrow('Invalid input');
+    });
+
+    it('rejects missing transaction_type', async () => {
+      await expect(
+        agent.execute({
+          data: {
+            segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+            include_fallbacks: false,
+          } as Parameters<typeof agent.execute>[0]['data'],
+        }),
+      ).rejects.toThrow('Invalid input');
+    });
+
+    it('rejects invalid transaction_type', async () => {
+      await expect(
+        agent.execute({
+          data: {
+            segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+            transaction_type: 'unknown' as 'shopping',
+            include_fallbacks: false,
+          },
+        }),
       ).rejects.toThrow('Invalid input');
     });
 
@@ -400,7 +567,8 @@ describe('GDS/NDC Router', () => {
         agent.execute({
           data: {
             segments: [{ marketing_carrier: 'TOOLONG', origin: 'JFK', destination: 'LHR' }],
-            include_fallbacks: false,
+            transaction_type: 'shopping',
+          include_fallbacks: false,
           },
         }),
       ).rejects.toThrow('Invalid input');
@@ -412,7 +580,8 @@ describe('GDS/NDC Router', () => {
           data: {
             segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
             preferred_channel: 'INVALID' as 'GDS',
-            include_fallbacks: false,
+            transaction_type: 'shopping',
+          include_fallbacks: false,
           },
         }),
       ).rejects.toThrow('Invalid input');
@@ -423,7 +592,8 @@ describe('GDS/NDC Router', () => {
         agent.execute({
           data: {
             segments: [{ marketing_carrier: 'BA', origin: '1', destination: 'JFK' }],
-            include_fallbacks: false,
+            transaction_type: 'shopping',
+          include_fallbacks: false,
           },
         }),
       ).rejects.toThrow('Invalid input');
@@ -446,6 +616,7 @@ describe('GDS/NDC Router', () => {
       const result = await agent.execute({
         data: {
           segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
+          transaction_type: 'shopping',
           include_fallbacks: false,
         },
       });
@@ -458,7 +629,8 @@ describe('GDS/NDC Router', () => {
         uninit.execute({
           data: {
             segments: [{ marketing_carrier: 'BA', origin: 'LHR', destination: 'JFK' }],
-            include_fallbacks: false,
+            transaction_type: 'shopping',
+          include_fallbacks: false,
           },
         }),
       ).rejects.toThrow('not been initialized');

--- a/packages/agents/booking/src/gds-ndc-router/index.ts
+++ b/packages/agents/booking/src/gds-ndc-router/index.ts
@@ -14,6 +14,7 @@ import type {
   GdsNdcRouterOutput,
   DistributionChannel,
   GdsSystem,
+  TransactionType,
 } from './types.js';
 import { routeSegments } from './router-engine.js';
 
@@ -21,6 +22,14 @@ const IATA_CODE_RE = /^[A-Z0-9]{2}$/;
 const AIRPORT_RE = /^[A-Z]{3}$/i;
 const VALID_CHANNELS = new Set<DistributionChannel>(['GDS', 'NDC', 'DIRECT']);
 const VALID_GDS = new Set<GdsSystem>(['AMADEUS', 'SABRE', 'TRAVELPORT']);
+const VALID_TRANSACTION_TYPES = new Set<TransactionType>([
+  'shopping',
+  'booking',
+  'ticketing',
+  'servicing',
+  'group',
+  'corporate',
+]);
 
 export class GdsNdcRouter implements Agent<GdsNdcRouterInput, GdsNdcRouterOutput> {
   readonly id = '3.1';
@@ -43,7 +52,9 @@ export class GdsNdcRouter implements Agent<GdsNdcRouterInput, GdsNdcRouterOutput
     const result = routeSegments(input.data);
 
     const warnings: string[] = [];
-    const directRoutes = result.routings.filter((r) => r.primary_channel === 'DIRECT');
+    const directRoutes = result.routings.filter(
+      (r) => r.primary_channel === 'DIRECT' && !r.domain_input_required,
+    );
     if (directRoutes.length > 0) {
       warnings.push(
         `${directRoutes.length} segment(s) routed to DIRECT channel — not bookable via GDS/NDC.`,
@@ -55,6 +66,12 @@ export class GdsNdcRouter implements Agent<GdsNdcRouterInput, GdsNdcRouterOutput
     const codeshares = result.routings.filter((r) => r.codeshare_applied);
     if (codeshares.length > 0) {
       warnings.push(`Codeshare routing applied for ${codeshares.length} segment(s).`);
+    }
+    const unresolved = result.routings.filter((r) => r.domain_input_required);
+    for (const r of unresolved) {
+      warnings.push(
+        `DOMAIN_INPUT_REQUIRED: capability matrix for carrier=${r.routed_carrier} transaction_type=${input.data.transaction_type} not provided — supply via input.capability_overrides.`,
+      );
     }
 
     return {
@@ -83,6 +100,13 @@ export class GdsNdcRouter implements Agent<GdsNdcRouterInput, GdsNdcRouterOutput
   }
 
   private validateInput(data: GdsNdcRouterInput): void {
+    if (!data.transaction_type || !VALID_TRANSACTION_TYPES.has(data.transaction_type)) {
+      throw new AgentInputValidationError(
+        this.id,
+        'transaction_type',
+        `Must be one of: ${[...VALID_TRANSACTION_TYPES].join(', ')}`,
+      );
+    }
     if (!data.segments || !Array.isArray(data.segments) || data.segments.length === 0) {
       throw new AgentInputValidationError(this.id, 'segments', 'At least one segment required.');
     }
@@ -150,4 +174,6 @@ export type {
   GdsPnrSegment,
   NdcOrderFormat,
   NdcOfferItem,
+  TransactionType,
+  TransactionCapabilityOverrides,
 } from './types.js';

--- a/packages/agents/booking/src/gds-ndc-router/router-engine.ts
+++ b/packages/agents/booking/src/gds-ndc-router/router-engine.ts
@@ -2,6 +2,18 @@
  * GDS/NDC Router Engine
  *
  * Routes booking requests to the correct distribution channel.
+ *
+ * Routing is PER-TRANSACTION, not per-airline. The same carrier can route
+ * differently for shopping vs booking vs ticketing vs servicing vs group
+ * vs corporate transactions. The built-in carrier capability map covers
+ * the common shopping/booking flows; for any other transaction type the
+ * caller must supply `capability_overrides` or the engine returns
+ * `domain_input_required` for that segment.
+ *
+ * // DOMAIN_QUESTION: per-carrier capability matrix per transaction type.
+ * // The previous implementation treated `carrier → channel_priority` as
+ * // unconditional, which was a CLAUDE.md violation: NDC carriers still
+ * // require GDS for groups, corporate fares, and post-booking servicing.
  */
 
 import { createRequire } from 'node:module';
@@ -16,6 +28,7 @@ import type {
   GdsPnrFormat,
   NdcOrderFormat,
   RoutingSegment,
+  TransactionType,
 } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -30,18 +43,41 @@ interface CarrierData {
 const require = createRequire(import.meta.url);
 const carrierData = require('./data/carrier-channels.json') as CarrierData;
 
+/** Transaction types whose channel capability is covered by the built-in carrier map. */
+const BUILTIN_TRANSACTION_TYPES: ReadonlySet<TransactionType> = new Set<TransactionType>([
+  'shopping',
+  'booking',
+]);
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getCarrierConfig(iata: string): CarrierChannelConfig | undefined {
-  return carrierData.carriers[iata];
+function getCarrierConfig(
+  iata: string,
+  transactionType: TransactionType,
+  overrides: GdsNdcRouterInput['capability_overrides'],
+): CarrierChannelConfig | undefined {
+  // Caller-supplied per-transaction override wins.
+  const carrierOverrides = overrides?.[iata];
+  if (carrierOverrides && carrierOverrides[transactionType]) {
+    return carrierOverrides[transactionType];
+  }
+  // Built-in carrier defaults apply ONLY to shopping/booking transactions.
+  if (BUILTIN_TRANSACTION_TYPES.has(transactionType)) {
+    return carrierData.carriers[iata];
+  }
+  return undefined;
 }
 
-function resolveRoutingCarrier(segment: RoutingSegment): { carrier: string; codeshare: boolean } {
+function resolveRoutingCarrier(
+  segment: RoutingSegment,
+  transactionType: TransactionType,
+  overrides: GdsNdcRouterInput['capability_overrides'],
+): { carrier: string; codeshare: boolean } {
   // Default strategy: use operating carrier if available
   if (segment.operating_carrier && segment.operating_carrier !== segment.marketing_carrier) {
-    const opConfig = getCarrierConfig(segment.operating_carrier);
+    const opConfig = getCarrierConfig(segment.operating_carrier, transactionType, overrides);
     if (opConfig) {
       return { carrier: segment.operating_carrier, codeshare: true };
     }
@@ -69,20 +105,31 @@ export function routeSegments(input: GdsNdcRouterInput): GdsNdcRouterOutput {
   const routings: ChannelRouting[] = [];
 
   for (const segment of input.segments) {
-    const { carrier, codeshare } = resolveRoutingCarrier(segment);
-    const config = getCarrierConfig(carrier);
+    const { carrier, codeshare } = resolveRoutingCarrier(
+      segment,
+      input.transaction_type,
+      input.capability_overrides,
+    );
+    const config = getCarrierConfig(carrier, input.transaction_type, input.capability_overrides);
 
     if (!config) {
-      // Unknown carrier — default to GDS via AMADEUS
+      // Two cases:
+      //  1. Transaction type beyond the built-in defaults and no override
+      //     supplied → we cannot decide a channel. Return DOMAIN_INPUT_REQUIRED.
+      //  2. Carrier truly unknown for shopping/booking → also DOMAIN_INPUT_REQUIRED.
       routings.push({
-        primary_channel: 'GDS',
-        gds_system: 'AMADEUS',
+        primary_channel: 'GDS', // placeholder; ignore when domain_input_required=true
+        gds_system: null,
         ndc_version: null,
         ndc_provider_id: null,
         fallbacks: [],
         routed_carrier: carrier,
         codeshare_applied: codeshare,
         booking_format: 'GDS_PNR',
+        domain_input_required: true,
+        missing_inputs: [
+          `capability_overrides[${carrier}].${input.transaction_type}`,
+        ],
       });
       continue;
     }
@@ -131,10 +178,14 @@ export function routeSegments(input: GdsNdcRouterInput): GdsNdcRouterOutput {
     });
   }
 
-  // Determine unified channel
-  const primaryChannels = new Set(routings.map((r) => r.primary_channel));
-  const unifiedChannel = primaryChannels.size === 1;
-  const recommendedChannel = unifiedChannel ? (routings[0]?.primary_channel ?? null) : null;
+  // Determine unified channel — only over resolvable segments.
+  const resolvedRoutings = routings.filter((r) => !r.domain_input_required);
+  const primaryChannels = new Set(resolvedRoutings.map((r) => r.primary_channel));
+  const unifiedChannel =
+    resolvedRoutings.length === routings.length && primaryChannels.size === 1;
+  const recommendedChannel = unifiedChannel
+    ? (resolvedRoutings[0]?.primary_channel ?? null)
+    : null;
 
   // Build format stubs
   const gdsFormat = buildGdsFormatStub(input.segments, routings);
@@ -157,7 +208,9 @@ function buildGdsFormatStub(
   segments: RoutingSegment[],
   routings: ChannelRouting[],
 ): GdsPnrFormat | null {
-  const gdsRoutings = routings.filter((r) => r.primary_channel === 'GDS');
+  const gdsRoutings = routings.filter(
+    (r) => r.primary_channel === 'GDS' && !r.domain_input_required,
+  );
   if (gdsRoutings.length === 0) return null;
 
   const gds = gdsRoutings[0]!.gds_system ?? 'AMADEUS';
@@ -167,7 +220,7 @@ function buildGdsFormatStub(
     gds,
     record_locator: null,
     segments: segments
-      .filter((_, i) => routings[i]?.primary_channel === 'GDS')
+      .filter((_, i) => routings[i]?.primary_channel === 'GDS' && !routings[i]?.domain_input_required)
       .map((seg) => ({
         carrier: seg.marketing_carrier,
         flight_number: seg.flight_number ?? '',
@@ -184,7 +237,9 @@ function buildNdcFormatStub(
   segments: RoutingSegment[],
   routings: ChannelRouting[],
 ): NdcOrderFormat | null {
-  const ndcRoutings = routings.filter((r) => r.primary_channel === 'NDC');
+  const ndcRoutings = routings.filter(
+    (r) => r.primary_channel === 'NDC' && !r.domain_input_required,
+  );
   if (ndcRoutings.length === 0) return null;
 
   const version = ndcRoutings[0]!.ndc_version ?? '21.3';
@@ -194,7 +249,7 @@ function buildNdcFormatStub(
     ndc_version: version,
     order_id: null,
     offer_items: segments
-      .filter((_, i) => routings[i]?.primary_channel === 'NDC')
+      .filter((_, i) => routings[i]?.primary_channel === 'NDC' && !routings[i]?.domain_input_required)
       .map((seg) => ({
         carrier: seg.marketing_carrier,
         origin: seg.origin,

--- a/packages/agents/booking/src/gds-ndc-router/types.ts
+++ b/packages/agents/booking/src/gds-ndc-router/types.ts
@@ -10,6 +10,26 @@ export type NdcVersion = '17.2' | '18.1' | '21.3';
 
 export type GdsSystem = 'AMADEUS' | 'SABRE' | 'TRAVELPORT';
 
+/**
+ * Transaction-level routing dimension. Channel choice depends on the
+ * type of operation, not just the carrier — most NDC carriers still
+ * require GDS for groups, corporate fares, and post-booking servicing
+ * even when their default shopping/booking flow is NDC.
+ *
+ * // DOMAIN_QUESTION: per-carrier capability matrix per transaction type
+ * // (groups, corporate, post-booking servicing). The built-in carrier
+ * // map covers 'shopping' and 'booking' only — every other transaction
+ * // type requires the caller to supply `transaction_capability_overrides`,
+ * // otherwise the engine returns DOMAIN_INPUT_REQUIRED.
+ */
+export type TransactionType =
+  | 'shopping'
+  | 'booking'
+  | 'ticketing'
+  | 'servicing'
+  | 'group'
+  | 'corporate';
+
 export interface CarrierChannelConfig {
   name: string;
   channels: DistributionChannel[];
@@ -33,9 +53,31 @@ export interface RoutingSegment {
   flight_number?: string;
 }
 
+/**
+ * Per-transaction-type capability override map. Caller supplies this when
+ * routing transaction types that the built-in carrier defaults don't cover
+ * ('ticketing', 'servicing', 'group', 'corporate'). Entries take the same
+ * shape as the built-in carrier defaults.
+ */
+export type TransactionCapabilityOverrides = Partial<
+  Record<TransactionType, CarrierChannelConfig>
+>;
+
 export interface GdsNdcRouterInput {
   /** Segments to route */
   segments: RoutingSegment[];
+  /**
+   * Transaction type being routed. The decision is per-transaction, not
+   * per-airline: a carrier may use NDC for shopping but require GDS for
+   * groups or post-booking servicing.
+   */
+  transaction_type: TransactionType;
+  /**
+   * Caller-supplied capability overrides keyed by carrier IATA, then by
+   * transaction type. Required for transaction types beyond
+   * 'shopping'/'booking' — the engine has no built-in defaults for them.
+   */
+  capability_overrides?: Record<string, TransactionCapabilityOverrides>;
   /** Preferred channel (optional override) */
   preferred_channel?: DistributionChannel;
   /** Preferred GDS (optional override) */
@@ -102,6 +144,14 @@ export interface ChannelRouting {
   codeshare_applied: boolean;
   /** Expected booking format */
   booking_format: 'GDS_PNR' | 'NDC_ORDER' | 'DIRECT_API';
+  /**
+   * Set when the engine could not resolve a channel for this segment
+   * (transaction type lacks a capability entry). `primary_channel` is
+   * meaningless in that case; callers must consult `missing_inputs`.
+   */
+  domain_input_required?: boolean;
+  /** Names of missing inputs when `domain_input_required` is true. */
+  missing_inputs?: string[];
 }
 
 export interface GdsNdcRouterOutput {


### PR DESCRIPTION
## Summary
Codex review MEDIUM #5 — CLAUDE.md violation in agents/booking.

The router previously treated \`carrier → channel_priority\` as unconditional. CLAUDE.md flags this rationalization explicitly: *"Most NDC airlines still require GDS for specific scenarios (groups, tours, corporate fares, post-booking servicing). The routing decision must be PER-TRANSACTION, not per-airline."*

### Changes
- New \`TransactionType\` enum: \`shopping | booking | ticketing | servicing | group | corporate\`.
- New required input field \`transaction_type\`. The agent's input validator rejects missing/invalid values.
- New optional \`capability_overrides\` map keyed by carrier → transaction type → \`CarrierChannelConfig\`.
- Engine resolution order:
  1. Caller override for \`{carrier, transaction_type}\` → use it
  2. Built-in carrier default (only for \`shopping\` / \`booking\`) → use it
  3. Anything else → \`domain_input_required: true\` with \`missing_inputs\` listing what's needed
- \`ChannelRouting\` carries new \`domain_input_required\` and \`missing_inputs\` fields. Agent emits \`DOMAIN_INPUT_REQUIRED\` warnings naming the carrier and transaction type that need overrides.
- Unknown-carrier path no longer defaults silently to GDS/AMADEUS — that was an invented default. Now returns \`domain_input_required: true\`.

### Tests
- Existing 32 test sites updated to pass \`transaction_type: 'shopping'\`.
- 5 new per-transaction tests covering \`group\`, \`servicing\`, \`corporate\` returning DOMAIN_INPUT_REQUIRED without override, and caller-override-beats-default.
- 2 new validator tests (missing/invalid \`transaction_type\`).
- 1 new override-for-unknown-carrier test.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` — succeeds
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm test\` — 3,083 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)