### PR TITLE
feat(adapter-hotelbeds): add Activities + Transfers APIs (v0.7.0)

### DIFF
--- a/docs/knowledge-base/activities.md
+++ b/docs/knowledge-base/activities.md
@@ -1,0 +1,97 @@
+# Hotelbeds Activities API — Domain Knowledge
+
+Source: vendor brief, May 2026. This file is the authoritative domain input for the `@otaip/adapter-hotelbeds` Activities surface. Anything missing here is captured as an open `DOMAIN_QUESTION` at the bottom — never invent.
+
+## Endpoints
+
+| Operation     | Method | Path                                     |
+| ------------- | ------ | ---------------------------------------- |
+| Availability  | POST   | `/activity-api/3.0/activities/availability` |
+| Booking       | POST   | `/activity-api/3.0/activities/booking`   |
+| Cancellation  | DELETE | `/activity-api/3.0/activities/booking/{ref}` *(see DQ-A1)* |
+
+Base URL is the same Hotelbeds host as Hotels (`api.test.hotelbeds.com` for sandbox, `api.hotelbeds.com` for production). Path prefix is `/activity-api/3.0`.
+
+## Auth
+
+Identical to Hotels API — `Api-key` + `X-Signature: SHA256(apiKey + secret + utcSeconds)`. Reuse `buildAuthHeaders()` from `auth.ts`.
+
+## Availability — request
+
+```json
+{
+  "filters": {
+    "searchFilterItems": [{ "type": "destination", "value": "BCN" }]
+  },
+  "from": "2026-06-01",
+  "to": "2026-06-03",
+  "paxes": {
+    "adults": 2,
+    "children": [8, 12]
+  }
+}
+```
+
+- `filters.searchFilterItems[].type`: `"destination"` is the only documented filter type for this session. `value` is a Hotelbeds destination code (BCN, PAR, LON, etc.).
+- `paxes.children`: array of *ages*, not a count. `[8, 12]` means two children aged 8 and 12.
+- Date range is inclusive; activities priced for the date range.
+
+## Availability — response shape
+
+The brief documents the OTAIP-canonical mapping (`ActivityOffer[]` with `modalities`, pricing per pax type, images, duration, cancellation policy) but does NOT specify the raw Hotelbeds wire field names. The adapter's raw response type is best-effort based on the OTAIP shape and Hotelbeds API conventions. Each activity carries:
+
+- One or more *modalities* — variants like skip-the-line, private, group. The booking call references one `modalityCode`.
+- Per-modality pricing keyed by pax type. The brief shows a single `Money` per modality (`price` per adult, optional `childPrice`). Net rate is the bedbank cost; selling rate is what the platform may surface to the user. See DQ-A2.
+- A cancellation policy. Brief shows enum `'NOR' | 'NRF'` — refundable vs non-refundable. Behavioral semantics (penalty schedule, free-cancel cutoff) are NOT documented here.
+- Activity metadata: name, description, duration string, images, geo location.
+
+## Booking — request
+
+```json
+{
+  "activities": [{
+    "activityCode": "E-A10-000100301",
+    "modalityCode": "TOUR_GUIDE|EN|1",
+    "from": "2026-06-01",
+    "paxes": [{ "age": 30 }, { "age": 28 }]
+  }],
+  "holder": { "name": "John", "surname": "Smith" },
+  "clientReference": "AVR-ACT-001"
+}
+```
+
+- `paxes[].age` is required for every pax. The brief does not differentiate between adult/child here — age alone is the input.
+- Multiple activities can be booked in one call (`activities: [...]`); the adapter surface in this session books one at a time.
+
+## Booking — response
+
+Returns `{ bookingReference, status: 'CONFIRMED' | 'ON_REQUEST', clientReference, voucherUrl? }`.
+
+- `'ON_REQUEST'` indicates the supplier has not yet confirmed; a follow-up retrieval may be required to learn the final outcome. The retrieval/poll flow is NOT specified — see DQ-A3.
+- `voucherUrl` is a string. Whether it is signed, time-limited, or anonymously accessible is not documented — DQ-A4.
+
+## Cancellation
+
+The brief specifies the OTAIP method signature `cancelActivity(bookingReference)` returning `{ status: 'CANCELLED', cancellationReference }`. The HTTP-level details (DELETE vs POST, two-step simulate-confirm pattern à la Hotels) are NOT documented for Activities — DQ-A1.
+
+## Sandbox
+
+- Same credentials as Hotels (`HOTELBEDS_API_KEY` / `HOTELBEDS_SECRET`).
+- Sandbox returns synthetic activities for major destinations (BCN, PAR, LON, etc.).
+- Subject to the same daily request quota as the Hotels sandbox.
+
+## Open DOMAIN_QUESTIONs
+
+- **DQ-A1** — Cancellation HTTP shape. Hotels supports a SIMULATION/CANCELLATION two-step (DELETE with `cancellationFlag` query param). Activities cancel HTTP shape is unverified. The adapter assumes `DELETE /activities/booking/{ref}` with no flag. Confirm against sandbox and update if different.
+- **DQ-A2** — Net vs selling rate field names. The brief uses a single `Money` per modality. The Hotels API returns `net` and `sellingRate` as separate string fields. The adapter mapper currently treats the modality price as net and does not surface a separate selling rate. If Activities does the same, surface it; if not, the price field is treated as net per the brief.
+- **DQ-A3** — `'ON_REQUEST'` confirmation flow. No retrieval endpoint or poll cadence is documented. The adapter returns the status as-is and leaves the orchestration agent to decide whether and how to confirm later.
+- **DQ-A4** — `voucherUrl` access semantics. Whether the URL requires auth, has an expiry, or is anonymously accessible is unverified. The adapter passes the URL through unmodified.
+- **DQ-A5** — Cancellation policy semantics. The brief defines `'NOR' | 'NRF'` only as enum values. The Hotels module treats `cancellationPolicies[]` as a list of (penalty amount, effective-from) pairs. Whether Activities returns a similar structure or only the bare class flag is unverified. The adapter exposes the class verbatim.
+
+## Method surface (for the adapter)
+
+```ts
+searchActivities(request: ActivitySearchRequest): Promise<ActivityOffer[]>;
+bookActivity(request: ActivityBookRequest): Promise<ActivityBookResponse>;
+cancelActivity(bookingReference: string): Promise<{ status: 'CANCELLED'; cancellationReference: string }>;
+```

--- a/docs/knowledge-base/transfers.md
+++ b/docs/knowledge-base/transfers.md
@@ -1,0 +1,97 @@
+# Hotelbeds Transfers API — Domain Knowledge
+
+Source: vendor brief, May 2026. This file is the authoritative domain input for the `@otaip/adapter-hotelbeds` Transfers surface. Anything missing here is captured as an open `DOMAIN_QUESTION` at the bottom — never invent.
+
+## Endpoints
+
+| Operation     | Method | Path                            |
+| ------------- | ------ | ------------------------------- |
+| Availability  | POST   | `/transfer-api/1.0/availability` |
+| Booking       | POST   | `/transfer-api/1.0/bookings`     |
+| Cancellation  | DELETE | `/transfer-api/1.0/bookings/{ref}` *(see DQ-T1)* |
+
+Base URL is the same Hotelbeds host as Hotels (`api.test.hotelbeds.com` for sandbox, `api.hotelbeds.com` for production). Path prefix is `/transfer-api/1.0`.
+
+## Auth
+
+Identical to Hotels API — `Api-key` + `X-Signature: SHA256(apiKey + secret + utcSeconds)`. Reuse `buildAuthHeaders()` from `auth.ts`.
+
+## Availability — request
+
+```json
+{
+  "language": "en",
+  "from": { "type": "IATA", "code": "BCN" },
+  "to":   { "type": "ATLAS", "code": "1234" },
+  "outbound": { "date": "2026-06-01", "time": "14:30" },
+  "adults": 2,
+  "children": 0
+}
+```
+
+- `from.type` / `to.type`: one of `'IATA' | 'ATLAS' | 'GPS'`.
+  - `IATA` — three-letter airport/station code (BCN, LHR, JFK).
+  - `ATLAS` — Hotelbeds' internal location identifier. The full code-set is not documented here; expect numeric strings.
+  - `GPS` — latitude/longitude pair encoded as `code` (format unverified — DQ-T2).
+- `outbound.time` is HH:mm in 24-hour clock. Whether this is local time at `from` or UTC is unverified — DQ-T3.
+- The brief documents one-way only (`outbound`). Round-trip / `inbound` leg is NOT in scope this session.
+
+## Availability — response shape
+
+The brief documents the OTAIP-canonical mapping (`TransferOffer[]` with vehicle types, prices, pickup info) but does NOT specify the raw Hotelbeds wire field names. The adapter's raw response type is best-effort based on the OTAIP shape. Each transfer carries:
+
+- `transferType`: `'PRIVATE' | 'SHARED' | 'LUXURY'` per brief. Hotelbeds may publish other classes; the adapter passes the raw string through and the field-mapper validates against the documented enum, falling back to the literal value if unknown.
+- `vehicleType`: free-form descriptor (e.g. "Sedan", "Minibus 8pax").
+- `maxPassengers`: integer cap.
+- `price`: per-vehicle (not per-pax). DQ-T4.
+- `pickupInfo` / `dropoffInfo`: `location` is free text; `time` for pickup is HH:mm (or ISO datetime — DQ-T5); `estimatedTime` for drop-off is similarly underspecified.
+
+## Booking — request
+
+```json
+{
+  "transferCode": "...",
+  "holder": { "name": "John", "surname": "Smith" },
+  "passengers": [{ "type": "ADULT", "name": "John", "surname": "Smith" }],
+  "clientReference": "AVR-TRF-001"
+}
+```
+
+- `passengers[].type`: `'ADULT' | 'CHILD'` per brief.
+- `transferCode` is opaque, returned in availability.
+
+## Booking — response
+
+Returns `{ bookingReference, status: 'CONFIRMED' | 'ON_REQUEST', clientReference, pickupDetails: { location, time, instructions? } }`.
+
+- `'ON_REQUEST'` semantics same as Activities — see DQ-T6.
+- `pickupDetails.instructions` free text passed through.
+
+## Cancellation
+
+The brief specifies the OTAIP method signature `cancelTransfer(bookingReference)` returning `{ status: 'CANCELLED', cancellationReference }`. The HTTP-level details (DELETE vs POST, simulate-confirm pattern) are NOT documented for Transfers — DQ-T1.
+
+## Sandbox
+
+- Same credentials as Hotels.
+- Sandbox returns synthetic results for airport→hotel routes.
+- Same daily quota.
+
+## Open DOMAIN_QUESTIONs
+
+- **DQ-T1** — Cancellation HTTP shape. Same situation as Activities. The adapter assumes `DELETE /bookings/{ref}` with no flag. Confirm against sandbox.
+- **DQ-T2** — `GPS` location code format. The brief lists `'GPS'` as a `from.type` / `to.type` value but does not document the `code` payload — comma-separated `lat,lon`? URL-encoded JSON? Unknown. The adapter passes the supplied string through verbatim; callers must format correctly until verified.
+- **DQ-T3** — `outbound.time` timezone. Local at `from` or UTC? The adapter passes through unchanged. Operators using non-IATA `from` types must confirm.
+- **DQ-T4** — Per-vehicle vs per-pax pricing. Brief implies per-vehicle but doesn't state. The adapter exposes a single `price` and treats it as the booking-line total.
+- **DQ-T5** — Pickup `time` format. HH:mm string vs full ISO datetime. The adapter passes through unchanged.
+- **DQ-T6** — `'ON_REQUEST'` confirmation flow. Same as Activities — no retrieval endpoint documented. Caller decides.
+- **DQ-T7** — Net vs selling rate. The brief uses a single `Money` price. Hotels exposes both. Whether Transfers does is unverified — the adapter currently treats the price as net.
+- **DQ-T8** — Round-trip / inbound leg. Out of scope this session. A future revision will need to model `inbound` symmetrically with `outbound`.
+
+## Method surface (for the adapter)
+
+```ts
+searchTransfers(request: TransferSearchRequest): Promise<TransferOffer[]>;
+bookTransfer(request: TransferBookRequest): Promise<TransferBookResponse>;
+cancelTransfer(bookingReference: string): Promise<{ status: 'CANCELLED'; cancellationReference: string }>;
+```

--- a/packages/adapters/hotelbeds/package.json
+++ b/packages/adapters/hotelbeds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@otaip/adapter-hotelbeds",
-  "version": "0.6.4",
-  "description": "OTAIP distribution adapter for the Hotelbeds APItude (Hotels) bedbank API",
+  "version": "0.7.0",
+  "description": "OTAIP distribution adapter for the Hotelbeds APItude APIs — Hotels, Activities, and Transfers",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/adapters/hotelbeds/src/__tests__/activities-adapter.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/activities-adapter.test.ts
@@ -1,0 +1,427 @@
+/**
+ * HotelbedsAdapter — Activities API unit tests with mocked fetch.
+ *
+ * No real network. Validates:
+ *   - Auth headers are attached (same SHA256 scheme as Hotels).
+ *   - Path is rooted at /activity-api/3.0 (not /hotel-api/1.0).
+ *   - Request body shape matches the KB spec (filters/searchFilterItems).
+ *   - Mapper output matches the canonical ActivityOffer shape.
+ *   - Error normalisation flows through the shared `request()` helper.
+ *
+ * Sandbox integration is in `activities-integration.test.ts` (env-gated).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HotelbedsAdapter } from '../hotelbeds-adapter.js';
+import type {
+  HotelbedsActivitiesAvailabilityResponse,
+  HotelbedsActivitiesBookingResponse,
+  HotelbedsActivitiesCancellationResponse,
+} from '../activities-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers — mirror the existing hotelbeds-adapter.test.ts pattern
+// ---------------------------------------------------------------------------
+
+interface RecordedCall {
+  url: string;
+  init: RequestInit;
+}
+
+function captureFetch(responses: Array<{ status: number; body: unknown }>): {
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let i = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      const r = responses[i++];
+      if (!r) throw new Error(`Unexpected fetch call #${i}: ${url}`);
+      return Promise.resolve({
+        ok: r.status >= 200 && r.status < 300,
+        status: r.status,
+        statusText: r.status === 200 ? 'OK' : 'Error',
+        json: () => Promise.resolve(r.body),
+      });
+    }),
+  );
+  return { calls };
+}
+
+const AVAIL_RESPONSE: HotelbedsActivitiesAvailabilityResponse = {
+  activities: [
+    {
+      code: 'E-A10-000100301',
+      name: 'Sagrada Família — Skip-the-Line Tour',
+      description: 'Guided tour of Gaudí’s basilica with priority entry.',
+      duration: 'PT1H30M',
+      location: { latitude: 41.4036, longitude: 2.1744 },
+      images: [{ url: 'https://example.invalid/img/sagrada-1.jpg' }, 'https://example.invalid/img/sagrada-2.jpg'],
+      cancellationPolicy: 'NOR',
+      modalities: [
+        {
+          code: 'TOUR_GUIDE|EN|1',
+          name: 'English Group Tour',
+          amount: '45.00',
+          childAmount: '20.00',
+          currency: 'EUR',
+          maxPax: 25,
+          schedule: ['09:00', '11:00', '14:00'],
+        },
+      ],
+    },
+  ],
+};
+
+const BOOKING_RESPONSE: HotelbedsActivitiesBookingResponse = {
+  booking: {
+    reference: 'HB-ACT-9001',
+    clientReference: 'AVR-ACT-001',
+    status: 'CONFIRMED',
+    voucherUrl: 'https://example.invalid/voucher/HB-ACT-9001.pdf',
+  },
+};
+
+const ON_REQUEST_BOOKING_RESPONSE: HotelbedsActivitiesBookingResponse = {
+  booking: {
+    reference: 'HB-ACT-9002',
+    clientReference: 'AVR-ACT-002',
+    status: 'ON_REQUEST',
+  },
+};
+
+const CANCELLATION_RESPONSE: HotelbedsActivitiesCancellationResponse = {
+  booking: {
+    reference: 'HB-ACT-9001',
+    cancellationReference: 'CXL-HB-ACT-9001',
+    status: 'CANCELLED',
+  },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// searchActivities
+// ---------------------------------------------------------------------------
+
+describe('HotelbedsAdapter.searchActivities', () => {
+  let adapter: HotelbedsAdapter;
+  beforeEach(() => {
+    adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
+  });
+
+  it('hits /activity-api/3.0/activities/availability with correct body shape', async () => {
+    const { calls } = captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+
+    await adapter.searchActivities({
+      destination: 'BCN',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-03',
+      paxes: { adults: 2, children: [8, 12] },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      'https://api.test.hotelbeds.com/activity-api/3.0/activities/availability',
+    );
+    expect(calls[0]!.init.method).toBe('POST');
+
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({
+      filters: {
+        searchFilterItems: [{ type: 'destination', value: 'BCN' }],
+      },
+      from: '2026-06-01',
+      to: '2026-06-03',
+      paxes: { adults: 2, children: [8, 12] },
+    });
+  });
+
+  it('attaches the same SHA256 signature headers used by the Hotels API', async () => {
+    const { calls } = captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+    await adapter.searchActivities({
+      destination: 'BCN',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-03',
+      paxes: { adults: 2 },
+    });
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers['Api-key']).toBe('test-key');
+    expect(headers['X-Signature']).toMatch(/^[a-f0-9]{64}$/);
+    expect(headers['Accept']).toBe('application/json');
+  });
+
+  it('maps the response to the canonical ActivityOffer shape', async () => {
+    captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+
+    const offers = await adapter.searchActivities({
+      destination: 'BCN',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-03',
+      paxes: { adults: 2 },
+    });
+
+    expect(offers).toHaveLength(1);
+    const offer = offers[0]!;
+    expect(offer.activityCode).toBe('E-A10-000100301');
+    expect(offer.name).toBe('Sagrada Família — Skip-the-Line Tour');
+    expect(offer.duration).toBe('PT1H30M');
+    expect(offer.cancellationPolicy).toBe('NOR');
+    expect(offer.location).toEqual({ latitude: 41.4036, longitude: 2.1744 });
+    // Both image shapes (object + string) get flattened
+    expect(offer.images).toEqual([
+      'https://example.invalid/img/sagrada-1.jpg',
+      'https://example.invalid/img/sagrada-2.jpg',
+    ]);
+    expect(offer.modalities).toHaveLength(1);
+    const m = offer.modalities[0]!;
+    expect(m.code).toBe('TOUR_GUIDE|EN|1');
+    expect(m.price).toEqual({ amount: '45.00', currency: 'EUR' });
+    expect(m.childPrice).toEqual({ amount: '20.00', currency: 'EUR' });
+    expect(m.maxPax).toBe(25);
+    expect(m.schedule).toEqual(['09:00', '11:00', '14:00']);
+  });
+
+  it('omits children when paxes.children is undefined', async () => {
+    const { calls } = captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+    await adapter.searchActivities({
+      destination: 'BCN',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-03',
+      paxes: { adults: 1 },
+    });
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.paxes).toEqual({ adults: 1 });
+    expect(body.paxes.children).toBeUndefined();
+  });
+
+  it('uppercases destination codes', async () => {
+    const { calls } = captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+    await adapter.searchActivities({
+      destination: 'bcn',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-03',
+      paxes: { adults: 1 },
+    });
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.filters.searchFilterItems[0]).toEqual({ type: 'destination', value: 'BCN' });
+  });
+
+  it('aborts pre-flight when an aborted signal is supplied', async () => {
+    captureFetch([]);
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      adapter.searchActivities({
+        destination: 'BCN',
+        dateFrom: '2026-06-01',
+        dateTo: '2026-06-03',
+        paxes: { adults: 1 },
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+  });
+
+  it('returns empty array when the response has no activities', async () => {
+    captureFetch([{ status: 200, body: { activities: [] } }]);
+    const offers = await adapter.searchActivities({
+      destination: 'XYZ',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-03',
+      paxes: { adults: 1 },
+    });
+    expect(offers).toEqual([]);
+  });
+
+  it('surfaces 429 as a rate-limit error after retries exhaust', async () => {
+    // fetchWithRetry retries 429 — every attempt must see the same response.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        json: () => Promise.resolve({ error: { message: 'Daily quota exceeded' } }),
+      }),
+    );
+    await expect(
+      adapter.searchActivities({
+        destination: 'BCN',
+        dateFrom: '2026-06-01',
+        dateTo: '2026-06-03',
+        paxes: { adults: 1 },
+      }),
+    ).rejects.toThrow(/rate limited/i);
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// bookActivity
+// ---------------------------------------------------------------------------
+
+describe('HotelbedsAdapter.bookActivity', () => {
+  let adapter: HotelbedsAdapter;
+  beforeEach(() => {
+    adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
+  });
+
+  it('posts /activities/booking with the brief-shape body', async () => {
+    const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+
+    await adapter.bookActivity({
+      activityCode: 'E-A10-000100301',
+      modalityCode: 'TOUR_GUIDE|EN|1',
+      date: '2026-06-01',
+      paxes: [{ age: 30 }, { age: 28 }],
+      holder: { name: 'John', surname: 'Smith' },
+      clientReference: 'AVR-ACT-001',
+    });
+
+    expect(calls[0]!.url).toBe(
+      'https://api.test.hotelbeds.com/activity-api/3.0/activities/booking',
+    );
+    expect(calls[0]!.init.method).toBe('POST');
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({
+      activities: [
+        {
+          activityCode: 'E-A10-000100301',
+          modalityCode: 'TOUR_GUIDE|EN|1',
+          from: '2026-06-01',
+          paxes: [{ age: 30 }, { age: 28 }],
+        },
+      ],
+      holder: { name: 'John', surname: 'Smith' },
+      clientReference: 'AVR-ACT-001',
+    });
+  });
+
+  it('returns the canonical CONFIRMED response with voucherUrl', async () => {
+    captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+    const result = await adapter.bookActivity({
+      activityCode: 'E-A10-000100301',
+      modalityCode: 'TOUR_GUIDE|EN|1',
+      date: '2026-06-01',
+      paxes: [{ age: 30 }],
+      holder: { name: 'John', surname: 'Smith' },
+      clientReference: 'AVR-ACT-001',
+    });
+    expect(result).toEqual({
+      bookingReference: 'HB-ACT-9001',
+      status: 'CONFIRMED',
+      clientReference: 'AVR-ACT-001',
+      voucherUrl: 'https://example.invalid/voucher/HB-ACT-9001.pdf',
+    });
+  });
+
+  it('preserves the ON_REQUEST status for unconfirmed bookings', async () => {
+    captureFetch([{ status: 200, body: ON_REQUEST_BOOKING_RESPONSE }]);
+    const result = await adapter.bookActivity({
+      activityCode: 'E-A10-000100301',
+      modalityCode: 'TOUR_GUIDE|EN|1',
+      date: '2026-06-01',
+      paxes: [{ age: 30 }],
+      holder: { name: 'John', surname: 'Smith' },
+      clientReference: 'AVR-ACT-002',
+    });
+    expect(result.status).toBe('ON_REQUEST');
+    expect(result.voucherUrl).toBeUndefined();
+  });
+
+  it('throws when the response has no booking object', async () => {
+    captureFetch([{ status: 200, body: {} }]);
+    await expect(
+      adapter.bookActivity({
+        activityCode: 'E-A10-000100301',
+        modalityCode: 'TOUR_GUIDE|EN|1',
+        date: '2026-06-01',
+        paxes: [{ age: 30 }],
+        holder: { name: 'John', surname: 'Smith' },
+        clientReference: 'AVR-ACT-001',
+      }),
+    ).rejects.toThrow(/no booking object/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelActivity
+// ---------------------------------------------------------------------------
+
+describe('HotelbedsAdapter.cancelActivity', () => {
+  let adapter: HotelbedsAdapter;
+  beforeEach(() => {
+    adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
+  });
+
+  it('sends DELETE /activities/booking/{ref}', async () => {
+    const { calls } = captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
+    await adapter.cancelActivity('HB-ACT-9001');
+    expect(calls[0]!.url).toBe(
+      'https://api.test.hotelbeds.com/activity-api/3.0/activities/booking/HB-ACT-9001',
+    );
+    expect(calls[0]!.init.method).toBe('DELETE');
+  });
+
+  it('returns the cancellation reference', async () => {
+    captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
+    const result = await adapter.cancelActivity('HB-ACT-9001');
+    expect(result).toEqual({
+      status: 'CANCELLED',
+      cancellationReference: 'CXL-HB-ACT-9001',
+    });
+  });
+
+  it('falls back to booking reference when cancellationReference is missing', async () => {
+    captureFetch([
+      {
+        status: 200,
+        body: { booking: { reference: 'HB-ACT-9001', status: 'CANCELLED' } },
+      },
+    ]);
+    const result = await adapter.cancelActivity('HB-ACT-9001');
+    expect(result.cancellationReference).toBe('HB-ACT-9001');
+  });
+
+  it('URL-encodes the booking reference', async () => {
+    const { calls } = captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
+    await adapter.cancelActivity('HB ACT/01');
+    expect(calls[0]!.url).toContain('HB%20ACT%2F01');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancellation policy normalisation (NRF default for unknown values)
+// ---------------------------------------------------------------------------
+
+describe('HotelbedsAdapter Activities — cancellation policy fallback', () => {
+  it('defaults unknown policy strings to NRF (safe assumption — DQ-A5)', async () => {
+    captureFetch([
+      {
+        status: 200,
+        body: {
+          activities: [
+            {
+              code: 'E-A10-000100302',
+              name: 'Mystery Tour',
+              cancellationPolicy: 'WEIRD-NEW-CODE',
+              modalities: [{ code: 'M1', amount: '10.00', currency: 'EUR' }],
+            },
+          ],
+        },
+      },
+    ]);
+    const adapter = new HotelbedsAdapter({ apiKey: 'k', secret: 's' });
+    const offers = await adapter.searchActivities({
+      destination: 'BCN',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-02',
+      paxes: { adults: 1 },
+    });
+    expect(offers[0]!.cancellationPolicy).toBe('NRF');
+  });
+});

--- a/packages/adapters/hotelbeds/src/__tests__/activities-integration.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/activities-integration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Hotelbeds Activities — sandbox integration test.
+ *
+ * Hits the REAL Hotelbeds test sandbox at https://api.test.hotelbeds.com.
+ * Auto-skips when HOTELBEDS_API_KEY / HOTELBEDS_SECRET are not set, so
+ * CI never accidentally runs it. Pattern mirrors the Hotels integration
+ * test — sequential it() blocks, shared state, afterAll cleanup.
+ *
+ * Counts toward the sandbox 50/day quota:
+ *   1. searchActivities (BCN, two-day window)
+ *   2. bookActivity (only when an activity + modality are returned)
+ *   3. cancelActivity (cleanup)
+ *
+ * Run with:
+ *   HOTELBEDS_API_KEY=... HOTELBEDS_SECRET=... HOTELBEDS_ENV=test \
+ *     pnpm exec vitest run packages/adapters/hotelbeds/src/__tests__/activities-integration.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { HotelbedsAdapter } from '../hotelbeds-adapter.js';
+import type { ActivityModality, ActivityOffer } from '../activities-types.js';
+
+const HAS_CREDENTIALS = Boolean(
+  process.env['HOTELBEDS_API_KEY'] && process.env['HOTELBEDS_SECRET'],
+);
+
+const DESTINATION = 'BCN';
+
+function isoDateOffsetDays(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+const DATE_FROM = isoDateOffsetDays(56);
+const DATE_TO = isoDateOffsetDays(58);
+
+describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Activities — sandbox integration', () => {
+  let adapter: HotelbedsAdapter;
+  let pickedActivity: ActivityOffer | null = null;
+  let pickedModality: ActivityModality | null = null;
+  let bookingRef: string | null = null;
+  let cancelled = false;
+
+  beforeAll(() => {
+    adapter = new HotelbedsAdapter();
+  });
+
+  afterAll(async () => {
+    if (bookingRef && !cancelled) {
+      try {
+        await adapter.cancelActivity(bookingRef);
+      } catch (err) {
+        console.warn(`[activities-integration] cleanup cancel failed for ${bookingRef}:`, err);
+      }
+    }
+  });
+
+  it('searchActivities returns at least one activity for a major destination', async () => {
+    const offers = await adapter.searchActivities({
+      destination: DESTINATION,
+      dateFrom: DATE_FROM,
+      dateTo: DATE_TO,
+      paxes: { adults: 2 },
+    });
+    expect(offers.length).toBeGreaterThan(0);
+    pickedActivity = offers.find((o) => o.modalities.length > 0) ?? null;
+    expect(pickedActivity, 'no activity with modalities returned').not.toBeNull();
+    pickedModality = pickedActivity!.modalities[0] ?? null;
+    expect(pickedModality, 'activity has no modalities').not.toBeNull();
+  });
+
+  it.runIf(true)('bookActivity creates a sandbox booking', async () => {
+    if (!pickedActivity || !pickedModality) {
+      console.warn('Skipping book: no candidate activity from search step');
+      return;
+    }
+    const result = await adapter.bookActivity({
+      activityCode: pickedActivity.activityCode,
+      modalityCode: pickedModality.code,
+      date: DATE_FROM,
+      paxes: [{ age: 30 }, { age: 28 }],
+      holder: { name: 'OTAIP', surname: 'Sandbox' },
+      clientReference: `OTAIP-INT-ACT-${Date.now()}`,
+    });
+    expect(result.bookingReference.length).toBeGreaterThan(0);
+    expect(['CONFIRMED', 'ON_REQUEST']).toContain(result.status);
+    bookingRef = result.bookingReference;
+  });
+
+  it('cancelActivity returns a cancellation reference', async () => {
+    if (!bookingRef) {
+      console.warn('Skipping cancel: no booking reference from book step');
+      return;
+    }
+    const result = await adapter.cancelActivity(bookingRef);
+    expect(result.status).toBe('CANCELLED');
+    expect(result.cancellationReference.length).toBeGreaterThan(0);
+    cancelled = true;
+  });
+});

--- a/packages/adapters/hotelbeds/src/__tests__/mock-activities-transfers.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/mock-activities-transfers.test.ts
@@ -1,0 +1,135 @@
+/**
+ * MockHotelbedsAdapter — Activities + Transfers in-memory behavior.
+ *
+ * No network, no fetch mocks. Verifies the mock adapter exposes the same
+ * surface as the live adapter and that book/cancel state is consistent.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { MockHotelbedsAdapter } from '../mock-hotelbeds-adapter.js';
+
+describe('MockHotelbedsAdapter — Activities', () => {
+  it('returns synthetic activities for known destinations', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    const offers = await adapter.searchActivities({
+      destination: 'BCN',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-03',
+      paxes: { adults: 2 },
+    });
+    expect(offers.length).toBeGreaterThan(0);
+    expect(offers[0]!.activityCode).toBe('E-A10-000100301');
+    expect(offers[0]!.modalities[0]!.price).toEqual({
+      amount: '45.00',
+      currency: 'EUR',
+    });
+  });
+
+  it('returns an empty array for unknown destinations', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    const offers = await adapter.searchActivities({
+      destination: 'UNK',
+      dateFrom: '2026-06-01',
+      dateTo: '2026-06-03',
+      paxes: { adults: 1 },
+    });
+    expect(offers).toEqual([]);
+  });
+
+  it('book → cancel round-trips on a deterministic reference', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    const booking = await adapter.bookActivity({
+      activityCode: 'E-A10-000100301',
+      modalityCode: 'TOUR_GUIDE|EN|1',
+      date: '2026-06-01',
+      paxes: [{ age: 30 }, { age: 28 }],
+      holder: { name: 'Ada', surname: 'Lovelace' },
+      clientReference: 'AVR-MOCK-1',
+    });
+    expect(booking.status).toBe('CONFIRMED');
+    expect(booking.bookingReference).toMatch(/^MOCK-ACT-\d{6}$/);
+
+    const cancellation = await adapter.cancelActivity(booking.bookingReference);
+    expect(cancellation.status).toBe('CANCELLED');
+    expect(cancellation.cancellationReference).toBe(`CXL-${booking.bookingReference}`);
+  });
+
+  it('cancelling an unknown reference throws', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    await expect(adapter.cancelActivity('does-not-exist')).rejects.toThrow(/unknown/);
+  });
+
+  it('rejects pre-aborted searchActivities calls', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      adapter.searchActivities({
+        destination: 'BCN',
+        dateFrom: '2026-06-01',
+        dateTo: '2026-06-02',
+        paxes: { adults: 1 },
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+  });
+
+  it('respects setAvailable(false) for activities flow', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    adapter.setAvailable(false);
+    await expect(
+      adapter.searchActivities({
+        destination: 'BCN',
+        dateFrom: '2026-06-01',
+        dateTo: '2026-06-02',
+        paxes: { adults: 1 },
+      }),
+    ).rejects.toThrow(/not available/);
+  });
+});
+
+describe('MockHotelbedsAdapter — Transfers', () => {
+  it('returns synthetic transfers keyed on the from-location', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    const offers = await adapter.searchTransfers({
+      from: { type: 'IATA', code: 'BCN' },
+      to: { type: 'ATLAS', code: '1234' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 2,
+    });
+    expect(offers.length).toBeGreaterThan(0);
+    const types = offers.map((o) => o.transferType);
+    expect(types).toContain('PRIVATE');
+    expect(types).toContain('SHARED');
+  });
+
+  it('returns empty for an unknown from-location', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    const offers = await adapter.searchTransfers({
+      from: { type: 'IATA', code: 'XYZ' },
+      to: { type: 'ATLAS', code: '0' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 1,
+    });
+    expect(offers).toEqual([]);
+  });
+
+  it('book → cancel round-trips on a deterministic reference', async () => {
+    const adapter = new MockHotelbedsAdapter();
+    const booking = await adapter.bookTransfer({
+      transferCode: 'mock-trf-BCN-private-sedan',
+      holder: { name: 'Ada', surname: 'Lovelace' },
+      passengers: [{ type: 'ADULT', name: 'Ada', surname: 'Lovelace' }],
+      clientReference: 'AVR-MOCK-T-1',
+    });
+    expect(booking.status).toBe('CONFIRMED');
+    expect(booking.bookingReference).toMatch(/^MOCK-TRF-\d{6}$/);
+    expect(booking.pickupDetails.location).toBeTruthy();
+
+    const cancellation = await adapter.cancelTransfer(booking.bookingReference);
+    expect(cancellation.status).toBe('CANCELLED');
+    expect(cancellation.cancellationReference).toBe(`CXL-${booking.bookingReference}`);
+  });
+});

--- a/packages/adapters/hotelbeds/src/__tests__/transfers-adapter.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/transfers-adapter.test.ts
@@ -1,0 +1,351 @@
+/**
+ * HotelbedsAdapter — Transfers API unit tests with mocked fetch.
+ *
+ * No real network. Validates path routing to /transfer-api/1.0, body shape
+ * (IATA/ATLAS/GPS location encoding, outbound date/time), mapper output,
+ * and abort-signal handling.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HotelbedsAdapter } from '../hotelbeds-adapter.js';
+import type {
+  HotelbedsTransfersAvailabilityResponse,
+  HotelbedsTransfersBookingResponse,
+  HotelbedsTransfersCancellationResponse,
+} from '../transfers-types.js';
+
+interface RecordedCall {
+  url: string;
+  init: RequestInit;
+}
+
+function captureFetch(responses: Array<{ status: number; body: unknown }>): {
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let i = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      const r = responses[i++];
+      if (!r) throw new Error(`Unexpected fetch call #${i}: ${url}`);
+      return Promise.resolve({
+        ok: r.status >= 200 && r.status < 300,
+        status: r.status,
+        statusText: r.status === 200 ? 'OK' : 'Error',
+        json: () => Promise.resolve(r.body),
+      });
+    }),
+  );
+  return { calls };
+}
+
+const AVAIL_RESPONSE: HotelbedsTransfersAvailabilityResponse = {
+  transfers: [
+    {
+      transferCode: 'trf-bcn-priv-sedan',
+      transferType: 'PRIVATE',
+      vehicleType: 'Sedan',
+      maxPassengers: 3,
+      amount: '54.00',
+      currency: 'EUR',
+      pickupInformation: {
+        pickup: { location: 'BCN T1 Arrivals', time: '14:30' },
+        dropoff: { location: 'Hotel Avenida Palace', estimatedTime: '15:30' },
+      },
+      cancellationPolicy: 'Free cancellation up to 48h before pickup.',
+    },
+    {
+      transferCode: 'trf-bcn-shared-shuttle',
+      transferType: 'SHARED',
+      vehicleType: 'Shuttle 8pax',
+      maxPassengers: 8,
+      amount: '12.00',
+      currency: 'EUR',
+      pickupInformation: {
+        pickup: { location: 'BCN T1 Arrivals (Shared)', time: '15:00' },
+        dropoff: { location: 'Hotel Avenida Palace', estimatedTime: '16:15' },
+      },
+      cancellationPolicy: 'Non-refundable.',
+    },
+  ],
+};
+
+const BOOKING_RESPONSE: HotelbedsTransfersBookingResponse = {
+  booking: {
+    reference: 'HB-TRF-3001',
+    clientReference: 'AVR-TRF-001',
+    status: 'CONFIRMED',
+    pickup: {
+      location: 'BCN T1 Arrivals',
+      time: '14:30',
+      instructions: 'Driver will hold a sign with passenger surname.',
+    },
+  },
+};
+
+const CANCELLATION_RESPONSE: HotelbedsTransfersCancellationResponse = {
+  booking: {
+    reference: 'HB-TRF-3001',
+    cancellationReference: 'CXL-HB-TRF-3001',
+    status: 'CANCELLED',
+  },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('HotelbedsAdapter.searchTransfers', () => {
+  let adapter: HotelbedsAdapter;
+  beforeEach(() => {
+    adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
+  });
+
+  it('hits /transfer-api/1.0/availability with the brief-shape body', async () => {
+    const { calls } = captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+
+    await adapter.searchTransfers({
+      from: { type: 'IATA', code: 'BCN' },
+      to: { type: 'ATLAS', code: '1234' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 2,
+      children: 0,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      'https://api.test.hotelbeds.com/transfer-api/1.0/availability',
+    );
+    expect(calls[0]!.init.method).toBe('POST');
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({
+      language: 'en',
+      from: { type: 'IATA', code: 'BCN' },
+      to: { type: 'ATLAS', code: '1234' },
+      outbound: { date: '2026-06-01', time: '14:30' },
+      adults: 2,
+      children: 0,
+    });
+  });
+
+  it('attaches Hotelbeds auth headers', async () => {
+    const { calls } = captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+    await adapter.searchTransfers({
+      from: { type: 'IATA', code: 'BCN' },
+      to: { type: 'ATLAS', code: '1234' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 1,
+    });
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers['Api-key']).toBe('test-key');
+    expect(headers['X-Signature']).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('omits children when undefined', async () => {
+    const { calls } = captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+    await adapter.searchTransfers({
+      from: { type: 'IATA', code: 'BCN' },
+      to: { type: 'ATLAS', code: '1234' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 2,
+    });
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.children).toBeUndefined();
+  });
+
+  it('maps the response to the canonical TransferOffer shape', async () => {
+    captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+    const offers = await adapter.searchTransfers({
+      from: { type: 'IATA', code: 'BCN' },
+      to: { type: 'ATLAS', code: '1234' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 2,
+    });
+    expect(offers).toHaveLength(2);
+
+    const first = offers[0]!;
+    expect(first.transferCode).toBe('trf-bcn-priv-sedan');
+    expect(first.transferType).toBe('PRIVATE');
+    expect(first.vehicleType).toBe('Sedan');
+    expect(first.maxPassengers).toBe(3);
+    expect(first.price).toEqual({ amount: '54.00', currency: 'EUR' });
+    expect(first.pickupInfo).toEqual({ location: 'BCN T1 Arrivals', time: '14:30' });
+    expect(first.dropoffInfo).toEqual({
+      location: 'Hotel Avenida Palace',
+      estimatedTime: '15:30',
+    });
+    expect(first.cancellationPolicy).toBe('Free cancellation up to 48h before pickup.');
+  });
+
+  it('passes through unknown transferType strings rather than coercing', async () => {
+    captureFetch([
+      {
+        status: 200,
+        body: {
+          transfers: [
+            {
+              transferCode: 'wild',
+              transferType: 'OFF_ROAD',
+              amount: '99.00',
+              currency: 'EUR',
+              maxPassengers: 4,
+              vehicleType: 'Jeep',
+              pickupInformation: {},
+              cancellationPolicy: '',
+            },
+          ],
+        },
+      },
+    ]);
+    const offers = await adapter.searchTransfers({
+      from: { type: 'IATA', code: 'BCN' },
+      to: { type: 'ATLAS', code: '1234' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 1,
+    });
+    expect(offers[0]!.transferType).toBe('OFF_ROAD');
+  });
+
+  it('aborts pre-flight when an aborted signal is supplied', async () => {
+    captureFetch([]);
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      adapter.searchTransfers({
+        from: { type: 'IATA', code: 'BCN' },
+        to: { type: 'ATLAS', code: '1234' },
+        outboundDate: '2026-06-01',
+        outboundTime: '14:30',
+        adults: 1,
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(/aborted/);
+  });
+
+  it('returns empty array when no transfers found', async () => {
+    captureFetch([{ status: 200, body: { transfers: [] } }]);
+    const offers = await adapter.searchTransfers({
+      from: { type: 'IATA', code: 'XYZ' },
+      to: { type: 'ATLAS', code: '0' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 1,
+    });
+    expect(offers).toEqual([]);
+  });
+
+  it('passes GPS-typed location codes through verbatim (DQ-T2)', async () => {
+    const { calls } = captureFetch([{ status: 200, body: AVAIL_RESPONSE }]);
+    await adapter.searchTransfers({
+      from: { type: 'GPS', code: '41.4036,2.1744' },
+      to: { type: 'ATLAS', code: '1234' },
+      outboundDate: '2026-06-01',
+      outboundTime: '14:30',
+      adults: 1,
+    });
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.from).toEqual({ type: 'GPS', code: '41.4036,2.1744' });
+  });
+});
+
+describe('HotelbedsAdapter.bookTransfer', () => {
+  let adapter: HotelbedsAdapter;
+  beforeEach(() => {
+    adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
+  });
+
+  it('posts /bookings with the brief-shape body', async () => {
+    const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+    await adapter.bookTransfer({
+      transferCode: 'trf-bcn-priv-sedan',
+      holder: { name: 'John', surname: 'Smith' },
+      passengers: [{ type: 'ADULT', name: 'John', surname: 'Smith' }],
+      clientReference: 'AVR-TRF-001',
+    });
+    expect(calls[0]!.url).toBe('https://api.test.hotelbeds.com/transfer-api/1.0/bookings');
+    expect(calls[0]!.init.method).toBe('POST');
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({
+      transferCode: 'trf-bcn-priv-sedan',
+      holder: { name: 'John', surname: 'Smith' },
+      passengers: [{ type: 'ADULT', name: 'John', surname: 'Smith' }],
+      clientReference: 'AVR-TRF-001',
+    });
+  });
+
+  it('returns the canonical CONFIRMED response with pickup details', async () => {
+    captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+    const result = await adapter.bookTransfer({
+      transferCode: 'trf-bcn-priv-sedan',
+      holder: { name: 'John', surname: 'Smith' },
+      passengers: [{ type: 'ADULT', name: 'John', surname: 'Smith' }],
+      clientReference: 'AVR-TRF-001',
+    });
+    expect(result).toEqual({
+      bookingReference: 'HB-TRF-3001',
+      status: 'CONFIRMED',
+      clientReference: 'AVR-TRF-001',
+      pickupDetails: {
+        location: 'BCN T1 Arrivals',
+        time: '14:30',
+        instructions: 'Driver will hold a sign with passenger surname.',
+      },
+    });
+  });
+
+  it('preserves the ON_REQUEST status', async () => {
+    captureFetch([
+      {
+        status: 200,
+        body: {
+          booking: {
+            reference: 'HB-TRF-3002',
+            clientReference: 'AVR-TRF-002',
+            status: 'ON_REQUEST',
+            pickup: { location: 'TBD', time: 'TBD' },
+          },
+        },
+      },
+    ]);
+    const result = await adapter.bookTransfer({
+      transferCode: 'trf-onreq',
+      holder: { name: 'Jane', surname: 'Doe' },
+      passengers: [{ type: 'ADULT', name: 'Jane', surname: 'Doe' }],
+      clientReference: 'AVR-TRF-002',
+    });
+    expect(result.status).toBe('ON_REQUEST');
+  });
+});
+
+describe('HotelbedsAdapter.cancelTransfer', () => {
+  let adapter: HotelbedsAdapter;
+  beforeEach(() => {
+    adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
+  });
+
+  it('sends DELETE /bookings/{ref}', async () => {
+    const { calls } = captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
+    await adapter.cancelTransfer('HB-TRF-3001');
+    expect(calls[0]!.url).toBe(
+      'https://api.test.hotelbeds.com/transfer-api/1.0/bookings/HB-TRF-3001',
+    );
+    expect(calls[0]!.init.method).toBe('DELETE');
+  });
+
+  it('returns the cancellation reference', async () => {
+    captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
+    const result = await adapter.cancelTransfer('HB-TRF-3001');
+    expect(result).toEqual({
+      status: 'CANCELLED',
+      cancellationReference: 'CXL-HB-TRF-3001',
+    });
+  });
+});

--- a/packages/adapters/hotelbeds/src/__tests__/transfers-integration.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/transfers-integration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Hotelbeds Transfers — sandbox integration test.
+ *
+ * Hits the REAL sandbox. Auto-skips without credentials. Counts toward
+ * the daily quota:
+ *   1. searchTransfers (BCN airport → ATLAS hotel id)
+ *   2. bookTransfer (when a candidate is returned)
+ *   3. cancelTransfer (cleanup)
+ *
+ * The `to` ATLAS code below is documented in Hotelbeds' Transfers
+ * sample — the live sandbox may reject it; if so, the test surfaces the
+ * raw error rather than masking it.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { HotelbedsAdapter } from '../hotelbeds-adapter.js';
+import type { TransferOffer } from '../transfers-types.js';
+
+const HAS_CREDENTIALS = Boolean(
+  process.env['HOTELBEDS_API_KEY'] && process.env['HOTELBEDS_SECRET'],
+);
+
+const FROM_IATA = 'BCN';
+// ATLAS code for a Barcelona hotel — placeholder; real ATLAS codes are
+// supplier-specific. Override via HOTELBEDS_TRANSFER_ATLAS_TO if needed.
+const TO_ATLAS = process.env['HOTELBEDS_TRANSFER_ATLAS_TO'] ?? '1234';
+
+function isoDateOffsetDays(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+const OUTBOUND_DATE = isoDateOffsetDays(56);
+const OUTBOUND_TIME = '14:30';
+
+describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Transfers — sandbox integration', () => {
+  let adapter: HotelbedsAdapter;
+  let pickedOffer: TransferOffer | null = null;
+  let bookingRef: string | null = null;
+  let cancelled = false;
+
+  beforeAll(() => {
+    adapter = new HotelbedsAdapter();
+  });
+
+  afterAll(async () => {
+    if (bookingRef && !cancelled) {
+      try {
+        await adapter.cancelTransfer(bookingRef);
+      } catch (err) {
+        console.warn(`[transfers-integration] cleanup cancel failed for ${bookingRef}:`, err);
+      }
+    }
+  });
+
+  it('searchTransfers returns at least one option for an airport→hotel route', async () => {
+    const offers = await adapter.searchTransfers({
+      from: { type: 'IATA', code: FROM_IATA },
+      to: { type: 'ATLAS', code: TO_ATLAS },
+      outboundDate: OUTBOUND_DATE,
+      outboundTime: OUTBOUND_TIME,
+      adults: 2,
+    });
+    if (offers.length === 0) {
+      console.warn(
+        `Sandbox returned zero transfers for ${FROM_IATA}→${TO_ATLAS} on ${OUTBOUND_DATE}; ` +
+          'override TO_ATLAS via HOTELBEDS_TRANSFER_ATLAS_TO if your sandbox uses different codes.',
+      );
+    }
+    expect(offers.length).toBeGreaterThan(0);
+    pickedOffer = offers[0]!;
+  });
+
+  it('bookTransfer creates a sandbox booking', async () => {
+    if (!pickedOffer) {
+      console.warn('Skipping book: no candidate transfer from search step');
+      return;
+    }
+    const result = await adapter.bookTransfer({
+      transferCode: pickedOffer.transferCode,
+      holder: { name: 'OTAIP', surname: 'Sandbox' },
+      passengers: [{ type: 'ADULT', name: 'OTAIP', surname: 'Sandbox' }],
+      clientReference: `OTAIP-INT-TRF-${Date.now()}`,
+    });
+    expect(result.bookingReference.length).toBeGreaterThan(0);
+    expect(['CONFIRMED', 'ON_REQUEST']).toContain(result.status);
+    bookingRef = result.bookingReference;
+  });
+
+  it('cancelTransfer returns a cancellation reference', async () => {
+    if (!bookingRef) {
+      console.warn('Skipping cancel: no booking reference from book step');
+      return;
+    }
+    const result = await adapter.cancelTransfer(bookingRef);
+    expect(result.status).toBe('CANCELLED');
+    expect(result.cancellationReference.length).toBeGreaterThan(0);
+    cancelled = true;
+  });
+});

--- a/packages/adapters/hotelbeds/src/activities-mapper.ts
+++ b/packages/adapters/hotelbeds/src/activities-mapper.ts
@@ -1,0 +1,138 @@
+/**
+ * Hotelbeds Activities — wire-to-canonical mapping.
+ *
+ * Per CLAUDE.md, no domain logic is invented. Behavioral semantics that
+ * the brief leaves open (cancellation policy details, on-request flow,
+ * voucher access) are NOT collapsed here — fields are passed through
+ * verbatim. See `docs/knowledge-base/activities.md` for open DOMAIN_QUESTIONs.
+ */
+
+import Decimal from 'decimal.js';
+
+import type {
+  ActivityBookResponse,
+  ActivityCancellationPolicy,
+  ActivityModality,
+  ActivityOffer,
+  HotelbedsActivitiesAvailabilityResponse,
+  HotelbedsActivitiesBookingResponse,
+  HotelbedsActivitiesCancellationResponse,
+  HotelbedsActivity,
+  HotelbedsActivityModality,
+} from './activities-types.js';
+import type { Money } from './shared-types.js';
+
+const KNOWN_CANCELLATION_POLICIES: ReadonlySet<ActivityCancellationPolicy> = new Set([
+  'NOR',
+  'NRF',
+]);
+
+/**
+ * Narrow Hotelbeds' free-form `cancellationPolicy` string into the
+ * documented enum. Unknown values default to non-refundable — the safer
+ * assumption when uncertain. See DQ-A5 in the KB.
+ */
+function normalizeCancellationPolicy(raw: string | undefined): ActivityCancellationPolicy {
+  if (raw && KNOWN_CANCELLATION_POLICIES.has(raw as ActivityCancellationPolicy)) {
+    return raw as ActivityCancellationPolicy;
+  }
+  // TODO: DOMAIN_QUESTION: confirm Hotelbeds Activities cancellation policy
+  // values beyond NOR/NRF. Defaulting unknown values to NRF avoids
+  // silently treating non-refundable rates as refundable.
+  return 'NRF';
+}
+
+function toNumeric(value: unknown, fallback: number): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const n = Number(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  return fallback;
+}
+
+function toMoney(amount: string | undefined, currency: string | undefined): Money {
+  // Run through Decimal to normalize "10" / "10.00" / "10.0" trailing zeros.
+  const amt = amount && amount.trim().length > 0 ? new Decimal(amount).toFixed(2) : '0.00';
+  return { amount: amt, currency: currency ?? 'EUR' };
+}
+
+function mapModality(raw: HotelbedsActivityModality, currency: string): ActivityModality {
+  const modality: ActivityModality = {
+    code: raw.code,
+    name: raw.name ?? raw.code,
+    price: toMoney(raw.amount, raw.currency ?? currency),
+    maxPax: typeof raw.maxPax === 'number' ? raw.maxPax : 0,
+  };
+  if (raw.childAmount !== undefined) {
+    modality.childPrice = toMoney(raw.childAmount, raw.currency ?? currency);
+  }
+  if (raw.schedule && raw.schedule.length > 0) {
+    modality.schedule = [...raw.schedule];
+  }
+  return modality;
+}
+
+function mapImages(images: HotelbedsActivity['images']): string[] {
+  if (!images) return [];
+  const out: string[] = [];
+  for (const item of images) {
+    if (typeof item === 'string') out.push(item);
+    else if (item && typeof item.url === 'string') out.push(item.url);
+  }
+  return out;
+}
+
+export function mapActivity(raw: HotelbedsActivity): ActivityOffer {
+  const lat = toNumeric(raw.location?.latitude, 0);
+  const lng = toNumeric(raw.location?.longitude, 0);
+  // Best-effort modality currency — first modality with a currency wins.
+  const currency = raw.modalities?.find((m) => m.currency)?.currency ?? 'EUR';
+
+  return {
+    activityCode: raw.code,
+    name: raw.name ?? raw.code,
+    description: raw.description ?? '',
+    duration: raw.duration ?? '',
+    location: { latitude: lat, longitude: lng },
+    images: mapImages(raw.images),
+    cancellationPolicy: normalizeCancellationPolicy(raw.cancellationPolicy),
+    modalities: (raw.modalities ?? []).map((m) => mapModality(m, currency)),
+  };
+}
+
+export function mapActivityAvailability(
+  response: HotelbedsActivitiesAvailabilityResponse,
+): ActivityOffer[] {
+  return (response.activities ?? []).map(mapActivity);
+}
+
+export function mapActivityBookingResponse(
+  response: HotelbedsActivitiesBookingResponse,
+): ActivityBookResponse {
+  const booking = response.booking;
+  if (!booking) {
+    throw new Error('Hotelbeds Activities booking returned no booking object');
+  }
+  const status = booking.status === 'ON_REQUEST' ? 'ON_REQUEST' : 'CONFIRMED';
+  const result: ActivityBookResponse = {
+    bookingReference: booking.reference,
+    status,
+    clientReference: booking.clientReference ?? '',
+  };
+  if (booking.voucherUrl) result.voucherUrl = booking.voucherUrl;
+  return result;
+}
+
+export function mapActivityCancellation(
+  response: HotelbedsActivitiesCancellationResponse,
+): { status: 'CANCELLED'; cancellationReference: string } {
+  const booking = response.booking;
+  if (!booking) {
+    throw new Error('Hotelbeds Activities cancellation returned no booking object');
+  }
+  return {
+    status: 'CANCELLED',
+    cancellationReference: booking.cancellationReference ?? booking.reference,
+  };
+}

--- a/packages/adapters/hotelbeds/src/activities-types.ts
+++ b/packages/adapters/hotelbeds/src/activities-types.ts
@@ -1,0 +1,179 @@
+/**
+ * Hotelbeds Activities API — types.
+ *
+ * Two layers:
+ *   - **Wire types** (`HotelbedsActivities*`) describe the JSON the API
+ *     returns. Field names are best-effort based on Hotelbeds API
+ *     conventions and the vendor brief; the adapter mapper tolerates
+ *     missing fields. See `docs/knowledge-base/activities.md` for the
+ *     authoritative source and outstanding DOMAIN_QUESTIONs.
+ *   - **Canonical types** (`Activity*`) are the OTAIP-facing shape the
+ *     adapter exports. These match the vendor brief verbatim.
+ */
+
+import type { Money } from './shared-types.js';
+
+// ---------------------------------------------------------------------------
+// Canonical (OTAIP-facing) types
+// ---------------------------------------------------------------------------
+
+export interface ActivitySearchRequest {
+  /** Hotelbeds destination code (BCN, PAR, LON, etc.). */
+  destination: string;
+  /** ISO date — first day of the activity window. */
+  dateFrom: string;
+  /** ISO date — last day of the activity window. */
+  dateTo: string;
+  /**
+   * Pax breakdown. `children` is an array of *ages*, not a count.
+   * `[8, 12]` means two children aged 8 and 12.
+   */
+  paxes: { adults: number; children?: number[] };
+  /** Optional category filter — passed through to Hotelbeds. */
+  category?: string;
+  /** Abort signal threaded through to fetch. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Cancellation policy class.
+ *
+ * `'NOR'` = refundable, `'NRF'` = non-refundable. Behavioral semantics
+ * (penalty schedule, free-cancel cutoff) are NOT documented in the vendor
+ * brief — see DQ-A5 in the KB. Adapter exposes the class verbatim.
+ */
+export type ActivityCancellationPolicy = 'NOR' | 'NRF';
+
+export interface ActivityModality {
+  code: string;
+  name: string;
+  /** Per-adult price. */
+  price: Money;
+  /** Per-child price, when published separately. */
+  childPrice?: Money;
+  maxPax: number;
+  /** Available start times for the modality. Format passed through verbatim. */
+  schedule?: string[];
+}
+
+export interface ActivityOffer {
+  activityCode: string;
+  name: string;
+  description: string;
+  modalities: ActivityModality[];
+  duration: string;
+  location: { latitude: number; longitude: number };
+  images: string[];
+  cancellationPolicy: ActivityCancellationPolicy;
+}
+
+export interface ActivityBookRequest {
+  activityCode: string;
+  modalityCode: string;
+  /** ISO date of the chosen activity slot. */
+  date: string;
+  /** One entry per pax — age is required for every passenger. */
+  paxes: Array<{ age: number }>;
+  holder: { name: string; surname: string };
+  clientReference: string;
+  signal?: AbortSignal;
+}
+
+export type ActivityBookingStatus = 'CONFIRMED' | 'ON_REQUEST';
+
+export interface ActivityBookResponse {
+  bookingReference: string;
+  status: ActivityBookingStatus;
+  clientReference: string;
+  /** Voucher URL when published by Hotelbeds. Access semantics — DQ-A4. */
+  voucherUrl?: string;
+}
+
+export interface ActivityCancelResponse {
+  status: 'CANCELLED';
+  cancellationReference: string;
+}
+
+// ---------------------------------------------------------------------------
+// Wire types — Hotelbeds Activities API responses
+//
+// Best-effort. Field names mirror Hotelbeds API conventions but the
+// authoritative shape is the live sandbox; the field-mapper tolerates
+// missing fields. See KB file for outstanding DQs.
+// ---------------------------------------------------------------------------
+
+export interface HotelbedsActivitiesAvailabilityRequest {
+  filters: {
+    searchFilterItems: Array<{ type: string; value: string }>;
+  };
+  from: string;
+  to: string;
+  paxes: {
+    adults: number;
+    children?: number[];
+  };
+  /** Optional category filter — wire field name is best-effort. */
+  category?: string;
+  language?: string;
+}
+
+export interface HotelbedsActivitiesAvailabilityResponse {
+  activities?: HotelbedsActivity[];
+  auditData?: { timestamp?: string; processTime?: string };
+}
+
+export interface HotelbedsActivity {
+  code: string;
+  name?: string;
+  /** Long-form description, often with HTML. */
+  description?: string;
+  duration?: string;
+  /** Cancellation class flag. Adapter narrows to ActivityCancellationPolicy. */
+  cancellationPolicy?: string;
+  /** Geo coordinates. Strings or numbers depending on supplier. */
+  location?: { latitude?: number | string; longitude?: number | string };
+  images?: Array<{ url?: string } | string>;
+  modalities?: HotelbedsActivityModality[];
+}
+
+export interface HotelbedsActivityModality {
+  code: string;
+  name?: string;
+  /** Per-adult net amount. String for decimal precision. */
+  amount?: string;
+  /** Per-child amount when published separately. */
+  childAmount?: string;
+  currency?: string;
+  maxPax?: number;
+  schedule?: string[];
+}
+
+export interface HotelbedsActivitiesBookingRequest {
+  activities: Array<{
+    activityCode: string;
+    modalityCode: string;
+    from: string;
+    paxes: Array<{ age: number }>;
+  }>;
+  holder: { name: string; surname: string };
+  clientReference: string;
+}
+
+export interface HotelbedsActivitiesBookingResponse {
+  booking?: {
+    reference: string;
+    clientReference?: string;
+    status?: string;
+    voucherUrl?: string;
+  };
+  auditData?: { timestamp?: string };
+}
+
+export interface HotelbedsActivitiesCancellationResponse {
+  booking?: {
+    reference: string;
+    cancellationReference?: string;
+    status?: string;
+  };
+  auditData?: { timestamp?: string };
+}

--- a/packages/adapters/hotelbeds/src/capabilities.ts
+++ b/packages/adapters/hotelbeds/src/capabilities.ts
@@ -54,3 +54,68 @@ export const hotelbedsCapabilities: LodgingChannelCapability = {
   testEnvDailyRequestLimit: 50,
   updatedAt: '2026-04-18',
 };
+
+// ---------------------------------------------------------------------------
+// Activities + Transfers capability manifests
+//
+// These are intentionally narrower than the lodging capability shape —
+// neither API has a check_rate / list_bookings step in the surface this
+// session adds. The shape is local; promote it to `@otaip/core` when more
+// adapters need a non-lodging activities/transfers manifest.
+// ---------------------------------------------------------------------------
+
+export type ActivitiesChannelKind = 'activities-bedbank';
+
+export interface ActivitiesChannelCapability {
+  channelId: string;
+  channelKind: ActivitiesChannelKind;
+  supportedMarkets: string[];
+  supportedFunctions: Array<'availability' | 'book' | 'cancel'>;
+  /** True when the channel sets retail price; Hotelbeds returns net. */
+  setsRetailPrice: false;
+  /**
+   * Whether this surface returns `'ON_REQUEST'` statuses in addition to
+   * `'CONFIRMED'`. Hotelbeds does — see DQ-A3 in the activities KB.
+   */
+  supportsOnRequest: boolean;
+  testEnvDailyRequestLimit?: number;
+  updatedAt: string;
+}
+
+export type TransfersChannelKind = 'transfers-bedbank';
+
+export interface TransfersChannelCapability {
+  channelId: string;
+  channelKind: TransfersChannelKind;
+  supportedMarkets: string[];
+  supportedFunctions: Array<'availability' | 'book' | 'cancel'>;
+  setsRetailPrice: false;
+  supportsOnRequest: boolean;
+  /** Whether the channel supports `inbound` (return-leg) — out of scope here. */
+  supportsRoundTrip: boolean;
+  testEnvDailyRequestLimit?: number;
+  updatedAt: string;
+}
+
+export const hotelbedsActivitiesCapabilities: ActivitiesChannelCapability = {
+  channelId: 'hotelbeds-activities',
+  channelKind: 'activities-bedbank',
+  supportedMarkets: ['*'],
+  supportedFunctions: ['availability', 'book', 'cancel'],
+  setsRetailPrice: false,
+  supportsOnRequest: true,
+  testEnvDailyRequestLimit: 50,
+  updatedAt: '2026-05-06',
+};
+
+export const hotelbedsTransfersCapabilities: TransfersChannelCapability = {
+  channelId: 'hotelbeds-transfers',
+  channelKind: 'transfers-bedbank',
+  supportedMarkets: ['*'],
+  supportedFunctions: ['availability', 'book', 'cancel'],
+  setsRetailPrice: false,
+  supportsOnRequest: true,
+  supportsRoundTrip: false,
+  testEnvDailyRequestLimit: 50,
+  updatedAt: '2026-05-06',
+};

--- a/packages/adapters/hotelbeds/src/hotelbeds-adapter.ts
+++ b/packages/adapters/hotelbeds/src/hotelbeds-adapter.ts
@@ -28,6 +28,16 @@ import type { RawHotelResult } from '@otaip/agents-lodging';
 
 import { buildAuthHeaders, type HotelbedsCredentials } from './auth.js';
 import { mapHotelToRawResult, summarizeBooking, type BookingSummary } from './field-mapper.js';
+import {
+  mapActivityAvailability,
+  mapActivityBookingResponse,
+  mapActivityCancellation,
+} from './activities-mapper.js';
+import {
+  mapTransferAvailability,
+  mapTransferBookingResponse,
+  mapTransferCancellation,
+} from './transfers-mapper.js';
 import type {
   HotelbedsAdapterConfig,
   HotelbedsAvailabilityRequest,
@@ -43,9 +53,45 @@ import type {
   HotelbedsErrorResponse,
 } from './types.js';
 import { HOTELBEDS_BASE_URLS } from './types.js';
+import type {
+  ActivityBookRequest,
+  ActivityBookResponse,
+  ActivityCancelResponse,
+  ActivityOffer,
+  ActivitySearchRequest,
+  HotelbedsActivitiesAvailabilityRequest,
+  HotelbedsActivitiesAvailabilityResponse,
+  HotelbedsActivitiesBookingRequest,
+  HotelbedsActivitiesBookingResponse,
+  HotelbedsActivitiesCancellationResponse,
+} from './activities-types.js';
+import type {
+  HotelbedsTransfersAvailabilityRequest,
+  HotelbedsTransfersAvailabilityResponse,
+  HotelbedsTransfersBookingRequest,
+  HotelbedsTransfersBookingResponse,
+  HotelbedsTransfersCancellationResponse,
+  TransferBookRequest,
+  TransferBookResponse,
+  TransferCancelResponse,
+  TransferOffer,
+  TransferSearchRequest,
+} from './transfers-types.js';
 import type { HotelSearchParams, HotelSourceAdapter } from './lodging-source-interface.js';
 
 const HOTELS_BASE_PATH = '/hotel-api/1.0';
+const ACTIVITIES_BASE_PATH = '/activity-api/3.0';
+const TRANSFERS_BASE_PATH = '/transfer-api/1.0';
+
+interface RequestOptions {
+  /**
+   * Caller-supplied abort signal. Checked BEFORE issuing the request — once
+   * fetch is in flight the per-attempt timeout controller in `fetchWithRetry`
+   * owns cancellation. Wiring caller-cancel through to in-flight requests
+   * needs an upstream change to `@otaip/core` and is tracked as future work.
+   */
+  signal?: AbortSignal;
+}
 
 /**
  * The `HotelSourceAdapter` interface lives in `@otaip/agents-lodging`. We
@@ -213,6 +259,127 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
   }
 
   // -------------------------------------------------------------------------
+  // Activities API — search / book / cancel
+  //
+  // Endpoints under /activity-api/3.0. Auth and retry policy are inherited
+  // from the shared `request()` helper. See
+  // `docs/knowledge-base/activities.md` for the authoritative domain input
+  // and outstanding DOMAIN_QUESTIONs.
+  // -------------------------------------------------------------------------
+
+  async searchActivities(request: ActivitySearchRequest): Promise<ActivityOffer[]> {
+    const body: HotelbedsActivitiesAvailabilityRequest = {
+      filters: {
+        searchFilterItems: [{ type: 'destination', value: request.destination.toUpperCase() }],
+      },
+      from: request.dateFrom,
+      to: request.dateTo,
+      paxes: {
+        adults: request.paxes.adults,
+        ...(request.paxes.children ? { children: request.paxes.children } : {}),
+      },
+      ...(request.category ? { category: request.category } : {}),
+    };
+    const response = (await this.request(
+      'POST',
+      `${ACTIVITIES_BASE_PATH}/activities/availability`,
+      body,
+      request.signal ? { signal: request.signal } : {},
+    )) as HotelbedsActivitiesAvailabilityResponse;
+    return mapActivityAvailability(response);
+  }
+
+  async bookActivity(request: ActivityBookRequest): Promise<ActivityBookResponse> {
+    const body: HotelbedsActivitiesBookingRequest = {
+      activities: [
+        {
+          activityCode: request.activityCode,
+          modalityCode: request.modalityCode,
+          from: request.date,
+          paxes: request.paxes,
+        },
+      ],
+      holder: request.holder,
+      clientReference: request.clientReference,
+    };
+    const response = (await this.request(
+      'POST',
+      `${ACTIVITIES_BASE_PATH}/activities/booking`,
+      body,
+      request.signal ? { signal: request.signal } : {},
+    )) as HotelbedsActivitiesBookingResponse;
+    return mapActivityBookingResponse(response);
+  }
+
+  /**
+   * Cancel an activity booking. The HTTP shape (DELETE vs POST,
+   * SIMULATION/CANCELLATION two-step) is not fully documented for
+   * Activities — see DQ-A1 in the KB. The adapter assumes
+   * `DELETE /activity-api/3.0/activities/booking/{ref}`. Update once
+   * verified against the live sandbox.
+   */
+  async cancelActivity(bookingReference: string): Promise<ActivityCancelResponse> {
+    const response = (await this.request(
+      'DELETE',
+      `${ACTIVITIES_BASE_PATH}/activities/booking/${encodeURIComponent(bookingReference)}`,
+    )) as HotelbedsActivitiesCancellationResponse;
+    return mapActivityCancellation(response);
+  }
+
+  // -------------------------------------------------------------------------
+  // Transfers API — search / book / cancel
+  //
+  // Endpoints under /transfer-api/1.0. See
+  // `docs/knowledge-base/transfers.md` for outstanding DOMAIN_QUESTIONs
+  // (location code formats, timezone semantics, vehicle taxonomy).
+  // -------------------------------------------------------------------------
+
+  async searchTransfers(request: TransferSearchRequest): Promise<TransferOffer[]> {
+    const body: HotelbedsTransfersAvailabilityRequest = {
+      language: 'en',
+      from: { type: request.from.type, code: request.from.code },
+      to: { type: request.to.type, code: request.to.code },
+      outbound: { date: request.outboundDate, time: request.outboundTime },
+      adults: request.adults,
+      ...(request.children !== undefined ? { children: request.children } : {}),
+    };
+    const response = (await this.request(
+      'POST',
+      `${TRANSFERS_BASE_PATH}/availability`,
+      body,
+      request.signal ? { signal: request.signal } : {},
+    )) as HotelbedsTransfersAvailabilityResponse;
+    return mapTransferAvailability(response);
+  }
+
+  async bookTransfer(request: TransferBookRequest): Promise<TransferBookResponse> {
+    const body: HotelbedsTransfersBookingRequest = {
+      transferCode: request.transferCode,
+      holder: request.holder,
+      passengers: request.passengers,
+      clientReference: request.clientReference,
+    };
+    const response = (await this.request(
+      'POST',
+      `${TRANSFERS_BASE_PATH}/bookings`,
+      body,
+      request.signal ? { signal: request.signal } : {},
+    )) as HotelbedsTransfersBookingResponse;
+    return mapTransferBookingResponse(response);
+  }
+
+  /**
+   * Cancel a transfer booking. Same caveat as `cancelActivity` — DQ-T1.
+   */
+  async cancelTransfer(bookingReference: string): Promise<TransferCancelResponse> {
+    const response = (await this.request(
+      'DELETE',
+      `${TRANSFERS_BASE_PATH}/bookings/${encodeURIComponent(bookingReference)}`,
+    )) as HotelbedsTransfersCancellationResponse;
+    return mapTransferCancellation(response);
+  }
+
+  // -------------------------------------------------------------------------
   // Convenience helpers — mapped output
   // -------------------------------------------------------------------------
 
@@ -244,7 +411,15 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
   // Low-level request
   // -------------------------------------------------------------------------
 
-  private async request(method: string, path: string, body?: unknown): Promise<unknown> {
+  private async request(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: RequestOptions = {},
+  ): Promise<unknown> {
+    if (options.signal?.aborted) {
+      throw new Error('Hotelbeds API request aborted before dispatch');
+    }
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = {
       ...buildAuthHeaders(this.credentials),

--- a/packages/adapters/hotelbeds/src/index.ts
+++ b/packages/adapters/hotelbeds/src/index.ts
@@ -1,7 +1,18 @@
 export { HotelbedsAdapter } from './hotelbeds-adapter.js';
 export { MockHotelbedsAdapter } from './mock-hotelbeds-adapter.js';
-export { hotelbedsCapabilities } from './capabilities.js';
-export type { LodgingChannelCapability, LodgingChannelKind } from './capabilities.js';
+export {
+  hotelbedsCapabilities,
+  hotelbedsActivitiesCapabilities,
+  hotelbedsTransfersCapabilities,
+} from './capabilities.js';
+export type {
+  LodgingChannelCapability,
+  LodgingChannelKind,
+  ActivitiesChannelCapability,
+  ActivitiesChannelKind,
+  TransfersChannelCapability,
+  TransfersChannelKind,
+} from './capabilities.js';
 
 export { signRequest, buildAuthHeaders } from './auth.js';
 export type { HotelbedsCredentials } from './auth.js';
@@ -22,6 +33,61 @@ export type { BookingSummary, MapHotelOptions } from './field-mapper.js';
 export type { HotelSearchParams, HotelSourceAdapter } from './lodging-source-interface.js';
 
 export { HOTELBEDS_BASE_URLS } from './types.js';
+
+// Activities + Transfers — mappers
+export {
+  mapActivity,
+  mapActivityAvailability,
+  mapActivityBookingResponse,
+  mapActivityCancellation,
+} from './activities-mapper.js';
+export {
+  mapTransfer,
+  mapTransferAvailability,
+  mapTransferBookingResponse,
+  mapTransferCancellation,
+} from './transfers-mapper.js';
+
+// Activities — types
+export type {
+  ActivitySearchRequest,
+  ActivityOffer,
+  ActivityModality,
+  ActivityCancellationPolicy,
+  ActivityBookRequest,
+  ActivityBookResponse,
+  ActivityBookingStatus,
+  ActivityCancelResponse,
+  HotelbedsActivity,
+  HotelbedsActivityModality,
+  HotelbedsActivitiesAvailabilityRequest,
+  HotelbedsActivitiesAvailabilityResponse,
+  HotelbedsActivitiesBookingRequest,
+  HotelbedsActivitiesBookingResponse,
+  HotelbedsActivitiesCancellationResponse,
+} from './activities-types.js';
+
+// Transfers — types
+export type {
+  TransferSearchRequest,
+  TransferLocation,
+  TransferLocationType,
+  TransferOffer,
+  TransferType,
+  TransferBookRequest,
+  TransferBookResponse,
+  TransferBookingStatus,
+  TransferCancelResponse,
+  HotelbedsTransfer,
+  HotelbedsTransfersAvailabilityRequest,
+  HotelbedsTransfersAvailabilityResponse,
+  HotelbedsTransfersBookingRequest,
+  HotelbedsTransfersBookingResponse,
+  HotelbedsTransfersCancellationResponse,
+} from './transfers-types.js';
+
+// Shared
+export type { Money } from './shared-types.js';
 export type {
   HotelbedsAdapterConfig,
   HotelbedsEnvironment,

--- a/packages/adapters/hotelbeds/src/mock-hotelbeds-adapter.ts
+++ b/packages/adapters/hotelbeds/src/mock-hotelbeds-adapter.ts
@@ -27,6 +27,20 @@ import type {
   HotelbedsHotel,
   HotelbedsRate,
 } from './types.js';
+import type {
+  ActivityBookRequest,
+  ActivityBookResponse,
+  ActivityCancelResponse,
+  ActivityOffer,
+  ActivitySearchRequest,
+} from './activities-types.js';
+import type {
+  TransferBookRequest,
+  TransferBookResponse,
+  TransferCancelResponse,
+  TransferOffer,
+  TransferSearchRequest,
+} from './transfers-types.js';
 import type { HotelSearchParams, HotelSourceAdapter } from './lodging-source-interface.js';
 import type { RawHotelResult } from '@otaip/agents-lodging';
 
@@ -109,6 +123,69 @@ const RECHECK_REPRICED: Record<string, HotelbedsRate> = {
 };
 
 // ---------------------------------------------------------------------------
+// Activities + Transfers fixtures
+//
+// Synthetic data only — exercises the canonical types the field-mappers
+// produce. Real shape comes from the live sandbox; see KB files.
+// ---------------------------------------------------------------------------
+
+const ACTIVITIES_BY_DESTINATION: Record<string, ActivityOffer[]> = {
+  BCN: [
+    {
+      activityCode: 'E-A10-000100301',
+      name: 'Sagrada Família — Skip-the-Line Tour',
+      description: 'Guided tour of Gaudí’s basilica with priority entry.',
+      duration: 'PT1H30M',
+      location: { latitude: 41.4036, longitude: 2.1744 },
+      images: ['https://example.invalid/img/sagrada-1.jpg'],
+      cancellationPolicy: 'NOR',
+      modalities: [
+        {
+          code: 'TOUR_GUIDE|EN|1',
+          name: 'English Group Tour',
+          price: { amount: '45.00', currency: 'EUR' },
+          childPrice: { amount: '20.00', currency: 'EUR' },
+          maxPax: 25,
+          schedule: ['09:00', '11:00', '14:00'],
+        },
+        {
+          code: 'TOUR_PRIVATE|EN|1',
+          name: 'English Private Tour',
+          price: { amount: '180.00', currency: 'EUR' },
+          maxPax: 6,
+        },
+      ],
+    },
+  ],
+};
+
+const TRANSFERS_BY_FROM: Record<string, TransferOffer[]> = {
+  // Keyed by `${type}:${code}` for the `from` location.
+  'IATA:BCN': [
+    {
+      transferCode: 'mock-trf-BCN-private-sedan',
+      transferType: 'PRIVATE',
+      vehicleType: 'Sedan',
+      maxPassengers: 3,
+      price: { amount: '54.00', currency: 'EUR' },
+      pickupInfo: { location: 'BCN T1 Arrivals', time: '14:30' },
+      dropoffInfo: { location: 'Hotel Avenida Palace', estimatedTime: '15:30' },
+      cancellationPolicy: 'Free cancellation up to 48h before pickup.',
+    },
+    {
+      transferCode: 'mock-trf-BCN-shared-shuttle',
+      transferType: 'SHARED',
+      vehicleType: 'Shuttle Van 8pax',
+      maxPassengers: 8,
+      price: { amount: '12.00', currency: 'EUR' },
+      pickupInfo: { location: 'BCN T1 Arrivals (Shared)', time: '15:00' },
+      dropoffInfo: { location: 'Hotel Avenida Palace', estimatedTime: '16:15' },
+      cancellationPolicy: 'Non-refundable.',
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
 // Mock adapter
 // ---------------------------------------------------------------------------
 
@@ -118,7 +195,11 @@ export class MockHotelbedsAdapter implements HotelSourceAdapter {
 
   private available = true;
   private readonly bookings = new Map<string, HotelbedsBooking>();
+  private readonly activityBookings = new Map<string, ActivityBookResponse>();
+  private readonly transferBookings = new Map<string, TransferBookResponse>();
   private nextRef = 1;
+  private nextActivityRef = 1;
+  private nextTransferRef = 1;
 
   setAvailable(available: boolean): void {
     this.available = available;
@@ -245,6 +326,95 @@ export class MockHotelbedsAdapter implements HotelSourceAdapter {
     this.bookings.set(reference, cancelled);
     return { booking: cancelled };
   }
+
+  // -------------------------------------------------------------------------
+  // Activities API
+  // -------------------------------------------------------------------------
+
+  async searchActivities(request: ActivitySearchRequest): Promise<ActivityOffer[]> {
+    this.assertAvailable();
+    if (request.signal?.aborted) {
+      throw new Error('Hotelbeds (mock) searchActivities aborted before dispatch');
+    }
+    return ACTIVITIES_BY_DESTINATION[request.destination.toUpperCase()] ?? [];
+  }
+
+  async bookActivity(request: ActivityBookRequest): Promise<ActivityBookResponse> {
+    this.assertAvailable();
+    if (request.signal?.aborted) {
+      throw new Error('Hotelbeds (mock) bookActivity aborted before dispatch');
+    }
+    const reference = `MOCK-ACT-${String(this.nextActivityRef++).padStart(6, '0')}`;
+    const result: ActivityBookResponse = {
+      bookingReference: reference,
+      status: 'CONFIRMED',
+      clientReference: request.clientReference,
+      voucherUrl: `https://example.invalid/voucher/${reference}.pdf`,
+    };
+    this.activityBookings.set(reference, result);
+    return result;
+  }
+
+  async cancelActivity(bookingReference: string): Promise<ActivityCancelResponse> {
+    this.assertAvailable();
+    const booking = this.activityBookings.get(bookingReference);
+    if (!booking) {
+      throw new Error(`Hotelbeds (mock) cancelActivity: unknown reference ${bookingReference}`);
+    }
+    this.activityBookings.delete(bookingReference);
+    return {
+      status: 'CANCELLED',
+      cancellationReference: `CXL-${bookingReference}`,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Transfers API
+  // -------------------------------------------------------------------------
+
+  async searchTransfers(request: TransferSearchRequest): Promise<TransferOffer[]> {
+    this.assertAvailable();
+    if (request.signal?.aborted) {
+      throw new Error('Hotelbeds (mock) searchTransfers aborted before dispatch');
+    }
+    const key = `${request.from.type}:${request.from.code.toUpperCase()}`;
+    return TRANSFERS_BY_FROM[key] ?? [];
+  }
+
+  async bookTransfer(request: TransferBookRequest): Promise<TransferBookResponse> {
+    this.assertAvailable();
+    if (request.signal?.aborted) {
+      throw new Error('Hotelbeds (mock) bookTransfer aborted before dispatch');
+    }
+    const reference = `MOCK-TRF-${String(this.nextTransferRef++).padStart(6, '0')}`;
+    const result: TransferBookResponse = {
+      bookingReference: reference,
+      status: 'CONFIRMED',
+      clientReference: request.clientReference,
+      pickupDetails: {
+        location: 'BCN T1 Arrivals',
+        time: '14:30',
+        instructions: 'Driver will meet you at the meeting point with a sign.',
+      },
+    };
+    this.transferBookings.set(reference, result);
+    return result;
+  }
+
+  async cancelTransfer(bookingReference: string): Promise<TransferCancelResponse> {
+    this.assertAvailable();
+    const booking = this.transferBookings.get(bookingReference);
+    if (!booking) {
+      throw new Error(`Hotelbeds (mock) cancelTransfer: unknown reference ${bookingReference}`);
+    }
+    this.transferBookings.delete(bookingReference);
+    return {
+      status: 'CANCELLED',
+      cancellationReference: `CXL-${bookingReference}`,
+    };
+  }
+
+  // -------------------------------------------------------------------------
 
   async availabilityRawResults(
     request: HotelbedsAvailabilityRequest,

--- a/packages/adapters/hotelbeds/src/shared-types.ts
+++ b/packages/adapters/hotelbeds/src/shared-types.ts
@@ -1,0 +1,15 @@
+/**
+ * Cross-cutting types shared by the Activities and Transfers surfaces.
+ *
+ * The Hotels surface uses `string` amount fields directly (decimal precision
+ * via decimal.js inside the field-mapper). Activities and Transfers expose
+ * a richer canonical `Money` shape because the brief's interface includes
+ * a typed `price: Money` on the public surface.
+ */
+
+export interface Money {
+  /** Decimal string — never parsed to Number. */
+  amount: string;
+  /** ISO 4217 currency code. */
+  currency: string;
+}

--- a/packages/adapters/hotelbeds/src/transfers-mapper.ts
+++ b/packages/adapters/hotelbeds/src/transfers-mapper.ts
@@ -1,0 +1,97 @@
+/**
+ * Hotelbeds Transfers — wire-to-canonical mapping.
+ *
+ * Per CLAUDE.md, no domain logic is invented. See
+ * `docs/knowledge-base/transfers.md` for outstanding DOMAIN_QUESTIONs
+ * (location code formats, timezone semantics, vehicle taxonomy).
+ */
+
+import Decimal from 'decimal.js';
+
+import type {
+  HotelbedsTransfer,
+  HotelbedsTransfersAvailabilityResponse,
+  HotelbedsTransfersBookingResponse,
+  HotelbedsTransfersCancellationResponse,
+  TransferBookResponse,
+  TransferOffer,
+  TransferType,
+} from './transfers-types.js';
+import type { Money } from './shared-types.js';
+
+const KNOWN_TRANSFER_TYPES: ReadonlySet<TransferType> = new Set(['PRIVATE', 'SHARED', 'LUXURY']);
+
+function toMoney(amount: string | undefined, currency: string | undefined): Money {
+  const amt = amount && amount.trim().length > 0 ? new Decimal(amount).toFixed(2) : '0.00';
+  return { amount: amt, currency: currency ?? 'EUR' };
+}
+
+export function mapTransfer(raw: HotelbedsTransfer): TransferOffer {
+  // Pass the raw transferType through unchanged when not in the documented
+  // set — preserves fidelity at the cost of a slightly wider TS type.
+  const transferType: TransferType | string =
+    raw.transferType && KNOWN_TRANSFER_TYPES.has(raw.transferType as TransferType)
+      ? (raw.transferType as TransferType)
+      : (raw.transferType ?? 'PRIVATE');
+
+  const pickup = raw.pickupInformation?.pickup;
+  const dropoff = raw.pickupInformation?.dropoff;
+
+  return {
+    transferCode: raw.transferCode ?? '',
+    transferType,
+    vehicleType: raw.vehicleType ?? '',
+    maxPassengers: typeof raw.maxPassengers === 'number' ? raw.maxPassengers : 0,
+    price: toMoney(raw.amount, raw.currency),
+    pickupInfo: {
+      location: pickup?.location ?? '',
+      time: pickup?.time ?? '',
+    },
+    dropoffInfo: {
+      location: dropoff?.location ?? '',
+      estimatedTime: dropoff?.estimatedTime ?? '',
+    },
+    cancellationPolicy: raw.cancellationPolicy ?? '',
+  };
+}
+
+export function mapTransferAvailability(
+  response: HotelbedsTransfersAvailabilityResponse,
+): TransferOffer[] {
+  return (response.transfers ?? []).map(mapTransfer);
+}
+
+export function mapTransferBookingResponse(
+  response: HotelbedsTransfersBookingResponse,
+): TransferBookResponse {
+  const booking = response.booking;
+  if (!booking) {
+    throw new Error('Hotelbeds Transfers booking returned no booking object');
+  }
+  const status = booking.status === 'ON_REQUEST' ? 'ON_REQUEST' : 'CONFIRMED';
+  const pickup = booking.pickup ?? {};
+  const result: TransferBookResponse = {
+    bookingReference: booking.reference,
+    status,
+    clientReference: booking.clientReference ?? '',
+    pickupDetails: {
+      location: pickup.location ?? '',
+      time: pickup.time ?? '',
+    },
+  };
+  if (pickup.instructions) result.pickupDetails.instructions = pickup.instructions;
+  return result;
+}
+
+export function mapTransferCancellation(
+  response: HotelbedsTransfersCancellationResponse,
+): { status: 'CANCELLED'; cancellationReference: string } {
+  const booking = response.booking;
+  if (!booking) {
+    throw new Error('Hotelbeds Transfers cancellation returned no booking object');
+  }
+  return {
+    status: 'CANCELLED',
+    cancellationReference: booking.cancellationReference ?? booking.reference,
+  };
+}

--- a/packages/adapters/hotelbeds/src/transfers-types.ts
+++ b/packages/adapters/hotelbeds/src/transfers-types.ts
@@ -1,0 +1,146 @@
+/**
+ * Hotelbeds Transfers API — types.
+ *
+ * Same two-layer split as the Activities module: wire types describe the
+ * Hotelbeds JSON; canonical types are the OTAIP-facing shape from the
+ * vendor brief. See `docs/knowledge-base/transfers.md` for outstanding
+ * DOMAIN_QUESTIONs (location code formats, timezone semantics, etc.).
+ */
+
+import type { Money } from './shared-types.js';
+
+// ---------------------------------------------------------------------------
+// Canonical (OTAIP-facing) types
+// ---------------------------------------------------------------------------
+
+export type TransferLocationType = 'IATA' | 'ATLAS' | 'GPS';
+
+export interface TransferLocation {
+  type: TransferLocationType;
+  /**
+   * Location code. Format depends on `type`:
+   *   - IATA — three-letter airport/station code.
+   *   - ATLAS — Hotelbeds internal numeric identifier (string).
+   *   - GPS — latitude/longitude payload — see DQ-T2 in KB.
+   */
+  code: string;
+}
+
+export interface TransferSearchRequest {
+  from: TransferLocation;
+  to: TransferLocation;
+  /** ISO date for the outbound leg. */
+  outboundDate: string;
+  /** HH:mm 24-hour clock. Timezone — see DQ-T3 in KB. */
+  outboundTime: string;
+  adults: number;
+  children?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Documented transfer classes. Hotelbeds may publish other values; the
+ * adapter mapper passes the raw string through and exposes it as
+ * `TransferType | string` so callers can branch on the documented set
+ * without losing fidelity.
+ */
+export type TransferType = 'PRIVATE' | 'SHARED' | 'LUXURY';
+
+export interface TransferOffer {
+  transferCode: string;
+  /** Documented enum or raw supplier value when unknown. */
+  transferType: TransferType | string;
+  /** Free-form vehicle descriptor — e.g. "Sedan", "Minibus 8pax". */
+  vehicleType: string;
+  maxPassengers: number;
+  /** Per-vehicle price — see DQ-T4 in KB. */
+  price: Money;
+  pickupInfo: { location: string; time: string };
+  dropoffInfo: { location: string; estimatedTime: string };
+  /** Free-text cancellation policy. Structured penalties are not modeled. */
+  cancellationPolicy: string;
+}
+
+export interface TransferBookRequest {
+  transferCode: string;
+  holder: { name: string; surname: string };
+  passengers: Array<{ type: 'ADULT' | 'CHILD'; name: string; surname: string }>;
+  clientReference: string;
+  signal?: AbortSignal;
+}
+
+export type TransferBookingStatus = 'CONFIRMED' | 'ON_REQUEST';
+
+export interface TransferBookResponse {
+  bookingReference: string;
+  status: TransferBookingStatus;
+  clientReference: string;
+  pickupDetails: { location: string; time: string; instructions?: string };
+}
+
+export interface TransferCancelResponse {
+  status: 'CANCELLED';
+  cancellationReference: string;
+}
+
+// ---------------------------------------------------------------------------
+// Wire types — Hotelbeds Transfers API
+// ---------------------------------------------------------------------------
+
+export interface HotelbedsTransfersAvailabilityRequest {
+  language?: string;
+  from: { type: TransferLocationType; code: string };
+  to: { type: TransferLocationType; code: string };
+  outbound: { date: string; time: string };
+  inbound?: { date: string; time: string };
+  adults: number;
+  children?: number;
+}
+
+export interface HotelbedsTransfersAvailabilityResponse {
+  transfers?: HotelbedsTransfer[];
+  auditData?: { timestamp?: string };
+}
+
+export interface HotelbedsTransfer {
+  /** Opaque booking key returned in availability and consumed by /bookings. */
+  transferCode?: string;
+  /** Documented set: PRIVATE | SHARED | LUXURY. */
+  transferType?: string;
+  vehicleType?: string;
+  maxPassengers?: number;
+  /** Per-vehicle net amount as decimal string. */
+  amount?: string;
+  currency?: string;
+  pickupInformation?: {
+    pickup?: { location?: string; time?: string };
+    dropoff?: { location?: string; estimatedTime?: string };
+  };
+  cancellationPolicy?: string;
+}
+
+export interface HotelbedsTransfersBookingRequest {
+  transferCode: string;
+  holder: { name: string; surname: string };
+  passengers: Array<{ type: 'ADULT' | 'CHILD'; name: string; surname: string }>;
+  clientReference: string;
+}
+
+export interface HotelbedsTransfersBookingResponse {
+  booking?: {
+    reference: string;
+    clientReference?: string;
+    status?: string;
+    pickup?: { location?: string; time?: string; instructions?: string };
+  };
+  auditData?: { timestamp?: string };
+}
+
+export interface HotelbedsTransfersCancellationResponse {
+  booking?: {
+    reference: string;
+    cancellationReference?: string;
+    status?: string;
+  };
+  auditData?: { timestamp?: string };
+}


### PR DESCRIPTION
## Summary

- New methods on `HotelbedsAdapter` for both Activities (`/activity-api/3.0`) and Transfers (`/transfer-api/1.0`) — `search*`, `book*`, `cancel*`. Same SHA256 auth, same credentials, same sandbox.
- Captures the vendor brief verbatim into `docs/knowledge-base/activities.md` and `docs/knowledge-base/transfers.md` with every gap surfaced as an explicit `DQ-*` open question. Implementation never invents domain behavior — falls back to the safe choice (e.g. unknown `cancellationPolicy` → `NRF`) and leaves the rest as `TODO: DOMAIN_QUESTION`.
- `request()` helper now accepts an optional `AbortSignal` (pre-flight only; in-flight cancel needs an upstream change to `fetchWithRetry`).
- Bumps to `v0.7.0`.

## Why a single adapter class

Hotelbeds models Hotels / Activities / Transfers as one account with one auth scheme. Splitting into three packages would force callers to juggle three clients for one credential set. The methods live on the same class; only the base path changes.

## Open DOMAIN_QUESTIONs (carried in the KB files)

Activities — DQ-A1 cancel HTTP shape, A2 net vs selling rate fields, A3 ON_REQUEST flow, A4 voucherUrl access, A5 cancellation policy semantics.

Transfers — DQ-T1 cancel shape, T2 GPS code format, T3 outbound time TZ, T4 per-vehicle vs per-pax pricing, T5 pickup time format, T6 ON_REQUEST flow, T7 net vs selling rate, T8 round-trip / inbound leg.

The sandbox integration tests are designed to validate these once credentials are available — auto-skip in CI.

## Test plan

- [x] `pnpm exec vitest run packages/adapters/hotelbeds` — 100 passed / 14 skipped (sandbox-gated).
- [x] `pnpm -r typecheck` — clean.
- [x] `pnpm exec eslint --ext .ts packages/adapters/hotelbeds/src` — clean.
- [ ] Manual: with `HOTELBEDS_API_KEY` / `HOTELBEDS_SECRET` set, run the activities + transfers integration test files; confirm DQ-A1 / DQ-T1 cancel shape against the live sandbox and update the adapter if needed.
- [ ] Publish: pipeline-driven once merged (no `pnpm publish` from this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)