### PR TITLE
v0.6.3 — Codex review closeout, first npm publish, per-transaction routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,93 @@
 
 > **Versioning policy:** Pre-v1.0, every release is a patch bump (`0.6.0 → 0.6.1 → 0.6.2 → …`). See [VERSIONING.md](VERSIONING.md) for the full policy and an explanation of the early-history version jumps (0.3.4 → 0.5.0 → 0.5.1 → 0.6.0) that predate this rule.
 
+## 0.6.3 — Codex review closeout, first npm publish, per-transaction routing
+
+Eleven PRs (#73–#83) addressing all 12 findings from a full-repo Codex review, the first-ever publish of the `@otaip/*` scope to npm, and a set of CI/publish hardening fixes. Several engines widen their output types and a couple of agents add required input fields — see **Potentially-breaking** below if you were depending on the previous behaviour.
+
+### Published to npm
+
+All 15 `@otaip/*` packages are now live on npm at `0.6.2` — previously the source existed but nothing had shipped. `npm install @otaip/core` (and friends) works.
+
+- `@otaip/core`, `@otaip/connect`, `@otaip/cli`, `@otaip/adapter-duffel`
+- `@otaip/agents-reference`, `@otaip/agents-search`, `@otaip/agents-pricing`, `@otaip/agents-booking`, `@otaip/agents-ticketing`, `@otaip/agents-exchange`, `@otaip/agents-settlement`, `@otaip/agents-reconciliation`, `@otaip/agents-lodging`
+- `@otaip/agents-tmc`, `@otaip/agents-platform`
+
+### Removed invented domain logic (CLAUDE.md compliance)
+
+Codex review flagged five engines that were computing fare/penalty/compensation amounts from invented "common industry pattern" data rather than authoritative sources. This release replaces all of them with either caller-supplied authoritative inputs or published-law constants.
+
+- **`@otaip/core`: EU 261/2004 + US DOT 14 CFR §250 modules (new).** `applyEU261()` encodes the published distance bands (€250/€400/€600), 3h arrival-delay trigger, Article 7(2) rerouting 50% reduction, 14-day cancellation safe harbour, and extraordinary-circumstances exemption. `applyUsDotIdb()` encodes the current 14 CFR §250.5 denied-boarding tables ($1,075 / $2,150 caps, effective 2025-01-22). Plus `greatCircleDistanceKm()` haversine helper.
+- **`@otaip/core`: new `DomainInputRequired` type + helpers** (`domainInputRequired`, `isDomainInputRequired`) — shared sentinel for engines that refuse to synthesise numbers when authoritative inputs are missing.
+- **Fare Construction (2.2):** removed the ROE 1.0 fallback (was silently multiplying every non-USD currency by 1), the per-mile-rate HIP heuristic, and the city-revisited BHC heuristic. Engine now returns `DomainInputRequired` when ROE is missing and populates `missing_inputs` on HIP/BHC checks that need intermediate-point fare lookups. The EMS mileage-surcharge formula (5%/5%, max 25%) stays — confirmed IATA standard. Output type widened to `FareConstructionResult = FareConstructionOutput | DomainInputRequired`.
+- **Change Management (5.1) + Refund Processing (6.1):** removed the "$200 default" fallback, the waiver-=-zero special case, and the residual = original − penalty formula. Engines now read `cat31_rules` / `cat33_rules` from input and apply them as filed. When rules are absent, they fall back to the ATPCO default — permitted at no charge for voluntary changes, fee waived for involuntary. Invented rule data moved out of `src/data/` into `__tests__/fixtures/` with a "TEST FIXTURE — do not use in production" banner.
+- **Involuntary Rebook (5.3):** removed the hardcoded 60-minute IRROP threshold. Caller now supplies `thresholds.time_change_minutes` per carrier. Real EU261 compensation is calculated via the core module when `eu261_inputs` (distance, delay, extraordinary circumstances, notice days, rerouting) are provided; `regulatory_flags[].missing_inputs` lists what's needed otherwise. Clarified that US DOT IDB applies to denied boarding only — not delays/cancellations.
+- **Feedback & Complaint (6.5):** replaced ~250 lines of inline EU261 / US DOT compensation math with calls to the core regulation modules. DOT IDB caps updated from pre-amendment $775 / $1,550 to current $1,075 / $2,150. Article 10(2) downgrade reimbursement (30/50/75%) kept — published law not covered by the Article 7 helper.
+
+### GDS/NDC router per-transaction routing (CLAUDE.md compliance)
+
+The router previously treated `carrier → channel_priority` as unconditional. Replaced with per-transaction routing: different transaction types (`shopping`, `booking`, `ticketing`, `servicing`, `group`, `corporate`) route differently for the same carrier. Built-in defaults cover `shopping` and `booking`; every other type requires caller-supplied `capability_overrides` or the engine returns `domain_input_required: true`. Unknown carriers no longer default silently to GDS/AMADEUS.
+
+### HTTP hardening
+
+- **New `@otaip/core` `fetchWithRetry(input, init?, options?)`** — wraps `fetch` with per-attempt `AbortController` timeout (default 30s) + retry on 5xx / 429 / network errors via the existing `withRetry`. Response stays a `Response`; callers still inspect `response.ok`.
+- **TripPro defaults now HTTPS.** Search and calendar-search URLs were `http://mas.trippro.com/...` — switched to `https://`. Reprice/book were already HTTPS.
+- **Sabre auth, Navitaire create+refresh, Duffel adapter, TripPro SOAP client** all route through `fetchWithRetry` instead of raw `fetch`.
+
+### Correctness fixes
+
+- **`booking/api-abstraction` rate limiter** — the counter incremented once per `execute()` call, **before** the retry loop, so retries against the upstream provider went uncounted. Moved the increment and the rate-limit guard inside the loop so each actual outbound attempt is charged against the quota.
+- **Stub agents now throw `UnimplementedDomainInputError`** (new `@otaip/core` export) instead of raw `Error`. Four agents migrated: `DisruptionResponseAgent` (5.4), `DynamicPricingAgent` (2.6), `RevenueManagementAgent` (2.7), `InterlineSettlementAgent` (7.4).
+
+### CLI
+
+- **`otaip agents` registry is now auto-discovered** from source metadata (`packages/cli/src/agent-discovery.ts`) rather than a hand-maintained array that had drifted (claimed 71, listed 69, several names didn't match the exported agent classes). Walks `packages/agents/*/src/*/index.ts`, `packages/agents-platform/src/*/index.ts`, `packages/agents-tmc/src/*/index.ts`, and `packages/core/src/agents/shopping/*/index.ts` — greps `readonly id`, `readonly name`, `readonly version`. Today: 75 agents across 12 stages.
+- **CLI now included in lint** (`--ignore-pattern 'packages/cli/**'` removed). `packages/cli/tsconfig.json` added to the ESLint parser project list. CLI-scoped override allows `console.*` (CLI stdout is the contract).
+- **7 new tests** for the discovery walk — count floor, unique IDs, file-resolves-to-real-path, stage matches ID prefix, sort order, etc.
+
+### Bootstrap + counts
+
+- **New `scripts/count-agents.ts`** (`pnpm run count:agents`) — single source of truth for agent counts. Replaces a `find` in `release.yml` that undercounted by skipping `agents-platform` and `agents-tmc`. All agent/stage counts in README, docs, and release notes now derive from one script.
+- **Removed root `postinstall`.** With `ignore-scripts=true` in `.npmrc` (shipped in 0.5.x for supply-chain safety), the `postinstall` never ran anyway. Docs updated to instruct an explicit `pnpm run data:download`.
+- **Publish prep** — every workspace package now has `"type": "module"` so tsup's ESM output (`index.js`/`index.d.ts`) matches the `main`/`types` fields; `exports["."].types` moved from `./src/index.ts` (not in the tarball) to `./dist/index.d.ts`; all 15 workspace packages aligned to the root version so the first publish was coherent.
+
+### CI / release
+
+- **`release.yml` no longer swallows test failures.** The previous step used `pnpm test 2>&1 || true`, masking failed tests so a broken release could publish with a misleading test count. Split into two steps that fail fast.
+- **`publish.yml` now verifies packages are actually live.** After `pnpm -r publish`, polls the registry for each of the 15 `@otaip/*` packages and expects `dist-tags.latest` to equal the released version. Fails loudly if pnpm reports success but the registry doesn't have the package. (Caught a "published successfully but 404 on registry for 5 minutes" class of bug on the first live publish.)
+- **`ci.yml` builds before typecheck.** With `exports.types → ./dist/index.d.ts`, cross-package `@otaip/*` imports need `dist/` to exist for TS to resolve types. Doubles as clean-tree build validation.
+
+### Docs
+
+- **README header numbers synced** — 75 agents across 12 stages, 3,092 tests, 16 packages. Test badge updated. Install instructions now say `pnpm install --frozen-lockfile && pnpm run data:download`.
+- **Accurate tsconfig strictness claim** — README and CLAUDE.md previously said "all strict flags ON" but `exactOptionalPropertyTypes` is intentionally off. Replaced with the explicit list of enabled flags.
+- **docs/getting-started.md** — added the explicit data-download step and documented the supply-chain trade-off.
+- **docs/agents.md** — header updated to "12 stages" with a note pointing future editors at `pnpm run count:agents` so the total cannot drift again.
+
+### Potentially-breaking
+
+> Pre-1.0 policy allows breaking changes in patch bumps; flagged here so downstream consumers can update.
+
+- `FareConstruction#execute()` return type widened to `AgentOutput<FareConstructionOutput | DomainInputRequired>`. Consumers must narrow on `result.data.status`.
+- `GdsNdcRouter` input now requires `transaction_type` (new enum). Previously-working inputs without it will be rejected by the validator.
+- `ChangeManagement` and `RefundProcessing` now require `cat31_rules` / `cat33_rules` in input to apply filed penalties. Absent rules → ATPCO default (no penalty for voluntary, waived for involuntary) — **was** a `$200` default in 0.6.2.
+- `InvoluntaryRebook` now requires `thresholds.time_change_minutes` to mark a time-change as involuntary. Absent → non-involuntary with a warning.
+- `@otaip/core` exports `fetchWithRetry`, `UnimplementedDomainInputError`, `DomainInputRequired`, `applyEU261`, `applyUsDotIdb`, `greatCircleDistanceKm` and related types.
+- TripPro `searchUrl` / `calendarSearchUrl` defaults switched from `http://` to `https://`. Override explicitly for local dev.
+- US DOT IDB compensation caps updated to 14 CFR §250.5 (effective 2025-01-22): `$1,075` / `$2,150` (was the pre-amendment `$775` / `$1,550`).
+- 11 packages that previously lacked `"type": "module"` now have it. CommonJS consumers will need to import via `import(...)` or upgrade their resolution.
+
+### Tests
+
+- **3,092 total passing** (was 3,034). 58 new tests:
+  - 18 for the new EU261 + US DOT IDB regulation modules
+  - 8 for `fetchWithRetry`
+  - 5 new EU261 compensation tests in involuntary-rebook
+  - 7 for CLI agent discovery
+  - 7 for the ATPCO-default branches in change-management + refund-processing
+  - 5 for per-transaction GDS/NDC routing + new validators
+  - 3 for the rate-limit retry counting + stub `UnimplementedDomainInputError`
+
 ## 0.6.2 — Reference OTA Multi-Adapter Fixes
 
 Three bugs in the Sprint H multi-adapter integration caught by Codex review, plus the follow-up to make booking adapter-aware. No behavior change to the single-adapter path; no breaking changes to public interfaces.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
Eleven PRs (#73–#83) merged since 0.6.2.

Root + all 15 workspace packages bumped \`0.6.2 → 0.6.3\`. Full CHANGELOG entry below; inline here for PR review.

## What's in this release

### Published to npm
All 15 \`@otaip/*\` packages are live on npm for the first time (at 0.6.2; 0.6.3 will go out when this merges).

### Removed invented domain logic (Codex review HIGH #3/#4/#5)
- **New \`@otaip/core\` regulation modules**: \`applyEU261()\` (EC 261/2004 — distance bands, 3h delay trigger, Article 7(2) reduction, 14-day safe harbour, extraordinary circumstances) and \`applyUsDotIdb()\` (14 CFR §250.5 denied-boarding, current $1,075/$2,150 caps effective 2025-01-22). Plus \`DomainInputRequired\` sentinel type.
- **Fare Construction (2.2)**: ROE 1.0 fallback removed (was silently multiplying every non-USD by 1); simplified HIP/BHC heuristics replaced with \`missing_inputs\` surface. Output widened to \`FareConstructionOutput | DomainInputRequired\`.
- **Change Management (5.1) + Refund Processing (6.1)**: \$200 default removed. Engines read \`cat31_rules\` / \`cat33_rules\` from input; absent → ATPCO default (no charge for voluntary, waived for involuntary). Invented rule data relocated to test fixtures.
- **Involuntary Rebook (5.3)**: 60min IRROP hardcode removed; caller supplies threshold. Real EU261 compensation via core module when inputs present.
- **Feedback & Complaint (6.5)**: ~250 lines of inline EU261/DOT math replaced with core module calls. DOT IDB caps updated to current law.

### Per-transaction GDS/NDC routing (MEDIUM #5)
New required \`transaction_type\` input (\`shopping\` | \`booking\` | \`ticketing\` | \`servicing\` | \`group\` | \`corporate\`). Built-in carrier defaults cover shopping/booking only; other types need \`capability_overrides\` or return \`domain_input_required: true\`.

### HTTP hardening (HIGH #2)
New \`@otaip/core\` \`fetchWithRetry\` (30s timeout + retry on 5xx/429/network) wired into TripPro SOAP, Sabre auth, Navitaire create+refresh, Duffel adapter. TripPro defaults now HTTPS.

### Correctness fixes (MEDIUM #1 + #4)
- Rate limiter counter now increments per attempt inside the retry loop (was counting once per execute() call, under-reporting by up to 4× on retries)
- Stub agents throw typed \`UnimplementedDomainInputError\` instead of raw \`Error\`

### CLI + counts (MEDIUM #3 + LOW #2)
- CLI agent registry auto-discovered from source (was hand-maintained, drifted from 71→69 and names mismatched)
- CLI now in lint; 7 new discovery tests
- New \`scripts/count-agents.ts\` as single source of truth — used by release notes. Today: 75 agents across 12 stages

### CI / release (HIGH #1 + bootstrap + publish prep)
- Release workflow fails on test failures (was \`|| true\`'d)
- CI builds before typecheck (cross-package \`@otaip/*\` imports now need \`dist/\`)
- \`publish.yml\` verifies packages are live on registry after publish
- Every workspace package now has \`"type": "module"\` so tsup output matches declared \`main\`
- Root \`postinstall\` removed (was blocked by \`ignore-scripts=true\` anyway); docs instruct explicit \`pnpm run data:download\`
- tsconfig strictness claim in README/CLAUDE.md corrected

## Potentially-breaking (pre-1.0 policy allows this in patch bumps)
- \`FareConstruction\` return type widened to union with \`DomainInputRequired\`
- \`GdsNdcRouter\` requires \`transaction_type\`
- \`ChangeManagement\` / \`RefundProcessing\` default to "no charge" when rules absent (was \$200)
- \`InvoluntaryRebook\` requires \`thresholds.time_change_minutes\` for TIME_CHANGE
- TripPro \`searchUrl\` / \`calendarSearchUrl\` defaults switched http→https
- US DOT IDB caps updated to current law (\$1,075 / \$2,150)
- 11 packages gained \`"type": "module"\`

See full details in the CHANGELOG entry for 0.6.3.

## Test plan
- [x] \`pnpm install\` — clean
- [x] \`pnpm -r run build\` — all 16 packages Done
- [x] \`pnpm test\` — 3,092 passed (3 skipped)
- [x] \`pnpm run lint\` — clean
- [x] \`pnpm -r run typecheck\` — clean
- [ ] Post-merge: \`release.yml\` builds release notes from this CHANGELOG entry; \`publish.yml\` publishes 0.6.3 to npm and the new verification step confirms all 15 are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)