### PR TITLE
fix: bootstrap docs + agent counts derived from one source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,11 @@ jobs:
       - name: Count agents
         id: agents
         run: |
-          AGENT_COUNT=$(find packages/agents packages/adapters packages/core/src/agents -name 'index.ts' -path '*/src/*' ! -name '__tests__' | wc -l | tr -d ' ')
+          # Single source of truth: scripts/count-agents.ts walks the
+          # workspace exactly the same way the CLI's discoverAgents() does.
+          # The previous `find` undercounted by skipping agents-platform
+          # and agents-tmc.
+          AGENT_COUNT=$(pnpm tsx scripts/count-agents.ts --json | node -e "let s=''; process.stdin.on('data',c=>s+=c).on('end',()=>console.log(JSON.parse(s).total))")
           echo "count=${AGENT_COUNT}" >> "$GITHUB_OUTPUT"
 
       - name: Get version

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The full airline and hotel booking lifecycle — search, pricing, booking, ticketing, exchange, refund, and BSP/ARC settlement — modeled as typed, testable agents with a pipeline contract system that prevents LLM hallucinations at every step.
 
-**76 agents. 6 distribution adapters. 14 pipeline-contracted agents. 3,034 tests. TypeScript strict.**
+**75 agents. 6 distribution adapters. 14 pipeline-contracted agents. 3,092 tests. TypeScript strict.**
 
 OTAIP agents encode real industry logic: ATPCO fare rules (Categories 1-33), NUC/ROE fare construction with HIP/BHC/CTM checks, BSP HOT file reconciliation, ADM prevention (9 pre-ticketing checks), NDC/EDIFACT normalization, IRROPS rebooking with EU261 and US DOT compliance, void window enforcement, married segment integrity, and payment-to-ticketing state machines with BSP finality rules.
 
@@ -14,7 +14,7 @@ pnpm add @otaip/core @otaip/agents-booking @otaip/connect
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/telivity-otaip/otaip/actions/workflows/ci.yml/badge.svg)](https://github.com/telivity-otaip/otaip/actions)
-[![Tests](https://img.shields.io/badge/tests-3034%20passing-brightgreen)](https://github.com/telivity-otaip/otaip/actions)
+[![Tests](https://img.shields.io/badge/tests-3092%20passing-brightgreen)](https://github.com/telivity-otaip/otaip/actions)
 
 ---
 
@@ -39,7 +39,7 @@ See [docs/adapters/](docs/adapters/) for per-adapter documentation.
 
 ## Agent Domains
 
-76 agents across 12 operational stages. Every agent implements `Agent<TInput, TOutput>` — typed inputs, typed outputs, confidence scores. No framework lock-in, no LLM required.
+75 agents across 12 operational stages. Every agent implements `Agent<TInput, TOutput>` — typed inputs, typed outputs, confidence scores. No framework lock-in, no LLM required.
 
 | Stage | Domain | Package | Agents | Description |
 |-------|--------|---------|--------|-------------|
@@ -111,11 +111,14 @@ What you can build with this platform:
 ```bash
 git clone https://github.com/telivity-otaip/otaip.git
 cd otaip
-pnpm install
-pnpm test                    # 2,881 tests
+pnpm install --frozen-lockfile
+pnpm run data:download       # one-time: airport reference data
+pnpm test                    # 3,092 tests
 pnpm lint                    # 0 errors
-pnpm -r run typecheck        # 15 packages, all green
+pnpm -r run typecheck        # 16 packages, all green
 ```
+
+> Note: lifecycle scripts are disabled (`ignore-scripts=true`) for supply-chain safety, so the airport reference data is fetched explicitly via `pnpm run data:download` rather than via a `postinstall` hook.
 
 Run the full pipeline demo (requires `ANTHROPIC_API_KEY`):
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,7 @@
 # OTAIP Agent Catalog
 
-> 75 agents across 11 stages. 14 have pipeline contracts (marked with checkmark).
+> 75 agents across 12 stages. 14 have pipeline contracts (marked with checkmark).
+> Counts are computed from source by `pnpm run count:agents` — do not hand-edit the totals.
 
 ## Stage 0 -- Reference (7 agents)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,12 +17,22 @@ pnpm --version   # 10.x.x
 ```bash
 git clone https://github.com/telivity-otaip/otaip.git
 cd otaip
-pnpm install
+pnpm install --frozen-lockfile
 ```
 
 This installs all workspace packages: `@otaip/core`, `@otaip/connect`, `@otaip/duffel`, and all agent packages.
 
-## 2. Build the Project
+> **Note**: lifecycle scripts are disabled (`ignore-scripts=true` in `.npmrc`) for supply-chain safety. No `postinstall` hooks run.
+
+## 2. Download Reference Data
+
+```bash
+pnpm run data:download
+```
+
+Fetches airport reference data into `data/reference/`. Required for the airport-code resolver and any agent that depends on it. Re-run whenever the upstream OurAirports dataset is updated.
+
+## 3. Build the Project
 
 ```bash
 pnpm build
@@ -30,13 +40,13 @@ pnpm build
 
 Builds all packages with `tsup` in the correct dependency order.
 
-## 3. Run Tests to Verify
+## 4. Run Tests to Verify
 
 ```bash
 pnpm test
 ```
 
-You should see 2,881 tests pass across all packages. The adapter tests (456 tests) use mocked HTTP -- no live API calls.
+You should see 3,092 tests pass across all packages. The adapter tests (456 tests) use mocked HTTP -- no live API calls.
 
 ## 4. Set Up Duffel Sandbox (Optional)
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "format": "prettier --write 'packages/*/src/**/*.ts' 'packages/agents/*/src/**/*.ts' 'packages/adapters/*/src/**/*.ts'",
     "format:check": "prettier --check 'packages/*/src/**/*.ts' 'packages/agents/*/src/**/*.ts' 'packages/adapters/*/src/**/*.ts'",
     "typecheck": "pnpm -r run typecheck",
-    "postinstall": "tsx scripts/download-airport-data.ts",
     "data:download": "tsx scripts/download-airport-data.ts",
+    "count:agents": "tsx scripts/count-agents.ts",
     "clean": "pnpm -r run clean && rm -rf node_modules"
   },
   "pnpm": {

--- a/packages/cli/src/__tests__/agent-discovery.test.ts
+++ b/packages/cli/src/__tests__/agent-discovery.test.ts
@@ -50,9 +50,12 @@ describe('discoverAgents', () => {
       '7': 'reconciliation',
       '20': 'lodging',
     };
+    // 1.9 (OfferEvaluator) lives in @otaip/core for circular-dep reasons,
+    // so its stage is 'core' rather than 'search'. Carve it out.
+    const idStageOverrides: Record<string, string> = { '1.9': 'core' };
     for (const a of agents) {
       const prefix = a.id.split('.')[0]!;
-      const expected = expectedStage[prefix];
+      const expected = idStageOverrides[a.id] ?? expectedStage[prefix];
       if (!expected) continue; // 8.x → tmc, 9.x → platform handled separately
       expect(a.stage, `agent ${a.id} ${a.name}`).toBe(expected);
     }

--- a/packages/cli/src/agent-discovery.ts
+++ b/packages/cli/src/agent-discovery.ts
@@ -52,6 +52,8 @@ function repoRoot(): string {
 const STAGE_ROOTS: ReadonlyArray<AgentRoot> = [
   { path: 'packages/agents-platform/src', stage: 'platform' },
   { path: 'packages/agents-tmc/src', stage: 'tmc' },
+  // OfferEvaluator (1.9) lives in @otaip/core for circular-dep reasons.
+  { path: 'packages/core/src/agents/shopping', stage: 'core' },
 ];
 
 const NESTED_STAGE_ROOT = 'packages/agents';

--- a/scripts/count-agents.ts
+++ b/scripts/count-agents.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env tsx
+/**
+ * Single source of truth for the agent count + per-stage breakdown.
+ *
+ * Walks the workspace exactly the same way the CLI does
+ * (packages/cli/src/agent-discovery.ts), so README claims, docs counts,
+ * and the release-notes pipeline cannot drift apart.
+ *
+ * Usage:
+ *   pnpm tsx scripts/count-agents.ts            # plain text
+ *   pnpm tsx scripts/count-agents.ts --json     # machine-readable
+ *
+ * The previous release.yml `find` command undercounted by skipping
+ * packages/agents-platform and packages/agents-tmc; this script does not.
+ */
+
+import { discoverAgents } from '../packages/cli/src/agent-discovery.js';
+
+interface Counts {
+  total: number;
+  stages: number;
+  by_stage: Record<string, number>;
+}
+
+function tally(): Counts {
+  const agents = discoverAgents();
+  const by_stage: Record<string, number> = {};
+  for (const a of agents) {
+    by_stage[a.stage] = (by_stage[a.stage] ?? 0) + 1;
+  }
+  return {
+    total: agents.length,
+    stages: Object.keys(by_stage).length,
+    by_stage,
+  };
+}
+
+function printJson(counts: Counts): void {
+  console.log(JSON.stringify(counts, null, 2));
+}
+
+function printText(counts: Counts): void {
+  console.log(`Total agents: ${counts.total}`);
+  console.log(`Stages:       ${counts.stages}`);
+  console.log('');
+  for (const [stage, n] of Object.entries(counts.by_stage).sort()) {
+    console.log(`  ${stage.padEnd(20)} ${n}`);
+  }
+}
+
+const counts = tally();
+if (process.argv.includes('--json')) {
+  printJson(counts);
+} else {
+  printText(counts);
+}


### PR DESCRIPTION
## Summary
Codex review MEDIUM #2 + LOW #2.

### MEDIUM #2 — postinstall vs ignore-scripts
With \`.npmrc\` \`ignore-scripts=true\` (PR #50), the root \`postinstall\` already never ran but the script tag was still in \`package.json\`, leading to confusion about whether airport data was fetched automatically. Removed the \`postinstall\` and added an explicit \`pnpm run data:download\` step to README + docs/getting-started.md with a note explaining the supply-chain trade-off.

### LOW #2 — agent/stage count drift
README claimed 76 agents / 12 stages. docs/agents.md claimed 75 / 11. The CLI registry (PR #78) discovered 74. The \`release.yml\` \`find\` undercounted by skipping \`agents-platform\` and \`agents-tmc\`.

Fix: one source of truth.
- New \`scripts/count-agents.ts\` (\`pnpm run count:agents\`) walks the workspace exactly the way the CLI's \`discoverAgents()\` does. Outputs \`--json\` for CI consumption.
- Extended discovery to also scan \`packages/core/src/agents/shopping\` so OfferEvaluator (1.9) is counted.
- Replaced \`release.yml\`'s \`find\` with the new script.
- Synced all surfaces:
  - README header → \"75 agents. ... 3,092 tests.\"
  - Tests badge → 3092
  - Agent Domains intro → \"75 agents across 12 operational stages\"
  - Install/test commands updated (frozen-lockfile, data:download, 16 packages)
  - docs/agents.md → \"12 stages\" + a line pointing future editors at \`pnpm run count:agents\`

Today: **75 agents across 12 stages**.

## Test plan
- [x] \`pnpm install --frozen-lockfile\` — succeeds
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm test\` — 3,092 passed
- [x] \`pnpm run count:agents\` — total=75, stages=12

🤖 Generated with [Claude Code](https://claude.com/claude-code)