### PR TITLE
fix: rate limiter retry counting + stub agents use AgentError

### DIFF
--- a/packages/agents/booking/src/api-abstraction/__tests__/api-abstraction.test.ts
+++ b/packages/agents/booking/src/api-abstraction/__tests__/api-abstraction.test.ts
@@ -380,6 +380,27 @@ describe('API Abstraction', () => {
       expect(client.getRateLimitStatus(amadeus).request_count).toBe(1);
       expect(client.getRateLimitStatus(sabre).request_count).toBe(0);
     });
+
+    it('counts each retry against the rate limit (not just the first attempt)', async () => {
+      // Previously the counter incremented once per execute() call, so
+      // retries to the upstream provider went uncounted and we under-
+      // reported traffic against provider quotas.
+      let calls = 0;
+      const flakyHandler: RequestHandler = (): Promise<ApiResponse> => {
+        calls++;
+        return Promise.reject(new Error('ECONNRESET — upstream socket reset'));
+      };
+      const client = new ApiClient(flakyHandler);
+      const provider = client.getProvider('NDC_BA')!;
+
+      await client.execute({
+        request: { provider_id: 'NDC_BA', method: 'GET', path: '/test' },
+        max_retries: 2,
+      });
+
+      expect(calls).toBe(3); // 1 initial + 2 retries
+      expect(client.getRateLimitStatus(provider).request_count).toBe(3);
+    });
   });
 
   describe('Error normalization', () => {

--- a/packages/agents/booking/src/api-abstraction/api-client.ts
+++ b/packages/agents/booking/src/api-abstraction/api-client.ts
@@ -108,19 +108,7 @@ export class ApiClient {
       );
     }
 
-    // Check rate limit
-    const rlStatus = this.checkRateLimit(provider);
-    if (rlStatus.exceeded) {
-      return this.buildErrorOutput(
-        provider.id,
-        'RATE_LIMITED',
-        `Rate limit exceeded for ${provider.id}: ${rlStatus.request_count}/${rlStatus.max_requests}`,
-        'RATE_LIMIT_EXCEEDED',
-        true,
-      );
-    }
-
-    // Check circuit breaker
+    // Check circuit breaker (no per-attempt outbound traffic if open).
     if (!input.force) {
       const cbState = this.getCircuitState(provider);
       if (cbState.state === 'open') {
@@ -134,10 +122,10 @@ export class ApiClient {
       }
     }
 
-    // Increment rate limit counter
-    this.incrementRateLimit(provider);
-
-    // Execute with retry
+    // Execute with retry — rate-limit check + counter increment happen
+    // PER ATTEMPT. The previous implementation incremented once before
+    // the loop, so retries to the upstream provider went uncounted and
+    // we under-reported traffic against provider quotas.
     const maxRetries = input.max_retries ?? provider.max_retries;
     const timeoutMs = input.timeout_ms ?? provider.timeout_ms;
 
@@ -145,6 +133,24 @@ export class ApiClient {
     let retries = 0;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      // Per-attempt rate-limit guard.
+      const rlStatus = this.checkRateLimit(provider);
+      if (rlStatus.exceeded) {
+        // If we've already issued at least one outbound attempt, surface
+        // the prior failure (if any). Otherwise return the rate-limit
+        // error directly.
+        if (lastError) {
+          break;
+        }
+        return this.buildErrorOutput(
+          provider.id,
+          'RATE_LIMITED',
+          `Rate limit exceeded for ${provider.id}: ${rlStatus.request_count}/${rlStatus.max_requests}`,
+          'RATE_LIMIT_EXCEEDED',
+          true,
+        );
+      }
+
       try {
         // Exponential backoff (skip for first attempt)
         if (attempt > 0) {
@@ -152,6 +158,11 @@ export class ApiClient {
           await this.sleep(backoffMs);
           retries = attempt;
         }
+
+        // Count this outbound attempt against the provider's quota
+        // BEFORE the call so concurrent attempts cannot race past the
+        // limit, and so retries are correctly accounted for.
+        this.incrementRateLimit(provider);
 
         const response = await this.requestHandler(provider, input.request, timeoutMs);
 

--- a/packages/agents/exchange/src/disruption-response/__tests__/disruption-response.test.ts
+++ b/packages/agents/exchange/src/disruption-response/__tests__/disruption-response.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { UnimplementedDomainInputError } from '@otaip/core';
 import { DisruptionResponseAgent } from '../index.js';
 
 describe('DisruptionResponseAgent (5.4)', () => {
@@ -17,8 +18,23 @@ describe('DisruptionResponseAgent (5.4)', () => {
     expect(h.status).toBe('degraded');
   });
 
-  it('throws not-implemented after initialization', async () => {
+  it('throws UnimplementedDomainInputError after initialization', async () => {
     await agent.initialize();
-    await expect(agent.execute({ data: {} })).rejects.toThrow('not yet implemented');
+    await expect(agent.execute({ data: {} })).rejects.toBeInstanceOf(
+      UnimplementedDomainInputError,
+    );
+  });
+
+  it('error carries agent id and code', async () => {
+    await agent.initialize();
+    try {
+      await agent.execute({ data: {} });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnimplementedDomainInputError);
+      const e = err as UnimplementedDomainInputError;
+      expect(e.agentId).toBe('5.4');
+      expect(e.code).toBe('UNIMPLEMENTED_DOMAIN_INPUT');
+    }
   });
 });

--- a/packages/agents/exchange/src/disruption-response/index.ts
+++ b/packages/agents/exchange/src/disruption-response/index.ts
@@ -1,6 +1,6 @@
 // Coming soon — pending domain input
 import type { Agent, AgentInput, AgentOutput, AgentHealthStatus } from '@otaip/core';
-import { AgentNotInitializedError } from '@otaip/core';
+import { AgentNotInitializedError, UnimplementedDomainInputError } from '@otaip/core';
 
 export class DisruptionResponseAgent implements Agent<
   Record<string, unknown>,
@@ -19,8 +19,9 @@ export class DisruptionResponseAgent implements Agent<
     _input: AgentInput<Record<string, unknown>>,
   ): Promise<AgentOutput<Record<string, unknown>>> {
     if (!this.initialized) throw new AgentNotInitializedError(this.id);
-    throw new Error(
-      'DisruptionResponseAgent not yet implemented. Requires domain input on disruption priority rules and carrier-specific response procedures.',
+    throw new UnimplementedDomainInputError(
+      this.id,
+      'disruption priority rules and carrier-specific response procedures',
     );
   }
 

--- a/packages/agents/pricing/src/dynamic-pricing/__tests__/dynamic-pricing.test.ts
+++ b/packages/agents/pricing/src/dynamic-pricing/__tests__/dynamic-pricing.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
+import { UnimplementedDomainInputError } from '@otaip/core';
 import { DynamicPricingAgent } from '../index.js';
 
 describe('DynamicPricingAgent (coming soon)', () => {
-  it('throws not implemented', async () => {
+  it('throws UnimplementedDomainInputError', async () => {
     const a = new DynamicPricingAgent();
     await a.initialize();
-    await expect(a.execute({ data: {} })).rejects.toThrow('not yet implemented');
+    await expect(a.execute({ data: {} })).rejects.toBeInstanceOf(
+      UnimplementedDomainInputError,
+    );
   });
 });

--- a/packages/agents/pricing/src/dynamic-pricing/index.ts
+++ b/packages/agents/pricing/src/dynamic-pricing/index.ts
@@ -1,6 +1,6 @@
 // Coming soon — Tier 4
 import type { Agent, AgentInput, AgentOutput, AgentHealthStatus } from '@otaip/core';
-import { AgentNotInitializedError } from '@otaip/core';
+import { AgentNotInitializedError, UnimplementedDomainInputError } from '@otaip/core';
 
 export class DynamicPricingAgent implements Agent<
   Record<string, unknown>,
@@ -17,8 +17,9 @@ export class DynamicPricingAgent implements Agent<
     _input: AgentInput<Record<string, unknown>>,
   ): Promise<AgentOutput<Record<string, unknown>>> {
     if (!this.initialized) throw new AgentNotInitializedError(this.id);
-    throw new Error(
-      'DynamicPricingAgent not yet implemented. Requires revenue management integration.',
+    throw new UnimplementedDomainInputError(
+      this.id,
+      'revenue management integration (per-carrier RBD inventory + bid-price feed)',
     );
   }
   async health(): Promise<AgentHealthStatus> {

--- a/packages/agents/pricing/src/revenue-management/__tests__/revenue-management.test.ts
+++ b/packages/agents/pricing/src/revenue-management/__tests__/revenue-management.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
+import { UnimplementedDomainInputError } from '@otaip/core';
 import { RevenueManagementAgent } from '../index.js';
 
 describe('RevenueManagementAgent (coming soon)', () => {
-  it('throws not implemented', async () => {
+  it('throws UnimplementedDomainInputError', async () => {
     const a = new RevenueManagementAgent();
     await a.initialize();
-    await expect(a.execute({ data: {} })).rejects.toThrow('not yet implemented');
+    await expect(a.execute({ data: {} })).rejects.toBeInstanceOf(
+      UnimplementedDomainInputError,
+    );
   });
 });

--- a/packages/agents/pricing/src/revenue-management/index.ts
+++ b/packages/agents/pricing/src/revenue-management/index.ts
@@ -1,6 +1,6 @@
 // Coming soon — Tier 4
 import type { Agent, AgentInput, AgentOutput, AgentHealthStatus } from '@otaip/core';
-import { AgentNotInitializedError } from '@otaip/core';
+import { AgentNotInitializedError, UnimplementedDomainInputError } from '@otaip/core';
 
 export class RevenueManagementAgent implements Agent<
   Record<string, unknown>,
@@ -17,8 +17,9 @@ export class RevenueManagementAgent implements Agent<
     _input: AgentInput<Record<string, unknown>>,
   ): Promise<AgentOutput<Record<string, unknown>>> {
     if (!this.initialized) throw new AgentNotInitializedError(this.id);
-    throw new Error(
-      'RevenueManagementAgent not yet implemented. Requires revenue management integration.',
+    throw new UnimplementedDomainInputError(
+      this.id,
+      'revenue management integration (per-carrier RBD inventory + bid-price feed)',
     );
   }
   async health(): Promise<AgentHealthStatus> {

--- a/packages/agents/reconciliation/src/interline-settlement/__tests__/interline-settlement.test.ts
+++ b/packages/agents/reconciliation/src/interline-settlement/__tests__/interline-settlement.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
+import { UnimplementedDomainInputError } from '@otaip/core';
 import { InterlineSettlementAgent } from '../index.js';
 
 describe('InterlineSettlementAgent (coming soon)', () => {
-  it('throws not implemented', async () => {
+  it('throws UnimplementedDomainInputError', async () => {
     const a = new InterlineSettlementAgent();
     await a.initialize();
-    await expect(a.execute({ data: {} })).rejects.toThrow('not yet implemented');
+    await expect(a.execute({ data: {} })).rejects.toBeInstanceOf(
+      UnimplementedDomainInputError,
+    );
   });
   it('health returns degraded', async () => {
     const a = new InterlineSettlementAgent();

--- a/packages/agents/reconciliation/src/interline-settlement/index.ts
+++ b/packages/agents/reconciliation/src/interline-settlement/index.ts
@@ -1,6 +1,6 @@
 // Coming soon — pending domain input (prorate/SIS)
 import type { Agent, AgentInput, AgentOutput, AgentHealthStatus } from '@otaip/core';
-import { AgentNotInitializedError } from '@otaip/core';
+import { AgentNotInitializedError, UnimplementedDomainInputError } from '@otaip/core';
 
 export class InterlineSettlementAgent implements Agent<
   Record<string, unknown>,
@@ -22,8 +22,9 @@ export class InterlineSettlementAgent implements Agent<
     _input: AgentInput<Record<string, unknown>>,
   ): Promise<AgentOutput<Record<string, unknown>>> {
     if (!this.initialized) throw new AgentNotInitializedError(this.id);
-    throw new Error(
-      'InterlineSettlementAgent is not yet implemented. Requires domain input on interline prorate methodology before build can proceed.',
+    throw new UnimplementedDomainInputError(
+      this.id,
+      'interline prorate methodology and IATA SIS billing rules',
     );
   }
   async health(): Promise<AgentHealthStatus> {

--- a/packages/core/src/errors/agent-errors.ts
+++ b/packages/core/src/errors/agent-errors.ts
@@ -41,3 +41,19 @@ export class AgentDataUnavailableError extends AgentError {
     this.name = 'AgentDataUnavailableError';
   }
 }
+
+/**
+ * Thrown by stub agents whose implementation is gated on travel-domain
+ * input that the platform does not yet have. The message must describe
+ * the specific input still needed.
+ */
+export class UnimplementedDomainInputError extends AgentError {
+  constructor(agentId: string, detail: string) {
+    super(
+      `Agent ${agentId} requires domain input before it can be implemented: ${detail}`,
+      agentId,
+      'UNIMPLEMENTED_DOMAIN_INPUT',
+    );
+    this.name = 'UnimplementedDomainInputError';
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export {
   AgentNotInitializedError,
   AgentInputValidationError,
   AgentDataUnavailableError,
+  UnimplementedDomainInputError,
 } from './errors/agent-errors.js';
 
 export { OfferEvaluatorAgent, evaluateOffers } from './agents/shopping/index.js';


### PR DESCRIPTION
## Summary
Codex review MEDIUM #1 + MEDIUM #4.

### MEDIUM #1 — booking/api-abstraction rate limiter undercounted retries
The rate-limit counter incremented once per \`execute()\` call, *before* the retry loop. Each retry fired \`requestHandler\` again without incrementing the counter, under-reporting upstream traffic against provider quotas.

Fix: move the increment **inside** the retry loop, before each \`requestHandler\` call. The rate-limit guard also moves inside the loop so an attempt that would exceed the quota short-circuits cleanly without burning another outbound request.

New test verifies: 1 initial attempt + 2 retries on a retryable failure → \`request_count\` ends at 3 (not 1).

### MEDIUM #4 — stub agents threw raw \`Error\`
- New \`@otaip/core\` class \`UnimplementedDomainInputError(agentId, detail)\` with code \`UNIMPLEMENTED_DOMAIN_INPUT\`.
- 4 stub agents now throw it instead of raw \`Error\`:
  - \`DisruptionResponseAgent\` (5.4)
  - \`DynamicPricingAgent\` (2.6)
  - \`RevenueManagementAgent\` (2.7)
  - \`InterlineSettlementAgent\` (7.4)
- The other \"placeholder\" agents called out in the original Codex finding (\`self-service-rebooking\`, \`waitlist-management\`) were since fully built out and no longer throw raw Errors.
- Tests updated to assert \`toBeInstanceOf(UnimplementedDomainInputError)\` plus \`agentId\` + \`code\`.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` — succeeds
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm test\` — 3,085 passed (3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)