### PR TITLE
fix(cli): auto-discover agents from source; lint + test the CLI

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ export default defineConfig([
                 "./packages/agents-platform/tsconfig.json",
                 "./packages/adapters/duffel/tsconfig.json",
                 "./packages/connect/tsconfig.json",
+                "./packages/cli/tsconfig.json",
             ],
         },
     },
@@ -63,5 +64,11 @@ export default defineConfig([
         "no-console": ["warn", {
             allow: ["warn", "error"],
         }],
+    },
+}, {
+    // CLI is the one place where stdout output IS the contract.
+    files: ["packages/cli/**/*.ts"],
+    rules: {
+        "no-console": "off",
     },
 }]);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "pnpm -r run build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint 'packages/*/src/**/*.ts' 'packages/agents/*/src/**/*.ts' 'packages/adapters/*/src/**/*.ts' --ignore-pattern 'packages/cli/**'",
+    "lint": "eslint 'packages/*/src/**/*.ts' 'packages/agents/*/src/**/*.ts' 'packages/adapters/*/src/**/*.ts'",
     "lint:fix": "eslint 'packages/*/src/**/*.ts' 'packages/agents/*/src/**/*.ts' 'packages/adapters/*/src/**/*.ts' --fix",
     "format": "prettier --write 'packages/*/src/**/*.ts' 'packages/agents/*/src/**/*.ts' 'packages/adapters/*/src/**/*.ts'",
     "format:check": "prettier --check 'packages/*/src/**/*.ts' 'packages/agents/*/src/**/*.ts' 'packages/adapters/*/src/**/*.ts'",

--- a/packages/cli/src/__tests__/agent-discovery.test.ts
+++ b/packages/cli/src/__tests__/agent-discovery.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { discoverAgents } from '../agent-discovery.js';
+
+describe('discoverAgents', () => {
+  const agents = discoverAgents();
+
+  it('finds at least 60 agents across the workspace', () => {
+    // Hard floor: anything substantially below this means the discovery
+    // walk is broken (paths moved, regex stopped matching, etc.).
+    expect(agents.length).toBeGreaterThanOrEqual(60);
+  });
+
+  it('every entry has id, name, stage, version', () => {
+    for (const a of agents) {
+      expect(a.id).toMatch(/^\d+(\.\d+)+$/);
+      expect(a.name.length).toBeGreaterThan(0);
+      expect(a.stage.length).toBeGreaterThan(0);
+      expect(a.version).toMatch(/^\d+\.\d+\.\d+$/);
+    }
+  });
+
+  it('agent IDs are unique', () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    for (const a of agents) {
+      if (seen.has(a.id)) dupes.push(a.id);
+      seen.add(a.id);
+    }
+    expect(dupes).toEqual([]);
+  });
+
+  it('source_path resolves to a real file under the repo', () => {
+    expect(agents[0]!.source_path).toMatch(/^packages\//);
+    expect(agents[0]!.source_path).toMatch(/\/index\.ts$/);
+  });
+
+  it('stage matches the agent ID prefix where applicable', () => {
+    // Stage 0 = reference, 1 = search, 2 = pricing, 3 = booking,
+    // 4 = ticketing, 5 = exchange, 6 = settlement, 7 = reconciliation,
+    // 20 = lodging. Platform (9.x) and TMC (8.x) are flat layouts so
+    // the stage name does not match the numeric prefix.
+    const expectedStage: Record<string, string> = {
+      '0': 'reference',
+      '1': 'search',
+      '2': 'pricing',
+      '3': 'booking',
+      '4': 'ticketing',
+      '5': 'exchange',
+      '6': 'settlement',
+      '7': 'reconciliation',
+      '20': 'lodging',
+    };
+    for (const a of agents) {
+      const prefix = a.id.split('.')[0]!;
+      const expected = expectedStage[prefix];
+      if (!expected) continue; // 8.x → tmc, 9.x → platform handled separately
+      expect(a.stage, `agent ${a.id} ${a.name}`).toBe(expected);
+    }
+  });
+
+  it('contract_status is "stub" exactly when version is 0.0.0', () => {
+    for (const a of agents) {
+      if (a.version === '0.0.0') {
+        expect(a.contract_status).toBe('stub');
+      } else {
+        expect(a.contract_status).toBe('active');
+      }
+    }
+  });
+
+  it('agents are sorted by numeric ID components (2.10 after 2.2)', () => {
+    for (let i = 1; i < agents.length; i++) {
+      const prev = agents[i - 1]!.id.split('.').map(Number);
+      const curr = agents[i]!.id.split('.').map(Number);
+      const len = Math.max(prev.length, curr.length);
+      for (let j = 0; j < len; j++) {
+        const a = prev[j] ?? 0;
+        const b = curr[j] ?? 0;
+        if (a < b) break;
+        if (a === b) continue;
+        throw new Error(
+          `Out of order: ${agents[i - 1]!.id} should not come before ${agents[i]!.id}`,
+        );
+      }
+    }
+  });
+});

--- a/packages/cli/src/agent-discovery.ts
+++ b/packages/cli/src/agent-discovery.ts
@@ -1,0 +1,147 @@
+/**
+ * Discover OTAIP agents by walking the workspace source tree.
+ *
+ * Replaces the previous hand-maintained registry that drifted from the
+ * actual codebase (claimed 71, listed 69, several names didn't match
+ * the exported agent classes). Now there is one source of truth: the
+ * agent's own exported `id`, `name`, and `version` constants.
+ *
+ * The walk is filesystem-only and synchronous — no agent code is
+ * executed and no transitive dependencies are loaded. We grep for the
+ * `readonly id = '…';` / `readonly name = '…';` / `readonly version = '…';`
+ * lines in each candidate `index.ts`. Any file missing all three is
+ * skipped (it is not an agent).
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface DiscoveredAgent {
+  id: string;
+  name: string;
+  stage: string;
+  version: string;
+  /** Path relative to the repo root for traceability. */
+  source_path: string;
+  /** Derived from version: '0.0.0' → 'stub', anything else → 'active'. */
+  contract_status: 'active' | 'stub';
+}
+
+interface AgentRoot {
+  /** Path under the repo root that contains agent subdirectories. */
+  path: string;
+  /** Stage name for everything under this root. */
+  stage: string;
+}
+
+function repoRoot(): string {
+  // packages/cli/src/agent-discovery.ts → repo root is 3 dirs up
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..');
+}
+
+/**
+ * Roots to walk. Each entry maps either:
+ *   - a single stage path: `packages/agents-platform/src` (stage 'platform')
+ *   - or a parent path holding stage subdirs: `packages/agents`
+ *
+ * For the parent-form, every immediate subdir under it becomes its own
+ * stage and is scanned at `<stage>/src/<agent>/index.ts`.
+ */
+const STAGE_ROOTS: ReadonlyArray<AgentRoot> = [
+  { path: 'packages/agents-platform/src', stage: 'platform' },
+  { path: 'packages/agents-tmc/src', stage: 'tmc' },
+];
+
+const NESTED_STAGE_ROOT = 'packages/agents';
+
+const ID_RE = /readonly\s+id\s*=\s*['"]([^'"]+)['"]/;
+const NAME_RE = /readonly\s+name\s*=\s*['"]([^'"]+)['"]/;
+const VERSION_RE = /readonly\s+version\s*=\s*['"]([^'"]+)['"]/;
+
+function safeListDirs(p: string): string[] {
+  try {
+    return readdirSync(p)
+      .filter((entry) => {
+        try {
+          return statSync(join(p, entry)).isDirectory();
+        } catch {
+          return false;
+        }
+      })
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function readAgentMetadata(indexPath: string): { id: string; name: string; version: string } | null {
+  let src: string;
+  try {
+    src = readFileSync(indexPath, 'utf8');
+  } catch {
+    return null;
+  }
+  const idMatch = ID_RE.exec(src);
+  const nameMatch = NAME_RE.exec(src);
+  const versionMatch = VERSION_RE.exec(src);
+  if (!idMatch || !nameMatch || !versionMatch) return null;
+  return { id: idMatch[1]!, name: nameMatch[1]!, version: versionMatch[1]! };
+}
+
+function scanStageRoot(root: AgentRoot, repo: string): DiscoveredAgent[] {
+  const stageDir = join(repo, root.path);
+  const out: DiscoveredAgent[] = [];
+  for (const agentDir of safeListDirs(stageDir)) {
+    if (agentDir.startsWith('__')) continue; // skip __tests__ etc.
+    const indexPath = join(stageDir, agentDir, 'index.ts');
+    const meta = readAgentMetadata(indexPath);
+    if (!meta) continue;
+    out.push({
+      id: meta.id,
+      name: meta.name,
+      stage: root.stage,
+      version: meta.version,
+      source_path: `${root.path}/${agentDir}/index.ts`,
+      contract_status: meta.version === '0.0.0' ? 'stub' : 'active',
+    });
+  }
+  return out;
+}
+
+function scanNestedRoots(repo: string): DiscoveredAgent[] {
+  const parent = join(repo, NESTED_STAGE_ROOT);
+  const out: DiscoveredAgent[] = [];
+  for (const stageName of safeListDirs(parent)) {
+    out.push(
+      ...scanStageRoot(
+        { path: `${NESTED_STAGE_ROOT}/${stageName}/src`, stage: stageName },
+        repo,
+      ),
+    );
+  }
+  return out;
+}
+
+/**
+ * Compare agent IDs as dotted-version sequences (so '2.10' sorts after
+ * '2.2'). Falls back to lexical comparison when components are equal.
+ */
+function compareAgentIds(a: string, b: string): number {
+  const partsA = a.split('.').map((n) => Number(n));
+  const partsB = b.split('.').map((n) => Number(n));
+  const len = Math.max(partsA.length, partsB.length);
+  for (let i = 0; i < len; i++) {
+    const x = partsA[i] ?? 0;
+    const y = partsB[i] ?? 0;
+    if (x !== y) return x - y;
+  }
+  return a.localeCompare(b);
+}
+
+export function discoverAgents(): DiscoveredAgent[] {
+  const repo = repoRoot();
+  const found = [...scanNestedRoots(repo), ...STAGE_ROOTS.flatMap((r) => scanStageRoot(r, repo))];
+  return found.sort((a, b) => compareAgentIds(a.id, b.id));
+}

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,118 +1,21 @@
 /**
  * CLI command: otaip agents
  *
- * List all OTAIP agents with their contract status.
+ * List all OTAIP agents with their contract status. The registry is
+ * AUTO-DISCOVERED from the workspace source tree at module load time —
+ * no hand-maintained array. See `../agent-discovery.ts`.
  */
 
 import { Command } from 'commander';
+import { discoverAgents } from '../agent-discovery.js';
 
-/** Agent registry — all 71 agents across all stages. */
-interface AgentEntry {
-  id: string;
-  name: string;
-  stage: string;
-  actionType: string;
-  contractStatus: 'active' | 'planned' | 'stub';
-}
-
-const AGENTS: AgentEntry[] = [
-  // Stage 0 — Reference
-  { id: '0.1', name: 'Airport Code Resolver', stage: 'reference', actionType: 'query', contractStatus: 'active' },
-  { id: '0.2', name: 'Airline Code Mapper', stage: 'reference', actionType: 'query', contractStatus: 'active' },
-  { id: '0.3', name: 'Fare Basis Decoder', stage: 'reference', actionType: 'query', contractStatus: 'active' },
-  { id: '0.4', name: 'Equipment Type Resolver', stage: 'reference', actionType: 'query', contractStatus: 'active' },
-  { id: '0.5', name: 'Currency Converter', stage: 'reference', actionType: 'query', contractStatus: 'active' },
-
-  // Stage 1 — Search
-  { id: '1.1', name: 'Availability Search', stage: 'search', actionType: 'query', contractStatus: 'active' },
-  { id: '1.2', name: 'Connection Builder', stage: 'search', actionType: 'query', contractStatus: 'active' },
-  { id: '1.3', name: 'Schedule Search', stage: 'search', actionType: 'query', contractStatus: 'active' },
-  { id: '1.4', name: 'Low Fare Search', stage: 'search', actionType: 'query', contractStatus: 'active' },
-  { id: '1.5', name: 'Seat Map', stage: 'search', actionType: 'query', contractStatus: 'active' },
-  { id: '1.6', name: 'Ancillary Catalog', stage: 'search', actionType: 'query', contractStatus: 'active' },
-
-  // Stage 2 — Pricing
-  { id: '2.1', name: 'Fare Rule', stage: 'pricing', actionType: 'query', contractStatus: 'active' },
-  { id: '2.2', name: 'Fare Construction', stage: 'pricing', actionType: 'query', contractStatus: 'active' },
-  { id: '2.3', name: 'Tax Calculation', stage: 'pricing', actionType: 'query', contractStatus: 'active' },
-  { id: '2.4', name: 'Offer Builder', stage: 'pricing', actionType: 'query', contractStatus: 'active' },
-  { id: '2.5', name: 'Offer Evaluator', stage: 'pricing', actionType: 'query', contractStatus: 'active' },
-  { id: '2.6', name: 'Commission Calculator', stage: 'pricing', actionType: 'query', contractStatus: 'active' },
-  { id: '2.7', name: 'Markup Engine', stage: 'pricing', actionType: 'query', contractStatus: 'active' },
-
-  // Stage 3 — Booking
-  { id: '3.1', name: 'GDS/NDC Router', stage: 'booking', actionType: 'query', contractStatus: 'active' },
-  { id: '3.2', name: 'PNR Creation', stage: 'booking', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '3.3', name: 'Payment Processing', stage: 'booking', actionType: 'mutation_irreversible', contractStatus: 'active' },
-  { id: '3.4', name: 'SSR Handler', stage: 'booking', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '3.5', name: 'Queue Manager', stage: 'booking', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '3.6', name: 'Order Manager', stage: 'booking', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '3.7', name: 'Booking Validator', stage: 'booking', actionType: 'query', contractStatus: 'active' },
-  { id: '3.8', name: 'PNR Retrieval', stage: 'booking', actionType: 'query', contractStatus: 'active' },
-  { id: '3.9', name: 'NDC Booking Fallback', stage: 'booking', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '3.10', name: 'Booking Fallback Chain', stage: 'booking', actionType: 'mutation_reversible', contractStatus: 'active' },
-
-  // Stage 4 — Ticketing
-  { id: '4.1', name: 'Ticket Issuance', stage: 'ticketing', actionType: 'mutation_irreversible', contractStatus: 'active' },
-  { id: '4.2', name: 'EMD Issuance', stage: 'ticketing', actionType: 'mutation_irreversible', contractStatus: 'active' },
-  { id: '4.3', name: 'Void Processing', stage: 'ticketing', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '4.4', name: 'Conjunction Ticketing', stage: 'ticketing', actionType: 'mutation_irreversible', contractStatus: 'active' },
-
-  // Stage 5 — Exchange
-  { id: '5.1', name: 'Change Management', stage: 'exchange', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '5.2', name: 'Exchange/Reissue', stage: 'exchange', actionType: 'mutation_irreversible', contractStatus: 'active' },
-  { id: '5.3', name: 'Involuntary Rebook', stage: 'exchange', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '5.4', name: 'Schedule Change Handler', stage: 'exchange', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '5.5', name: 'Same-Day Change', stage: 'exchange', actionType: 'mutation_reversible', contractStatus: 'active' },
-
-  // Stage 6 — Settlement
-  { id: '6.1', name: 'Refund Processing', stage: 'settlement', actionType: 'mutation_irreversible', contractStatus: 'active' },
-  { id: '6.2', name: 'ADM Prevention', stage: 'settlement', actionType: 'query', contractStatus: 'active' },
-  { id: '6.3', name: 'Loyalty Accrual', stage: 'settlement', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '6.4', name: 'Credit Shell Manager', stage: 'settlement', actionType: 'mutation_reversible', contractStatus: 'active' },
-
-  // Stage 7 — Reconciliation
-  { id: '7.1', name: 'BSP Reconciliation', stage: 'reconciliation', actionType: 'query', contractStatus: 'active' },
-  { id: '7.2', name: 'ARC Reconciliation', stage: 'reconciliation', actionType: 'query', contractStatus: 'active' },
-  { id: '7.3', name: 'Commission Reconciliation', stage: 'reconciliation', actionType: 'query', contractStatus: 'active' },
-  { id: '7.4', name: 'Revenue Reporting', stage: 'reconciliation', actionType: 'query', contractStatus: 'active' },
-
-  // Stage 8 — TMC
-  { id: '8.1', name: 'Travel Policy', stage: 'tmc', actionType: 'query', contractStatus: 'active' },
-  { id: '8.2', name: 'Approval Workflow', stage: 'tmc', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '8.3', name: 'Duty of Care', stage: 'tmc', actionType: 'query', contractStatus: 'active' },
-  { id: '8.4', name: 'Profile Manager', stage: 'tmc', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '8.5', name: 'Expense Reporting', stage: 'tmc', actionType: 'query', contractStatus: 'active' },
-
-  // Stage 9 — Platform
-  { id: '9.1', name: 'Orchestrator', stage: 'platform', actionType: 'query', contractStatus: 'active' },
-  { id: '9.2', name: 'Knowledge', stage: 'platform', actionType: 'query', contractStatus: 'active' },
-  { id: '9.3', name: 'Monitoring', stage: 'platform', actionType: 'query', contractStatus: 'active' },
-  { id: '9.4', name: 'Audit & Compliance', stage: 'platform', actionType: 'query', contractStatus: 'active' },
-  { id: '9.5', name: 'Performance Audit', stage: 'platform', actionType: 'query', contractStatus: 'active' },
-  { id: '9.6', name: 'Routing Audit', stage: 'platform', actionType: 'query', contractStatus: 'active' },
-  { id: '9.7', name: 'Recommendation', stage: 'platform', actionType: 'query', contractStatus: 'active' },
-  { id: '9.8', name: 'Alert', stage: 'platform', actionType: 'query', contractStatus: 'active' },
-  { id: '9.9', name: 'Plugin Manager', stage: 'platform', actionType: 'mutation_reversible', contractStatus: 'active' },
-
-  // Stage 20 — Lodging
-  { id: '20.1', name: 'Hotel Availability Search', stage: 'lodging', actionType: 'query', contractStatus: 'active' },
-  { id: '20.2', name: 'Hotel Rate Shopping', stage: 'lodging', actionType: 'query', contractStatus: 'active' },
-  { id: '20.3', name: 'Hotel Booking', stage: 'lodging', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '20.4', name: 'Hotel Confirmation', stage: 'lodging', actionType: 'query', contractStatus: 'active' },
-  { id: '20.5', name: 'Hotel Payment', stage: 'lodging', actionType: 'mutation_irreversible', contractStatus: 'active' },
-  { id: '20.6', name: 'Hotel Modification & Cancellation', stage: 'lodging', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '20.7', name: 'Hotel Loyalty', stage: 'lodging', actionType: 'mutation_reversible', contractStatus: 'active' },
-  { id: '20.8', name: 'Hotel Content', stage: 'lodging', actionType: 'query', contractStatus: 'active' },
-  { id: '20.9', name: 'Hotel Policy Engine', stage: 'lodging', actionType: 'query', contractStatus: 'active' },
-  { id: '20.10', name: 'Hotel Revenue Manager', stage: 'lodging', actionType: 'query', contractStatus: 'active' },
-];
+const AGENTS = discoverAgents();
 
 export const agentsCommand = new Command('agents')
   .description('List all OTAIP agents with contract status')
   .option('--json', 'Output as JSON')
   .option('--stage <stage>', 'Filter by stage name')
-  .option('--verbose', 'Show action type and additional details')
+  .option('--verbose', 'Show source path')
   .action(async (opts: { json?: boolean; stage?: string; verbose?: boolean }) => {
     let filtered = AGENTS;
     if (opts.stage) {
@@ -134,8 +37,8 @@ export const agentsCommand = new Command('agents')
           'ID'.padEnd(8) +
           'Name'.padEnd(30) +
           'Stage'.padEnd(16) +
-          'Action'.padEnd(14) +
-          'Contract',
+          'Contract'.padEnd(10) +
+          'Source',
       );
     } else {
       console.log(
@@ -155,8 +58,8 @@ export const agentsCommand = new Command('agents')
             a.id.padEnd(8) +
             a.name.padEnd(30) +
             a.stage.padEnd(16) +
-            a.actionType.padEnd(14) +
-            a.contractStatus,
+            a.contract_status.padEnd(10) +
+            a.source_path,
         );
       } else {
         console.log(
@@ -164,7 +67,7 @@ export const agentsCommand = new Command('agents')
             a.id.padEnd(8) +
             a.name.padEnd(32) +
             a.stage.padEnd(16) +
-            a.contractStatus,
+            a.contract_status,
         );
       }
     }


### PR DESCRIPTION
## Summary
Codex review MEDIUM #3.

The CLI's \`agents\` command shipped a 71-entry hardcoded array that drifted from the actual codebase (Codex flagged the count claim and several IDs/names didn't match the exported agent classes). The CLI was also excluded from lint and had no tests.

### Changes
- **New \`packages/cli/src/agent-discovery.ts\`** — synchronous filesystem walk of \`packages/agents/*/src/*/index.ts\`, \`packages/agents-platform/src/*/index.ts\`, \`packages/agents-tmc/src/*/index.ts\`. Each \`index.ts\` is grepped for \`readonly id\`, \`readonly name\`, \`readonly version\`. Stage is derived from path. \`contract_status\` derived from version (\`0.0.0\` → \`stub\`, else \`active\`). No agent code executed. Numeric ID-component sort (2.10 after 2.2).
- **Rewrite \`agents.ts\` command** to call \`discoverAgents()\`. Drops the \`action_type\` column (not derivable from source — was a hand-maintained drift source). \`--verbose\` now shows \`source_path\`.
- **7 new tests** in \`packages/cli/src/__tests__/agent-discovery.test.ts\` — count floor, required fields, ID uniqueness, file-resolves, stage-matches-prefix, status derivation, sort order.
- **Lint** — remove \`--ignore-pattern 'packages/cli/**'\` from root script. Add \`packages/cli/tsconfig.json\` to ESLint parser project list. CLI-scoped \`no-console: off\` (CLI stdout IS the contract).

Discovered count today: 74 agents across 11 stages.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` — succeeds
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — clean (CLI now linted, 0 errors)
- [x] \`pnpm test\` — 3,092 passed (was 3,085, +7 new CLI tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)