### PR TITLE
docs(readme): fix package count; verify other sync items

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ docs/                       Architecture, agents, adapters, getting started
 
 - **TypeScript** (`strict: true`, plus `noUncheckedIndexedAccess`, `noImplicitOverride`, `noPropertyAccessFromIndexSignature`; `exactOptionalPropertyTypes` is off — enabling it would require call-site changes across dozens of files, tracked as a separate cleanup)
 - **Node.js** >=24
-- **pnpm** 10+ (workspace monorepo, 17 packages)
+- **pnpm** 10+ (workspace monorepo, 16 packages)
 - **Vitest** for testing (3,092 tests)
 - **tsup** for building (ESM + DTS)
 - **ESLint** + **Prettier** for linting/formatting


### PR DESCRIPTION
## Summary
Sync check of 4 README claims against the codebase.

| # | Claim | Code says | Action |
|---|-------|-----------|--------|
| 1 | Stage 9 Platform = 9 agents | 9 (PlatformHealthAggregator is a utility class, not an Agent) | no change |
| 2 | Tech Stack: 17 packages | 16 (\`pnpm -r run typecheck\`) | **fixed** |
| 3 | Node.js >=24 | \`package.json\` engines \`>=24.14.1\` | no change |
| 4 | Zod 4 | \`@otaip/core\` dependency \`^4.3.6\` | no change |

Only the package count was wrong. One-line fix: Tech Stack now says 16 to match the Quick Start line and \`pnpm -r\`.

## Test plan
- [x] \`pnpm test\` — 3,092 pass (3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)