### PR TITLE
docs: accurate tsconfig strictness claim (exactOptionalPropertyTypes is off)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 If you lack domain input to proceed: refactor, clean, document existing code, then surface the blocking question. Never invent travel industry behavior.
 
 ## Tech Stack
-- TypeScript (strict mode — all strict flags ON)
+- TypeScript (`strict: true`, plus `noUncheckedIndexedAccess`, `noImplicitOverride`, `noPropertyAccessFromIndexSignature`; `exactOptionalPropertyTypes` is off — enabling it would require widespread call-site changes, tracked as a separate cleanup)
 - Node.js >=24
 - pnpm 10+ (workspace monorepo)
 - Vitest for testing

--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ docs/                       Architecture, agents, adapters, getting started
 
 ## Tech Stack
 
-- **TypeScript** (strict mode — all strict flags ON)
+- **TypeScript** (`strict: true`, plus `noUncheckedIndexedAccess`, `noImplicitOverride`, `noPropertyAccessFromIndexSignature`; `exactOptionalPropertyTypes` is off — enabling it would require call-site changes across dozens of files, tracked as a separate cleanup)
 - **Node.js** >=24
 - **pnpm** 10+ (workspace monorepo, 17 packages)
-- **Vitest** for testing (2,881 tests)
+- **Vitest** for testing (3,092 tests)
 - **tsup** for building (ESM + DTS)
 - **ESLint** + **Prettier** for linting/formatting
 - **Zod** 4 for schema validation + JSON Schema generation


### PR DESCRIPTION
## Summary
Codex review LOW #1.

README and CLAUDE.md both claimed \"all strict flags ON\", but \`tsconfig.base.json\` line 18 explicitly sets \`exactOptionalPropertyTypes: false\`.

Replace the broad claim with the actual enabled set — \`strict\`, \`noUncheckedIndexedAccess\`, \`noImplicitOverride\`, \`noPropertyAccessFromIndexSignature\` — and note that \`exactOptionalPropertyTypes\` is intentionally off (enabling it is tracked as a separate cleanup since it would require widespread call-site changes).

Also fixes the stale Vitest test count (2,881 → 3,092) that slipped through PR #79's sync.

## Test plan
No code changes. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)