### PR TITLE
fix(release): unbreak Release workflow's Count agents step

### DIFF
--- a/scripts/count-agents.ts
+++ b/scripts/count-agents.ts
@@ -2,19 +2,23 @@
 /**
  * Single source of truth for the agent count + per-stage breakdown.
  *
- * Walks the workspace exactly the same way the CLI does
- * (packages/cli/src/agent-discovery.ts), so README claims, docs counts,
- * and the release-notes pipeline cannot drift apart.
+ * Walks the workspace exactly the same way the CLI does — `discoverAgents`
+ * lives in `@otaip/core` since v0.7.1, with the CLI re-exporting it.
+ * README claims, docs counts, and the release-notes pipeline all read
+ * from this script so they cannot drift apart.
  *
  * Usage:
  *   pnpm tsx scripts/count-agents.ts            # plain text
  *   pnpm tsx scripts/count-agents.ts --json     # machine-readable
  *
- * The previous release.yml `find` command undercounted by skipping
- * packages/agents-platform and packages/agents-tmc; this script does not.
+ * Imports the helper directly from its source path rather than through
+ * the `@otaip/core` package specifier. The Release workflow's "Count
+ * agents" step runs before any build, so a bare `import from '@otaip/core'`
+ * fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` when `dist/index.js` doesn't
+ * yet exist on the runner.
  */
 
-import { discoverAgents } from '../packages/cli/src/agent-discovery.js';
+import { discoverAgents } from '../packages/core/src/discovery/agent-discovery.js';
 
 interface Counts {
   total: number;


### PR DESCRIPTION
## Summary

Hotfix: every push-to-main since [#93](https://github.com/telivity-otaip/otaip/pull/93) (incl. [#95](https://github.com/telivity-otaip/otaip/pull/95) and [#96](https://github.com/telivity-otaip/otaip/pull/96)) has failed the **Release** workflow's *Count agents* step. Result: v0.7.1 hasn't been tagged or published despite #96 being merged, and the GitHub front page still shows v0.7.0.

## Root cause

[#93](https://github.com/telivity-otaip/otaip/pull/93) moved `discoverAgents` into `@otaip/core` and made the CLI a re-export. `scripts/count-agents.ts` imports through the CLI, so the indirection now forces tsx to resolve `@otaip/core` through its `package.json` `exports` map — which points at `./dist/index.js`. The Release workflow's *Count agents* step runs before any build, so the file doesn't exist:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined
in /home/runner/work/otaip/otaip/packages/cli/node_modules/@otaip/core/package.json
```

## Fix

Import `discoverAgents` directly from `packages/core/src/discovery/agent-discovery.js` so tsx walks files instead of resolving a package specifier. The CLI keeps its re-export untouched — every external consumer of `@otaip/cli` is unaffected.

## Test plan

- [x] One-line import path change; same export, no behavior delta.
- [ ] CI green on this PR.
- [ ] On merge: Release workflow on the merge commit should succeed → tags `v0.7.1` → triggers `Publish to npm` → `npm view @otaip/core version` returns `0.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)