### PR TITLE
chore(publish): prep 15 packages for first npm publish at 0.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      # Build before typecheck so cross-package `@otaip/*` imports can
+      # resolve via the published-style `exports["."].types -> ./dist/...`
+      # entries. Doubles as a validation that every package builds on a
+      # clean tree (the same configuration that ships to npm).
+      - name: Build
+        run: pnpm -r run build
+
       - name: Type check
         run: pnpm run typecheck
 

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,7 +10,7 @@
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@otaip/connect",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@otaip/core",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },


### PR DESCRIPTION
## Summary
Preparation for the first-ever npm publish of the \`@otaip/*\` scope. Found two structural blockers during pre-publish audit that would have bricked every consumer on \`npm install\`; fixed them both.

### Blockers fixed
**1. Wrong module type on 11 of 15 packages.**
\`core\`, \`agents-platform\`, \`agents-tmc\`, and all nested \`agents/*\` except \`lodging\` lacked \`"type": "module"\`. With tsup configured \`--format esm --dts\`, that produced \`dist/index.mjs\` + \`dist/index.d.mts\`, but \`package.json\` said \`main: "./dist/index.js"\` and \`types: "./dist/index.d.ts"\`. Consumers would hit \`Cannot find module\`.

Fix: add \`"type": "module"\` to all 15 so tsup emits \`index.js\` / \`index.d.ts\` matching the declared fields. Verified each package's \`main\` and \`types\` now resolve to a real file.

**2. Types exported from src (which doesn't ship).**
All 15 packages had \`exports["."].types: "./src/index.ts"\`. But \`files: ["dist"]\` excludes \`src/\` from the tarball, so TypeScript users would get no types.

Fix: point \`exports["."].types\` at \`./dist/index.d.ts\`.

### Version sync
All 15 workspace packages were still at \`0.6.0\` while root was \`0.6.2\`. Bumped them all to \`0.6.2\` so the first publish is coherent.

### Dry-run output
\`\`\`
$ pnpm -r publish --access public --no-git-checks --dry-run
+ @otaip/adapter-duffel@0.6.2
+ @otaip/agents-booking@0.6.2
+ @otaip/agents-exchange@0.6.2
+ @otaip/agents-lodging@0.6.2
+ @otaip/agents-platform@0.6.2
+ @otaip/agents-pricing@0.6.2
+ @otaip/agents-reconciliation@0.6.2
+ @otaip/agents-reference@0.6.2
+ @otaip/agents-search@0.6.2
+ @otaip/agents-settlement@0.6.2
+ @otaip/agents-ticketing@0.6.2
+ @otaip/agents-tmc@0.6.2
+ @otaip/cli@0.6.2
+ @otaip/connect@0.6.2
+ @otaip/core@0.6.2
\`\`\`

Also inspected the \`@otaip/agents-booking\` tarball manifest — pnpm correctly rewrote every \`workspace:*\` dep to \`"0.6.2"\`.

## What is NOT in this PR (you need to do before publishing)
1. Create the \`@otaip\` npm org → https://www.npmjs.com/org/create
2. Generate an automation-type npm token with read+write scope on \`@otaip/*\`
3. Add it to the GitHub repo as \`NPM_TOKEN\` → Settings → Secrets → Actions
4. Merge this PR
5. Either tag \`v0.6.2\` on main (triggers \`release.yml\` → \`publish.yml\`) or trigger \`publish.yml\` manually (workflow_dispatch)

Once published, smoke-test with:
\`\`\`
npm view @otaip/core
npm view @otaip/agents-search
npm view @otaip/adapter-duffel
\`\`\`

## Test plan
- [x] \`pnpm -r run clean && pnpm -r run build\` — all 16 packages Done
- [x] \`main\` and \`types\` resolve to existing files on all 15 packages
- [x] \`pnpm -r publish --dry-run\` — 15 @otaip/* packages at 0.6.2
- [x] Packed tarball dependency manifest uses concrete versions, not \`workspace:*\`
- [x] \`pnpm test\` — 3,092 pass (3 skipped)
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)