### PR TITLE
chore(release): v0.7.1 — Platform UI + agent-discovery in @otaip/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 > **Versioning policy:** Pre-v1.0, every release is a patch bump (`0.6.0 → 0.6.1 → 0.6.2 → …`). See [VERSIONING.md](VERSIONING.md) for the full policy and an explanation of the early-history version jumps (0.3.4 → 0.5.0 → 0.5.1 → 0.6.0) that predate this rule. v0.6.4 → v0.7.0 is the one post-policy exception — see VERSIONING.md.
 
+## 0.7.1 — Platform UI + agent-discovery promoted to `@otaip/core`
+
+Patch bump per the policy reset in v0.7.0. The headline of this window is the **Platform UI** ([#93](https://github.com/telivity-otaip/otaip/pull/93)) — a new React/Vite app at `examples/platform-ui/` that gives developers a visual control plane for an OTAIP instance: agent registry, adapter status, health sidebar, and an interactive Playground for searches/agents/adapters. The Platform UI is private (`examples/*` is not published to npm); the npm-visible delta is one additive export on `@otaip/core`.
+
+### Published-package changes
+
+- **`@otaip/core`** — new `discoverAgents()` / `DiscoveredAgent` exports under `src/discovery/`. Filesystem-only walk of the workspace; no agent code executes. Repo root is resolved by walking up to `pnpm-workspace.yaml` rather than by counting parent directories, so the helper works the same way from `src/` (tsx/vitest) and from `dist/` (built consumer).
+- **`@otaip/cli`** — `agent-discovery.ts` now re-exports from `@otaip/core`. Behavior unchanged; every existing import path keeps working. The `pnpm cli agents` output is byte-identical.
+- All other published packages bumped 0.7.0 → 0.7.1 with no source changes — workspace-wide version sync.
+
+### Reference OTA additions ([#93](https://github.com/telivity-otaip/otaip/pull/93))
+
+`examples/ota` (private) gains the read-only telemetry routes the dashboard consumes: `/api/platform/{agents,adapters,health,stats}` (rate limit raised to 5 000/min so dashboard polling cannot trip the global cap) and `/api/playground/{catalog,search,agent,adapter}`. Catalog surfaces every discovered agent plus an `executable_ids` whitelist; the playground starts at one wired agent (`0.1` AirportCodeResolver — the canonical reference pattern from CLAUDE.md). Non-whitelisted IDs return a clear `501` rather than pretending to run. 12 new tests across `platform.test.ts` + `playground.test.ts` follow the existing Fastify `inject()` + `MockOtaAdapter` shape.
+
+### Dependency hygiene ([#95](https://github.com/telivity-otaip/otaip/pull/95))
+
+Dependabot bumped `postcss` 8.5.8 → 8.5.10 (dev-only, transitive through `tailwindcss`).
+
+### Verification
+
+- `pnpm -r typecheck` — clean across the workspace.
+- `pnpm exec vitest run examples/ota` — 100 passed across 9 files.
+- `pnpm --filter @otaip/platform-ui typecheck` — clean.
+
+### Versioning note
+
+Patch bump off v0.7.0 per the rule reaffirmed in the v0.7.0 release. The next release is **v0.7.2**.
+
 ## 0.7.0 — Reference OTA hardening + Hotelbeds Activities/Transfers
 
 Re-sync release. `@otaip/adapter-hotelbeds@0.7.0` shipped as a single-package minor bump in [#90](https://github.com/telivity-otaip/otaip/pull/90) ahead of the repo-wide release; this PR aligns root + every other workspace package with that version so the GitHub front page, npm, and `package.json` files all agree. Per-package, the only API surface change since v0.6.4 lives in `@otaip/adapter-hotelbeds`. The rest of the work in this window targeted the reference OTA — see below.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -41,7 +41,7 @@ The jumps from 0.3.4 to 0.5.0 and 0.5.1 to 0.6.0 came from mechanically followin
 
 The v0.6.4 → v0.7.0 jump is the one exception that came after this policy document was written. It exists because `@otaip/adapter-hotelbeds@0.7.0` was published to npm as a per-package minor bump before the corresponding repo-wide release was cut; rather than leave the rest of the ecosystem stuck behind a non-existent v0.6.5 tag, we ratify the bump and re-sync.
 
-**Going forward, all releases are patch bumps off v0.7.x until v1.0.** The next release is v0.7.1.
+**Going forward, all releases are patch bumps off v0.7.x until v1.0.** The next release is v0.7.2.
 
 ## How to bump
 

--- a/examples/platform-ui/package.json
+++ b/examples/platform-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/platform-ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapters/hotelbeds/package.json
+++ b/packages/adapters/hotelbeds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-hotelbeds",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP distribution adapter for the Hotelbeds APItude APIs — Hotels, Activities, and Transfers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Patch bump off v0.7.0 per the policy reset in [#92](https://github.com/telivity-otaip/otaip/pull/92). The headline of this window is the **Platform UI** ([#93](https://github.com/telivity-otaip/otaip/pull/93)) — private (`examples/*` is not published to npm), so the npm-visible delta is one additive export on `@otaip/core`.

## What's npm-visible

- **`@otaip/core`** gains `discoverAgents()` / `DiscoveredAgent` exports (filesystem-only; no agent code executes; works from src/ and dist/). [#93](https://github.com/telivity-otaip/otaip/pull/93)
- **`@otaip/cli`** `agent-discovery.ts` is now a re-export from `@otaip/core` — behavior identical, every existing import path keeps working.
- All other packages: workspace-version sync, no source changes.

## What's in the repo (private)

- `examples/platform-ui` — new React/Vite app: dashboard + developer playground.
- `examples/ota` gains read-only `/api/platform/*` and `/api/playground/*` routes plus 12 new tests.
- Dependabot postcss dev-dep bump 8.5.8 → 8.5.10 ([#95](https://github.com/telivity-otaip/otaip/pull/95)).

See [CHANGELOG.md → 0.7.1](CHANGELOG.md#071--platform-ui--agent-discovery-promoted-to-otaipcore) for the full entry.

## Files changed

- 18 `package.json` files bumped `0.7.0 → 0.7.1` (root + 16 workspace + `@otaip/platform-ui`).
- `CHANGELOG.md` — new `## 0.7.1` entry.
- `VERSIONING.md` — next-release pointer updated to `v0.7.2`.

## Test plan

- [x] `pnpm -r typecheck` — clean across the workspace.
- [x] No source changes — purely version + docs.
- [ ] On merge: `Release` workflow fires on push-to-main → creates `v0.7.1` tag + GitHub release → triggers `Publish to npm`.
- [ ] Post-publish: `npm view @otaip/core version` returns `0.7.1`; `discoverAgents` is importable from npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)