### PR TITLE
chore(release): v0.7.0 — re-sync workspace + Reference OTA hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,48 @@
 # Changelog
 
-> **Versioning policy:** Pre-v1.0, every release is a patch bump (`0.6.0 → 0.6.1 → 0.6.2 → …`). See [VERSIONING.md](VERSIONING.md) for the full policy and an explanation of the early-history version jumps (0.3.4 → 0.5.0 → 0.5.1 → 0.6.0) that predate this rule.
+> **Versioning policy:** Pre-v1.0, every release is a patch bump (`0.6.0 → 0.6.1 → 0.6.2 → …`). See [VERSIONING.md](VERSIONING.md) for the full policy and an explanation of the early-history version jumps (0.3.4 → 0.5.0 → 0.5.1 → 0.6.0) that predate this rule. v0.6.4 → v0.7.0 is the one post-policy exception — see VERSIONING.md.
+
+## 0.7.0 — Reference OTA hardening + Hotelbeds Activities/Transfers
+
+Re-sync release. `@otaip/adapter-hotelbeds@0.7.0` shipped as a single-package minor bump in [#90](https://github.com/telivity-otaip/otaip/pull/90) ahead of the repo-wide release; this PR aligns root + every other workspace package with that version so the GitHub front page, npm, and `package.json` files all agree. Per-package, the only API surface change since v0.6.4 lives in `@otaip/adapter-hotelbeds`. The rest of the work in this window targeted the reference OTA — see below.
+
+### `@otaip/adapter-hotelbeds` — Activities + Transfers ([#90](https://github.com/telivity-otaip/otaip/pull/90))
+
+`HotelbedsAdapter` now spans the full APItude product family. New direct methods on the same class:
+
+- **Activities** (`/activity-api/3.0`) — `searchActivities`, `bookActivity`, `cancelActivity`. Cancellation policy narrows to `'NOR' | 'NRF'`; unknown values default to `'NRF'` per DQ-A5.
+- **Transfers** (`/transfer-api/1.0`) — `searchTransfers`, `bookTransfer`, `cancelTransfer`. Unknown `transferType` values pass through verbatim rather than being coerced into the documented `PRIVATE | SHARED | LUXURY` set.
+- The shared `request()` helper now accepts an optional `AbortSignal` (pre-flight check; in-flight cancel needs an upstream change to `fetchWithRetry` and is left as future work).
+
+New canonical types (`ActivityOffer`, `ActivityModality`, `TransferOffer`, etc.), wire types, mappers (`decimal.js` for all amounts), capability manifests (`hotelbedsActivitiesCapabilities`, `hotelbedsTransfersCapabilities`), `MockHotelbedsAdapter` fixtures for both surfaces, and unit + sandbox-gated integration tests. Domain knowledge captured verbatim from the vendor brief in `docs/knowledge-base/activities.md` and `docs/knowledge-base/transfers.md` with 13 numbered `DOMAIN_QUESTION` markers (DQ-A1..A5, DQ-T1..T8) for the gaps the brief leaves open. Per the constitution's no-invent rule, those questions are surfaced rather than guessed.
+
+### Reference OTA — Path B hardening ([#88](https://github.com/telivity-otaip/otaip/pull/88))
+
+Three pieces:
+
+- **Durable persistence** — `MockOtaAdapter` now optionally stores bookings in SQLite via `node:sqlite` (Node 24+). Auto-loads when `DATABASE_PATH` is set; falls back to in-memory otherwise. Survives process restarts.
+- **Real Stripe payments** — `PaymentService` runs against Stripe when `STRIPE_SECRET_KEY` is set. PaymentIntents created at booking time, confirmed at pay time. Mock-mode preserved when no key.
+- **Security headers + input schemas** — `helmet`, `@fastify/cors` (env-driven), `@fastify/rate-limit` (100/min global, 20/min on `/api/book`, 10/min on `/api/pay`), AJV body schemas on every state-mutating route, custom error formatter that preserves the existing `{ error, details }` envelope.
+
+### Reference OTA — wire real DuffelAdapter ([#89](https://github.com/telivity-otaip/otaip/pull/89))
+
+When `DUFFEL_API_KEY` is set, `examples/ota`'s search/price/book flow now runs against the live Duffel sandbox via a new `DuffelOtaAdapter` wrapper. Without the key it falls back to `MockOtaAdapter` exactly as before. New `BookingLifecycle` interface lets `Payment` / `Ticketing` / `Manage` services type against `OtaAdapter & BookingLifecycle` instead of the concrete mock — drops the `as MockOtaAdapter` casts in `server.ts`. Standardizes the env var to `DUFFEL_API_KEY` (matches the demo); `DUFFEL_API_TOKEN` still works with a deprecation warning. `ADAPTERS=duffel` is now a valid value for live multi-source search.
+
+### Docs & CI
+
+- **README** — "Build on OTAIP" promoted to the hero slot; the domain-flex framing pushed to the bottom ([#87](https://github.com/telivity-otaip/otaip/pull/87)).
+- **Publish CI** — verify step now auto-discovers packages from the workspace instead of being hand-maintained, and `repository.url` is canonicalized across every `package.json` ([#86](https://github.com/telivity-otaip/otaip/pull/86)).
+
+### Verification
+
+- Workspace typecheck clean.
+- `@otaip/adapter-hotelbeds`: 100 unit tests pass, 14 sandbox-gated tests skip without credentials.
+- `examples/ota`: 88 tests pass.
+- All PRs in the v0.7.0 window were merged green individually before this release PR was cut.
+
+### Versioning note
+
+The patch-bump-only rule from VERSIONING.md was broken when `@otaip/adapter-hotelbeds` shipped as 0.7.0 in the per-package PR. This release ratifies that bump for the rest of the workspace and updates VERSIONING.md to acknowledge the deviation. **Going forward, all releases are patch bumps off v0.7.x until v1.0** — the next release is v0.7.1.
 
 ## 0.6.4 — Hotelbeds Distribution Adapter
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -35,10 +35,13 @@ Our early history has version jumps that don't follow the patch-bump rule. These
 | v0.5.0 | Sprint F — OTA Booking, Payment, Ticketing | 2026-04-17 | Should have been v0.3.5 under the current policy |
 | v0.5.1 | Sprint G — Offers & Orders (AIDM 24.1) | 2026-04-17 | Should have been v0.3.6 |
 | v0.6.0 | Sprint H — OOSD-Native + Multi-Adapter | 2026-04-17 | Should have been v0.3.7 |
+| v0.7.0 | Reference OTA hardening + Hotelbeds Activities/Transfers | 2026-05-06 | Should have been v0.6.5 under the patch-bump rule. Bumped to 0.7.0 to re-sync the workspace after `@otaip/adapter-hotelbeds@0.7.0` was published as a single-package minor bump in PR #90 ahead of the repo-wide release. |
 
 The jumps from 0.3.4 to 0.5.0 and 0.5.1 to 0.6.0 came from mechanically following a planning document's "target versions" instead of applying consistent semver. They're preserved as historical git tags because nothing downstream consumes the registry (packages are not yet published to npm).
 
-**Going forward, all releases are patch bumps off v0.6.x until v1.0.** The next release is v0.6.1.
+The v0.6.4 → v0.7.0 jump is the one exception that came after this policy document was written. It exists because `@otaip/adapter-hotelbeds@0.7.0` was published to npm as a per-package minor bump before the corresponding repo-wide release was cut; rather than leave the rest of the ecosystem stuck behind a non-existent v0.6.5 tag, we ratify the bump and re-sync.
+
+**Going forward, all releases are patch bumps off v0.7.x until v1.0.** The next release is v0.7.1.
 
 ## How to bump
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Re-sync release. `@otaip/adapter-hotelbeds@0.7.0` shipped as a per-package minor bump in [#90](https://github.com/telivity-otaip/otaip/pull/90); this PR aligns root + every other workspace package with that version so GitHub, npm, and `package.json` all agree.
- See [CHANGELOG.md → 0.7.0](CHANGELOG.md#070--reference-ota-hardening--hotelbeds-activitiestransfers) for the substantive work in this window — three reference-OTA hardening PRs plus the Hotelbeds Activities/Transfers APIs.

## Versioning policy note

[VERSIONING.md](VERSIONING.md) says pre-v1.0 releases are patch bumps only — strictly speaking this should have been v0.6.5. The hotelbeds-adapter ad-hoc minor bump broke that rule. Rather than leave the rest of the ecosystem at 0.6.4 behind a non-existent 0.6.5 tag, we ratify the bump and re-sync everything to 0.7.0. VERSIONING.md updated to acknowledge the deviation in its history table; future releases continue as patch bumps off 0.7.x. The next release is **v0.7.1**.

## Files changed

- `package.json` (root) and 16 workspace packages bumped `0.6.4 → 0.7.0` (`@otaip/adapter-hotelbeds` already at 0.7.0 — no change).
- `CHANGELOG.md` — new `## 0.7.0` entry.
- `VERSIONING.md` — exception added to the history table; `next release is v0.7.1` updated.

## Test plan

- [x] `pnpm -r typecheck` — clean across the workspace.
- [x] No code changes other than `version` fields and docs — no behavioral risk.
- [ ] On merge: `Release` workflow fires on push-to-main → creates `v0.7.0` tag + GitHub release → triggers `Publish to npm`.
- [ ] Post-publish: `npm view @otaip/core version` returns `0.7.0`; `npm view @otaip/adapter-duffel version` returns `0.7.0`; etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)