### PR TITLE
feat(adapter-duffel): add Cars API (search → quote → book) v0.7.2

### DIFF
--- a/docs/knowledge-base/cars.md
+++ b/docs/knowledge-base/cars.md
@@ -1,0 +1,168 @@
+# Duffel Cars API — Domain Knowledge
+
+Source: vendor brief, May 2026. Authoritative input for the `@otaip/adapter-duffel` Cars surface. Anything missing here is captured as `DOMAIN_QUESTION` at the bottom — never invent.
+
+## Endpoints
+
+| Operation     | Method | Path                                          |
+| ------------- | ------ | --------------------------------------------- |
+| Search        | POST   | `/cars/search`                                |
+| Quote         | POST   | `/cars/quotes`                                |
+| Booking       | POST   | `/cars/bookings`                              |
+| Get booking   | GET    | `/cars/bookings/{id}`                         |
+| Cancel        | POST   | `/cars/bookings/{id}/actions/cancel`          |
+
+Base URL: `https://api.duffel.com`. Same Bearer auth as flights (`DUFFEL_API_KEY`). Same `Duffel-Version: v2` header.
+
+## Booking flow
+
+**Three-step**, not two-step like flights: `search → quote → book`. Quote is mandatory — you cannot book directly off a search rate.
+
+## ID prefixes
+
+| Prefix  | Object                |
+| ------- | --------------------- |
+| `seh_`  | Search                |
+| `rae_`  | Rate (search result)  |
+| `qut_`  | Quote                 |
+| `boo_`  | Booking               |
+
+## Search
+
+**Geo-coordinate based, NOT IATA airport codes.** Caller provides `{ latitude, longitude, radius? }` per location.
+
+```json
+{
+  "data": {
+    "pickup_date": "2026-06-15",
+    "pickup_time": "10:30",
+    "pickup_location": {
+      "radius": 5,
+      "geographic_coordinates": { "latitude": 41.3874, "longitude": 2.1686 }
+    },
+    "dropoff_date": "2026-06-20",
+    "dropoff_time": "10:30",
+    "dropoff_location": {
+      "radius": 5,
+      "geographic_coordinates": { "latitude": 41.3874, "longitude": 2.1686 }
+    },
+    "driver": { "age": 30, "residence_country_code": "US" }
+  }
+}
+```
+
+- `radius` — kilometres. Default 5 (per brief). Upper bound not specified — see DQ-C1.
+- `driver.age` — used by suppliers to filter rates by minimum-driver-age policies.
+- `driver.residence_country_code` — ISO 3166-1 alpha-2.
+- `pickup_time` / `dropoff_time` — `HH:mm` 24-hour. Timezone semantics — see DQ-C2.
+
+Response keys we map:
+
+```text
+data.id                              → searchId        (seh_…)
+data.rates[].id                      → rateId          (rae_…)
+data.rates[].car.{name, category, type, transmission, fuel, code, max_passengers,
+                  baggage.{small, large}, air_conditioning, images}
+data.rates[].supplier.{name, logo_url}
+data.rates[].pickup_location.{address, geographic_coordinates, phone, opening_hours}
+data.rates[].dropoff_location.{...}
+data.rates[].base_amount / base_currency
+data.rates[].total_amount / total_currency
+data.rates[].payment_type           → 'guarantee' | 'prepaid' | 'postpaid'
+```
+
+### Car category & ACRISS
+
+- `car.category` documented values: `compact | economy | standard | full_size | premium | luxury | suv | van`. Adapter narrows to that union and passes through unknown values verbatim — see DQ-C3.
+- `car.type` documented values: `four_door | suv | van | …`. Treated as a free-form descriptor; DQ-C3 covers the open enum.
+- `car.code` is the **ACRISS** four-letter code (e.g. `CDAV` = Compact, 4-door, Automatic, AC). Industry standard, exposed verbatim as `acrissCode`. The first two characters classify size/body, the third is transmission/drive, the fourth is fuel/AC. The adapter does not parse the code into components — caller decides.
+
+### Payment type
+
+- `prepaid` — paid up front, included in `total_amount`.
+- `guarantee` — card on file, paid at counter.
+- `postpaid` — paid at counter, no card needed.
+
+## Quote
+
+```json
+{ "data": { "rate_id": "rae_…" } }
+```
+
+Response repeats search fields plus:
+
+- `id` (`qut_…`)
+- `conditions[]` — list of `{ title, text }` (cancellation policy, fuel policy, smoking policy, …). Free text per supplier.
+- `charges[]` — itemized supplier charges (insurance, young-driver fee, etc.) `{ amount, currency, description }`.
+- `mileage` — `{ unlimited: boolean, included?: number, unit?: string }`.
+- `privacy_policies[]` — must be acknowledged by the user before booking. See DQ-C4 — adapter exposes them verbatim; UI/orchestration layer is responsible for the consent step.
+
+## Book
+
+```json
+{
+  "data": {
+    "quote_id": "qut_…",
+    "driver": {
+      "given_name": "John",
+      "family_name": "Smith",
+      "email": "john@example.com",
+      "phone_number": "+1234567890",
+      "date_of_birth": "1990-01-15"
+    },
+    "payment": { "method": "card", "card_id": "crd_…" },
+    "metadata": {},
+    "inbound_flight_number": "BA123"
+  }
+}
+```
+
+- `payment.card_id` — references a Duffel-stored card. Card creation is a separate Duffel API and is **out of scope for this adapter** — DQ-C5. The adapter accepts `payment` as an opaque pass-through object; callers construct it.
+- `inbound_flight_number` — optional flight number the supplier uses to track late arrivals. Format unverified — DQ-C6.
+- `metadata` — opaque `Record<string, string>`.
+
+Response: full booking record. Mapped fields:
+
+```text
+data.id                             → bookingId        (boo_…)
+data.status                         → 'confirmed' | 'cancelled'
+data.reference                      → supplier-issued reference
+data.confirmed_at
+data.car / supplier / pickup_location / dropoff_location
+data.total_amount / total_currency
+```
+
+## Get booking
+
+`GET /cars/bookings/{id}` — returns the same shape as Book.
+
+## Cancel
+
+`POST /cars/bookings/{id}/actions/cancel` (no body documented).
+
+Returns `{ status: 'cancelled', cancelled_at }`. Refund mechanics (full vs partial) depend on the supplier's cancellation policy on the quote — see DQ-C7. The adapter exposes the cancellation status only; refund computation is out of scope.
+
+## Sandbox
+
+Provider name: **"Duffel Test Drive"**. Same `https://api.duffel.com` base URL with a test API key prefix.
+
+## Open DOMAIN_QUESTIONs
+
+- **DQ-C1** — `radius` upper bound. The brief documents radius defaulting to 5km but not the maximum. The adapter passes the value through; supplier-side rejection surfaces as a 4xx.
+- **DQ-C2** — `pickup_time` / `dropoff_time` timezone. Local time at the pickup location is the typical convention but unverified. The adapter passes the value through unchanged.
+- **DQ-C3** — `car.category` and `car.type` enum closure. The brief lists examples but doesn't claim the lists are closed. The adapter narrows to the documented set when matched and passes the raw string through otherwise (`CarCategory | string`).
+- **DQ-C4** — `privacy_policies` consent flow. Brief notes "must be acknowledged" but doesn't specify the API mechanic (a header? a flag in the book request? out-of-band?). Adapter exposes the array verbatim; integrating layers handle consent.
+- **DQ-C5** — Card creation. The brief explicitly excludes card creation. Adapter accepts `payment` as an opaque object — callers construct `{ method, card_id }` and the adapter doesn't validate.
+- **DQ-C6** — `inbound_flight_number` format. Whether it's `BA123` or `BAW123` (IATA vs ICAO) is unverified. Adapter passes through as a string.
+- **DQ-C7** — Refund computation on cancellation. The brief says the cancellation endpoint returns status only; refund amount/eligibility comes from quote `conditions[]` text. Adapter does not compute refunds.
+- **DQ-C8** — IATA-to-coordinate conversion. The brief explicitly defers this to a future iteration. The adapter accepts only coordinate-based locations; calling code must geocode IATA codes upstream.
+
+## Method surface
+
+```ts
+searchCars(request: CarSearchRequest): Promise<{ searchId: string; rates: CarRate[] }>;
+quoteCar(rateId: string, signal?: AbortSignal): Promise<CarQuote>;
+bookCar(request: CarBookRequest): Promise<CarBookResponse>;
+getCarBooking(bookingId: string, signal?: AbortSignal): Promise<CarBookResponse>;
+cancelCarBooking(bookingId: string, signal?: AbortSignal): Promise<{ status: 'cancelled'; cancelledAt: string }>;
+```

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.7.1",
-  "description": "OTAIP distribution adapter for Duffel NDC API (mock + live implementations)",
+  "version": "0.7.2",
+  "description": "OTAIP distribution adapter for Duffel NDC API — Flights and Cars (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/adapters/duffel/src/__tests__/cars.test.ts
+++ b/packages/adapters/duffel/src/__tests__/cars.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Duffel Cars — unit tests with mocked fetch.
+ *
+ * No real network. Validates:
+ *   - Three-step flow: search → quote → book.
+ *   - Auth + Duffel-Version headers (same as flights).
+ *   - Path routing under /cars/ (not /air/).
+ *   - Body shapes match the brief (geo coordinates wrapped in `data`).
+ *   - Mapper output matches the canonical Car* types (money normalised
+ *     via decimal.js).
+ *   - 429 retry-then-error.
+ *   - AbortSignal pre-flight.
+ *   - MockDuffelAdapter cars flow exercises the same surface.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DuffelAdapter } from '../duffel-adapter.js';
+import { MockDuffelAdapter } from '../mock-duffel-adapter.js';
+import type {
+  DuffelCarsBookingResponse,
+  DuffelCarsCancelResponse,
+  DuffelCarsQuoteResponse,
+  DuffelCarsSearchResponse,
+} from '../cars-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface RecordedCall {
+  url: string;
+  init: RequestInit;
+}
+
+function captureFetch(responses: Array<{ status: number; body: unknown }>): {
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let i = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation((url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      const r = responses[i++];
+      if (!r) throw new Error(`Unexpected fetch call #${i}: ${url}`);
+      return Promise.resolve({
+        ok: r.status >= 200 && r.status < 300,
+        status: r.status,
+        statusText: r.status === 200 ? 'OK' : 'Error',
+        json: () => Promise.resolve(r.body),
+      });
+    }),
+  );
+  return { calls };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SEARCH_RESPONSE: DuffelCarsSearchResponse = {
+  data: {
+    id: 'seh_test_001',
+    rates: [
+      {
+        id: 'rae_test_alpha',
+        car: {
+          name: 'Toyota Corolla',
+          category: 'compact',
+          type: 'four_door',
+          transmission: 'automatic',
+          fuel: 'petrol',
+          code: 'CDAR',
+          max_passengers: 5,
+          baggage: { small: 2, large: 1 },
+          air_conditioning: true,
+          images: ['https://example.invalid/img/corolla.jpg'],
+        },
+        supplier: { name: 'Test Drive', logo_url: 'https://example.invalid/logo.png' },
+        pickup_location: {
+          address: 'Barcelona Airport T1',
+          geographic_coordinates: { latitude: 41.2974, longitude: 2.0833 },
+          phone: '+34-900-100-100',
+          opening_hours: '06:00–23:00',
+        },
+        dropoff_location: {
+          address: 'Barcelona Airport T1',
+          geographic_coordinates: { latitude: 41.2974, longitude: 2.0833 },
+        },
+        base_amount: '120.50',
+        base_currency: 'EUR',
+        total_amount: '142.40',
+        total_currency: 'EUR',
+        payment_type: 'prepaid',
+      },
+    ],
+  },
+};
+
+const QUOTE_RESPONSE: DuffelCarsQuoteResponse = {
+  data: {
+    id: 'qut_test_001',
+    rate_id: 'rae_test_alpha',
+    search_id: 'seh_test_001',
+    car: SEARCH_RESPONSE.data.rates![0]!.car!,
+    supplier: SEARCH_RESPONSE.data.rates![0]!.supplier!,
+    pickup_location: SEARCH_RESPONSE.data.rates![0]!.pickup_location!,
+    dropoff_location: SEARCH_RESPONSE.data.rates![0]!.dropoff_location!,
+    total_amount: '142.40',
+    total_currency: 'EUR',
+    conditions: [
+      { title: 'Free cancellation', text: 'Until 48h before pickup.' },
+      { title: 'Fuel policy', text: 'Full to full.' },
+    ],
+    charges: [
+      { amount: '5.00', currency: 'EUR', description: 'Airport surcharge' },
+      { amount: '12.50', currency: 'EUR', description: 'Insurance' },
+    ],
+    mileage: { unlimited: true },
+    privacy_policies: ['Mock privacy policy text.'],
+  },
+};
+
+const BOOKING_RESPONSE: DuffelCarsBookingResponse = {
+  data: {
+    id: 'boo_test_001',
+    status: 'confirmed',
+    reference: 'TST-CAR-12345',
+    confirmed_at: '2026-06-01T10:00:00Z',
+    car: SEARCH_RESPONSE.data.rates![0]!.car!,
+    supplier: SEARCH_RESPONSE.data.rates![0]!.supplier!,
+    pickup_location: SEARCH_RESPONSE.data.rates![0]!.pickup_location!,
+    dropoff_location: SEARCH_RESPONSE.data.rates![0]!.dropoff_location!,
+    total_amount: '142.40',
+    total_currency: 'EUR',
+  },
+};
+
+const CANCEL_RESPONSE: DuffelCarsCancelResponse = {
+  data: {
+    id: 'boo_test_001',
+    status: 'cancelled',
+    cancelled_at: '2026-06-01T11:30:00Z',
+  },
+};
+
+const SEARCH_REQUEST = {
+  pickupDate: '2026-06-15',
+  pickupTime: '10:30',
+  pickupLocation: { latitude: 41.3874, longitude: 2.1686, radius: 5 },
+  dropoffDate: '2026-06-20',
+  dropoffTime: '10:30',
+  dropoffLocation: { latitude: 41.3874, longitude: 2.1686, radius: 5 },
+  driver: { age: 30, residenceCountryCode: 'US' },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// searchCars
+// ---------------------------------------------------------------------------
+
+describe('DuffelAdapter.searchCars', () => {
+  let adapter: DuffelAdapter;
+  beforeEach(() => {
+    adapter = new DuffelAdapter('duffel_test_key');
+  });
+
+  it('hits POST /cars/search with the brief-shape body', async () => {
+    const { calls } = captureFetch([{ status: 200, body: SEARCH_RESPONSE }]);
+
+    await adapter.searchCars(SEARCH_REQUEST);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe('https://api.duffel.com/cars/search');
+    expect(calls[0]!.init.method).toBe('POST');
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({
+      data: {
+        pickup_date: '2026-06-15',
+        pickup_time: '10:30',
+        pickup_location: {
+          radius: 5,
+          geographic_coordinates: { latitude: 41.3874, longitude: 2.1686 },
+        },
+        dropoff_date: '2026-06-20',
+        dropoff_time: '10:30',
+        dropoff_location: {
+          radius: 5,
+          geographic_coordinates: { latitude: 41.3874, longitude: 2.1686 },
+        },
+        driver: { age: 30, residence_country_code: 'US' },
+      },
+    });
+  });
+
+  it('attaches the same Bearer auth + Duffel-Version headers as flights', async () => {
+    const { calls } = captureFetch([{ status: 200, body: SEARCH_RESPONSE }]);
+    await adapter.searchCars(SEARCH_REQUEST);
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer duffel_test_key');
+    expect(headers['Duffel-Version']).toBe('v2');
+    expect(headers['Accept']).toBe('application/json');
+  });
+
+  it('omits radius when caller does not supply it', async () => {
+    const { calls } = captureFetch([{ status: 200, body: SEARCH_RESPONSE }]);
+    await adapter.searchCars({
+      ...SEARCH_REQUEST,
+      pickupLocation: { latitude: 41.3874, longitude: 2.1686 },
+      dropoffLocation: { latitude: 41.3874, longitude: 2.1686 },
+    });
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.data.pickup_location.radius).toBeUndefined();
+    expect(body.data.dropoff_location.radius).toBeUndefined();
+    expect(body.data.pickup_location.geographic_coordinates).toEqual({
+      latitude: 41.3874,
+      longitude: 2.1686,
+    });
+  });
+
+  it('maps the response into canonical CarRate shape', async () => {
+    captureFetch([{ status: 200, body: SEARCH_RESPONSE }]);
+    const result = await adapter.searchCars(SEARCH_REQUEST);
+    expect(result.searchId).toBe('seh_test_001');
+    expect(result.rates).toHaveLength(1);
+    const rate = result.rates[0]!;
+    expect(rate.rateId).toBe('rae_test_alpha');
+    expect(rate.searchId).toBe('seh_test_001');
+    expect(rate.car.name).toBe('Toyota Corolla');
+    expect(rate.car.category).toBe('compact');
+    expect(rate.car.transmission).toBe('automatic');
+    expect(rate.car.acrissCode).toBe('CDAR');
+    expect(rate.car.maxPassengers).toBe(5);
+    expect(rate.car.baggage).toEqual({ small: 2, large: 1 });
+    expect(rate.car.airConditioning).toBe(true);
+    expect(rate.car.images).toEqual(['https://example.invalid/img/corolla.jpg']);
+    expect(rate.supplier).toEqual({
+      name: 'Test Drive',
+      logoUrl: 'https://example.invalid/logo.png',
+    });
+    expect(rate.pickupLocation.address).toBe('Barcelona Airport T1');
+    expect(rate.pickupLocation.latitude).toBe(41.2974);
+    expect(rate.pickupLocation.openingHours).toBe('06:00–23:00');
+    expect(rate.baseAmount).toEqual({ amount: '120.50', currency: 'EUR' });
+    expect(rate.totalAmount).toEqual({ amount: '142.40', currency: 'EUR' });
+    expect(rate.paymentType).toBe('prepaid');
+  });
+
+  it('aborts pre-flight when an aborted signal is supplied', async () => {
+    captureFetch([]);
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      adapter.searchCars({ ...SEARCH_REQUEST, signal: ac.signal }),
+    ).rejects.toThrow(/aborted/);
+  });
+
+  it('returns empty rates when none are returned', async () => {
+    captureFetch([{ status: 200, body: { data: { id: 'seh_empty', rates: [] } } }]);
+    const result = await adapter.searchCars(SEARCH_REQUEST);
+    expect(result.rates).toEqual([]);
+  });
+
+  it('defaults unknown payment_type to postpaid (safe assumption)', async () => {
+    captureFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            id: 'seh_x',
+            rates: [
+              {
+                id: 'rae_x',
+                car: { name: 'Mystery', code: 'XXXX', transmission: 'automatic' },
+                payment_type: 'NEW_FUTURE_VALUE',
+                total_amount: '10.00',
+                total_currency: 'USD',
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const result = await adapter.searchCars(SEARCH_REQUEST);
+    expect(result.rates[0]!.paymentType).toBe('postpaid');
+  });
+
+  it('surfaces 429 as a rate-limit error after retries exhaust', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+        json: () => Promise.resolve({ errors: [{ message: 'rate exceeded' }] }),
+      }),
+    );
+    await expect(adapter.searchCars(SEARCH_REQUEST)).rejects.toThrow(/rate limited/i);
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// quoteCar
+// ---------------------------------------------------------------------------
+
+describe('DuffelAdapter.quoteCar', () => {
+  let adapter: DuffelAdapter;
+  beforeEach(() => {
+    adapter = new DuffelAdapter('duffel_test_key');
+  });
+
+  it('posts /cars/quotes with rate_id wrapped in data', async () => {
+    const { calls } = captureFetch([{ status: 200, body: QUOTE_RESPONSE }]);
+    await adapter.quoteCar('rae_test_alpha');
+    expect(calls[0]!.url).toBe('https://api.duffel.com/cars/quotes');
+    expect(calls[0]!.init.method).toBe('POST');
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      data: { rate_id: 'rae_test_alpha' },
+    });
+  });
+
+  it('returns conditions, charges, mileage, and privacy_policies', async () => {
+    captureFetch([{ status: 200, body: QUOTE_RESPONSE }]);
+    const quote = await adapter.quoteCar('rae_test_alpha');
+    expect(quote.quoteId).toBe('qut_test_001');
+    expect(quote.rateId).toBe('rae_test_alpha');
+    expect(quote.searchId).toBe('seh_test_001');
+    expect(quote.totalAmount).toEqual({ amount: '142.40', currency: 'EUR' });
+    expect(quote.conditions).toHaveLength(2);
+    expect(quote.conditions[0]!.title).toBe('Free cancellation');
+    expect(quote.charges).toHaveLength(2);
+    expect(quote.charges[1]!.amount).toBe('12.50');
+    expect(quote.mileage).toEqual({ unlimited: true });
+    expect(quote.privacyPolicies).toEqual(['Mock privacy policy text.']);
+  });
+
+  it('aborts pre-flight when an aborted signal is supplied', async () => {
+    captureFetch([]);
+    const ac = new AbortController();
+    ac.abort();
+    await expect(adapter.quoteCar('rae_test_alpha', ac.signal)).rejects.toThrow(/aborted/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bookCar
+// ---------------------------------------------------------------------------
+
+describe('DuffelAdapter.bookCar', () => {
+  let adapter: DuffelAdapter;
+  beforeEach(() => {
+    adapter = new DuffelAdapter('duffel_test_key');
+  });
+
+  it('posts /cars/bookings with the brief-shape body', async () => {
+    const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+    await adapter.bookCar({
+      quoteId: 'qut_test_001',
+      driver: {
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        email: 'ada@example.com',
+        phoneNumber: '+1234567890',
+        dateOfBirth: '1985-12-10',
+      },
+      payment: { method: 'card', cardId: 'crd_abc' },
+      metadata: { trip: 'business' },
+      inboundFlightNumber: 'BA123',
+    });
+    expect(calls[0]!.url).toBe('https://api.duffel.com/cars/bookings');
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body).toEqual({
+      data: {
+        quote_id: 'qut_test_001',
+        driver: {
+          given_name: 'Ada',
+          family_name: 'Lovelace',
+          email: 'ada@example.com',
+          phone_number: '+1234567890',
+          date_of_birth: '1985-12-10',
+        },
+        payment: { method: 'card', cardId: 'crd_abc' },
+        metadata: { trip: 'business' },
+        inbound_flight_number: 'BA123',
+      },
+    });
+  });
+
+  it('returns the canonical confirmed booking', async () => {
+    captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+    const result = await adapter.bookCar({
+      quoteId: 'qut_test_001',
+      driver: {
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        email: 'ada@example.com',
+        phoneNumber: '+1234567890',
+      },
+    });
+    expect(result.bookingId).toBe('boo_test_001');
+    expect(result.status).toBe('confirmed');
+    expect(result.reference).toBe('TST-CAR-12345');
+    expect(result.totalAmount).toEqual({ amount: '142.40', currency: 'EUR' });
+    expect(result.car.name).toBe('Toyota Corolla');
+  });
+
+  it('omits optional fields from the request body when not supplied', async () => {
+    const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+    await adapter.bookCar({
+      quoteId: 'qut_test_001',
+      driver: {
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        email: 'ada@example.com',
+        phoneNumber: '+1234567890',
+      },
+    });
+    const body = JSON.parse(calls[0]!.init.body as string);
+    expect(body.data.driver.date_of_birth).toBeUndefined();
+    expect(body.data.payment).toBeUndefined();
+    expect(body.data.metadata).toBeUndefined();
+    expect(body.data.inbound_flight_number).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCarBooking + cancelCarBooking
+// ---------------------------------------------------------------------------
+
+describe('DuffelAdapter.getCarBooking', () => {
+  it('GETs /cars/bookings/{id}', async () => {
+    const adapter = new DuffelAdapter('duffel_test_key');
+    const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+    const result = await adapter.getCarBooking('boo_test_001');
+    expect(calls[0]!.url).toBe('https://api.duffel.com/cars/bookings/boo_test_001');
+    expect(calls[0]!.init.method).toBe('GET');
+    expect(result.bookingId).toBe('boo_test_001');
+  });
+
+  it('URL-encodes the booking id', async () => {
+    const adapter = new DuffelAdapter('duffel_test_key');
+    const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
+    await adapter.getCarBooking('boo /weird');
+    expect(calls[0]!.url).toContain('boo%20%2Fweird');
+  });
+});
+
+describe('DuffelAdapter.cancelCarBooking', () => {
+  it('POSTs /cars/bookings/{id}/actions/cancel', async () => {
+    const adapter = new DuffelAdapter('duffel_test_key');
+    const { calls } = captureFetch([{ status: 200, body: CANCEL_RESPONSE }]);
+    const result = await adapter.cancelCarBooking('boo_test_001');
+    expect(calls[0]!.url).toBe(
+      'https://api.duffel.com/cars/bookings/boo_test_001/actions/cancel',
+    );
+    expect(calls[0]!.init.method).toBe('POST');
+    expect(result.status).toBe('cancelled');
+    expect(result.cancelledAt).toBe('2026-06-01T11:30:00Z');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MockDuffelAdapter
+// ---------------------------------------------------------------------------
+
+describe('MockDuffelAdapter — Cars three-step flow', () => {
+  it('search → quote → book → get → cancel round-trips', async () => {
+    const adapter = new MockDuffelAdapter();
+    const search = await adapter.searchCars(SEARCH_REQUEST);
+    expect(search.searchId).toMatch(/^seh_mock_\d{6}$/);
+    expect(search.rates.length).toBeGreaterThan(0);
+    const rate = search.rates[0]!;
+    expect(rate.car.name).toBeTruthy();
+
+    const quote = await adapter.quoteCar(rate.rateId);
+    expect(quote.quoteId).toMatch(/^qut_mock_\d{6}$/);
+    expect(quote.privacyPolicies.length).toBeGreaterThan(0);
+    expect(quote.mileage?.unlimited).toBe(true);
+
+    const booking = await adapter.bookCar({
+      quoteId: quote.quoteId,
+      driver: {
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        email: 'ada@example.com',
+        phoneNumber: '+1234567890',
+      },
+    });
+    expect(booking.bookingId).toMatch(/^boo_mock_\d{6}$/);
+    expect(booking.status).toBe('confirmed');
+    expect(booking.totalAmount).toEqual(quote.totalAmount);
+
+    const fetched = await adapter.getCarBooking(booking.bookingId);
+    expect(fetched.bookingId).toBe(booking.bookingId);
+
+    const cancelled = await adapter.cancelCarBooking(booking.bookingId);
+    expect(cancelled.status).toBe('cancelled');
+    expect(cancelled.cancelledAt).toBeTruthy();
+  });
+
+  it('quoteCar with an unknown rateId throws', async () => {
+    const adapter = new MockDuffelAdapter();
+    await expect(adapter.quoteCar('rae_does_not_exist')).rejects.toThrow(/unknown/);
+  });
+
+  it('cancelling an already-cancelled booking throws', async () => {
+    const adapter = new MockDuffelAdapter();
+    const search = await adapter.searchCars(SEARCH_REQUEST);
+    const quote = await adapter.quoteCar(search.rates[0]!.rateId);
+    const booking = await adapter.bookCar({
+      quoteId: quote.quoteId,
+      driver: {
+        givenName: 'A',
+        familyName: 'B',
+        email: 'a@b',
+        phoneNumber: '+1',
+      },
+    });
+    await adapter.cancelCarBooking(booking.bookingId);
+    await expect(adapter.cancelCarBooking(booking.bookingId)).rejects.toThrow(
+      /already cancelled/,
+    );
+  });
+
+  it('rejects pre-aborted searchCars calls', async () => {
+    const adapter = new MockDuffelAdapter();
+    const ac = new AbortController();
+    ac.abort();
+    await expect(
+      adapter.searchCars({ ...SEARCH_REQUEST, signal: ac.signal }),
+    ).rejects.toThrow(/aborted/);
+  });
+});

--- a/packages/adapters/duffel/src/cars-mapper.ts
+++ b/packages/adapters/duffel/src/cars-mapper.ts
@@ -1,0 +1,236 @@
+/**
+ * Duffel Cars — wire-to-canonical mapping.
+ *
+ * Per CLAUDE.md, no domain logic is invented. Behavioral semantics that
+ * the brief leaves open (refund computation, ACRISS code parsing,
+ * privacy-policy consent flow) are passed through verbatim. See
+ * `docs/knowledge-base/cars.md` for outstanding DOMAIN_QUESTIONs.
+ */
+
+import Decimal from 'decimal.js';
+
+import type {
+  CarBookResponse,
+  CarBookingStatus,
+  CarCancelResponse,
+  CarCharge,
+  CarCondition,
+  CarDetails,
+  CarLocation,
+  CarMileage,
+  CarPaymentType,
+  CarQuote,
+  CarRate,
+  CarSearchResult,
+  CarSupplier,
+  CarTransmission,
+  DuffelCarWire,
+  DuffelCarsBookingResponse,
+  DuffelCarsBookingWire,
+  DuffelCarsCancelResponse,
+  DuffelCarsLocationWire,
+  DuffelCarsQuoteResponse,
+  DuffelCarsQuoteWire,
+  DuffelCarsRateWire,
+  DuffelCarsSearchResponse,
+  Money,
+} from './cars-types.js';
+
+const KNOWN_PAYMENT_TYPES: ReadonlySet<CarPaymentType> = new Set([
+  'guarantee',
+  'prepaid',
+  'postpaid',
+]);
+
+const KNOWN_TRANSMISSIONS: ReadonlySet<CarTransmission> = new Set([
+  'automatic',
+  'manual',
+]);
+
+const KNOWN_BOOKING_STATUSES: ReadonlySet<CarBookingStatus> = new Set([
+  'confirmed',
+  'cancelled',
+]);
+
+function toMoney(amount: string | undefined, currency: string | undefined): Money {
+  // Run through Decimal to normalize "10" / "10.00" / "10.0".
+  const amt = amount && amount.trim().length > 0 ? new Decimal(amount).toFixed(2) : '0.00';
+  return { amount: amt, currency: currency ?? 'USD' };
+}
+
+function toLocation(raw: DuffelCarsLocationWire | undefined): CarLocation {
+  const coords = raw?.geographic_coordinates;
+  const result: CarLocation = {
+    address: raw?.address ?? '',
+    latitude: typeof coords?.latitude === 'number' ? coords.latitude : 0,
+    longitude: typeof coords?.longitude === 'number' ? coords.longitude : 0,
+  };
+  if (raw?.phone) result.phone = raw.phone;
+  if (raw?.opening_hours) result.openingHours = raw.opening_hours;
+  return result;
+}
+
+function mapImages(raw: DuffelCarWire['images']): string[] {
+  if (!raw) return [];
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item === 'string') out.push(item);
+    else if (item && typeof item.url === 'string') out.push(item.url);
+  }
+  return out;
+}
+
+function toCarDetails(raw: DuffelCarWire | undefined): CarDetails {
+  const transmission =
+    raw?.transmission && KNOWN_TRANSMISSIONS.has(raw.transmission as CarTransmission)
+      ? (raw.transmission as CarTransmission)
+      : 'automatic';
+  return {
+    name: raw?.name ?? '',
+    // Pass the supplier value through; consumers can switch on the
+    // documented enum and still see unknown values verbatim. DQ-C3.
+    category: raw?.category ?? '',
+    type: raw?.type ?? '',
+    transmission,
+    fuel: raw?.fuel ?? '',
+    acrissCode: raw?.code ?? '',
+    maxPassengers: typeof raw?.max_passengers === 'number' ? raw.max_passengers : 0,
+    baggage: {
+      small: typeof raw?.baggage?.small === 'number' ? raw.baggage.small : 0,
+      large: typeof raw?.baggage?.large === 'number' ? raw.baggage.large : 0,
+    },
+    airConditioning: Boolean(raw?.air_conditioning),
+    images: mapImages(raw?.images),
+  };
+}
+
+function toSupplier(raw: { name?: string; logo_url?: string } | undefined): CarSupplier {
+  const out: CarSupplier = { name: raw?.name ?? '' };
+  if (raw?.logo_url) out.logoUrl = raw.logo_url;
+  return out;
+}
+
+function normalizePaymentType(raw: string | undefined): CarPaymentType {
+  if (raw && KNOWN_PAYMENT_TYPES.has(raw as CarPaymentType)) {
+    return raw as CarPaymentType;
+  }
+  // TODO: DOMAIN_QUESTION (DQ-C3 adjacent): unknown payment_type values.
+  // Defaulting to 'postpaid' avoids mis-charging the user; pay-at-counter
+  // is the safer assumption when the supplier intent is unclear.
+  return 'postpaid';
+}
+
+export function mapRate(raw: DuffelCarsRateWire, searchId: string): CarRate {
+  return {
+    rateId: raw.id,
+    searchId,
+    car: toCarDetails(raw.car),
+    supplier: toSupplier(raw.supplier),
+    pickupLocation: toLocation(raw.pickup_location),
+    dropoffLocation: toLocation(raw.dropoff_location),
+    baseAmount: toMoney(raw.base_amount, raw.base_currency),
+    totalAmount: toMoney(raw.total_amount, raw.total_currency),
+    paymentType: normalizePaymentType(raw.payment_type),
+  };
+}
+
+export function mapSearchResponse(response: DuffelCarsSearchResponse): CarSearchResult {
+  const data = response.data;
+  if (!data?.id) {
+    throw new Error('Duffel Cars search response missing data.id');
+  }
+  const rates = (data.rates ?? []).map((r) => mapRate(r, data.id));
+  return { searchId: data.id, rates };
+}
+
+function mapConditions(raw: DuffelCarsQuoteWire['conditions']): CarCondition[] {
+  return (raw ?? []).map((c) => ({ title: c?.title ?? '', text: c?.text ?? '' }));
+}
+
+function mapCharges(raw: DuffelCarsQuoteWire['charges']): CarCharge[] {
+  return (raw ?? []).map((c) => ({
+    amount: c?.amount ? new Decimal(c.amount).toFixed(2) : '0.00',
+    currency: c?.currency ?? 'USD',
+    description: c?.description ?? '',
+  }));
+}
+
+function mapMileage(raw: DuffelCarsQuoteWire['mileage']): CarMileage | undefined {
+  if (!raw) return undefined;
+  const out: CarMileage = { unlimited: Boolean(raw.unlimited) };
+  if (typeof raw.included === 'number') out.included = raw.included;
+  if (raw.unit) out.unit = raw.unit;
+  return out;
+}
+
+function mapPrivacyPolicies(raw: DuffelCarsQuoteWire['privacy_policies']): string[] {
+  if (!raw) return [];
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item === 'string') out.push(item);
+    else if (item && typeof item.text === 'string') out.push(item.text);
+    else if (item && typeof item.url === 'string') out.push(item.url);
+  }
+  return out;
+}
+
+export function mapQuoteResponse(response: DuffelCarsQuoteResponse): CarQuote {
+  const data = response.data;
+  if (!data?.id) {
+    throw new Error('Duffel Cars quote response missing data.id');
+  }
+  return {
+    quoteId: data.id,
+    rateId: data.rate_id ?? data.id,
+    searchId: data.search_id ?? '',
+    car: toCarDetails(data.car),
+    supplier: toSupplier(data.supplier),
+    pickupLocation: toLocation(data.pickup_location),
+    dropoffLocation: toLocation(data.dropoff_location),
+    totalAmount: toMoney(data.total_amount, data.total_currency),
+    conditions: mapConditions(data.conditions),
+    charges: mapCharges(data.charges),
+    ...(data.mileage ? { mileage: mapMileage(data.mileage) } : {}),
+    privacyPolicies: mapPrivacyPolicies(data.privacy_policies),
+  };
+}
+
+function normalizeBookingStatus(raw: string | undefined): CarBookingStatus {
+  if (raw && KNOWN_BOOKING_STATUSES.has(raw as CarBookingStatus)) {
+    return raw as CarBookingStatus;
+  }
+  // Unknown status — default to 'confirmed' for a successful book/get
+  // response. Cancellation is handled by a dedicated endpoint and
+  // mapper, so we never see 'cancelled' here unintentionally.
+  return 'confirmed';
+}
+
+function mapBookingWire(raw: DuffelCarsBookingWire): CarBookResponse {
+  return {
+    bookingId: raw.id,
+    status: normalizeBookingStatus(raw.status),
+    reference: raw.reference ?? '',
+    confirmedAt: raw.confirmed_at ?? '',
+    car: toCarDetails(raw.car),
+    supplier: toSupplier(raw.supplier),
+    pickupLocation: toLocation(raw.pickup_location),
+    dropoffLocation: toLocation(raw.dropoff_location),
+    totalAmount: toMoney(raw.total_amount, raw.total_currency),
+  };
+}
+
+export function mapBookingResponse(response: DuffelCarsBookingResponse): CarBookResponse {
+  const data = response.data;
+  if (!data?.id) {
+    throw new Error('Duffel Cars booking response missing data.id');
+  }
+  return mapBookingWire(data);
+}
+
+export function mapCancelResponse(response: DuffelCarsCancelResponse): CarCancelResponse {
+  const data = response.data;
+  return {
+    status: 'cancelled',
+    cancelledAt: data?.cancelled_at ?? '',
+  };
+}

--- a/packages/adapters/duffel/src/cars-types.ts
+++ b/packages/adapters/duffel/src/cars-types.ts
@@ -1,0 +1,322 @@
+/**
+ * Duffel Cars API — types.
+ *
+ * Two layers:
+ *   - **Canonical** (`Car*`) — the OTAIP-facing shape, matches the vendor brief.
+ *   - **Wire** (`DuffelCars*`) — the raw JSON Duffel returns. Best-effort
+ *     based on the brief; mappers tolerate missing fields. See
+ *     `docs/knowledge-base/cars.md` for outstanding DOMAIN_QUESTIONs.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared
+// ---------------------------------------------------------------------------
+
+export interface Money {
+  /** Decimal string — never parsed to Number. */
+  amount: string;
+  /** ISO 4217 currency code. */
+  currency: string;
+}
+
+export interface GeoCoordinates {
+  latitude: number;
+  longitude: number;
+}
+
+/**
+ * Documented car categories. Suppliers may publish other values; the
+ * mapper passes unknown strings through verbatim, so the public type is
+ * the union OR the raw string. See DQ-C3 in the KB.
+ */
+export type CarCategory =
+  | 'compact'
+  | 'economy'
+  | 'standard'
+  | 'full_size'
+  | 'premium'
+  | 'luxury'
+  | 'suv'
+  | 'van';
+
+export type CarTransmission = 'automatic' | 'manual';
+export type CarPaymentType = 'guarantee' | 'prepaid' | 'postpaid';
+export type CarBookingStatus = 'confirmed' | 'cancelled';
+
+// ---------------------------------------------------------------------------
+// Canonical types
+// ---------------------------------------------------------------------------
+
+export interface CarSearchLocation {
+  latitude: number;
+  longitude: number;
+  /** Search radius in kilometres. Default 5 (DQ-C1 — upper bound unverified). */
+  radius?: number;
+}
+
+export interface CarSearchRequest {
+  /** ISO date. */
+  pickupDate: string;
+  /** HH:mm 24-hour. Timezone — see DQ-C2. */
+  pickupTime: string;
+  pickupLocation: CarSearchLocation;
+  dropoffDate: string;
+  dropoffTime: string;
+  dropoffLocation: CarSearchLocation;
+  driver: {
+    age: number;
+    /** ISO 3166-1 alpha-2. */
+    residenceCountryCode: string;
+  };
+  signal?: AbortSignal;
+}
+
+export interface CarLocation {
+  address: string;
+  latitude: number;
+  longitude: number;
+  phone?: string;
+  /** Free-form opening hours. */
+  openingHours?: string;
+}
+
+export interface CarBaggage {
+  small: number;
+  large: number;
+}
+
+export interface CarDetails {
+  name: string;
+  /** Documented category or raw supplier value (DQ-C3). */
+  category: CarCategory | string;
+  /** Free-form body type — `four_door`, `suv`, etc. (DQ-C3). */
+  type: string;
+  transmission: CarTransmission;
+  fuel: string;
+  /** ACRISS four-letter code (e.g. `CDAV`). */
+  acrissCode: string;
+  maxPassengers: number;
+  baggage: CarBaggage;
+  airConditioning: boolean;
+  images: string[];
+}
+
+export interface CarSupplier {
+  name: string;
+  logoUrl?: string;
+}
+
+export interface CarRate {
+  rateId: string;
+  searchId: string;
+  car: CarDetails;
+  supplier: CarSupplier;
+  pickupLocation: CarLocation;
+  dropoffLocation: CarLocation;
+  baseAmount: Money;
+  totalAmount: Money;
+  paymentType: CarPaymentType;
+}
+
+export interface CarSearchResult {
+  searchId: string;
+  rates: CarRate[];
+}
+
+export interface CarCondition {
+  title: string;
+  text: string;
+}
+
+export interface CarCharge {
+  amount: string;
+  currency: string;
+  description: string;
+}
+
+export interface CarMileage {
+  unlimited: boolean;
+  /** Allowance count when not unlimited. */
+  included?: number;
+  /** Unit string passed through verbatim. */
+  unit?: string;
+}
+
+export interface CarQuote {
+  quoteId: string;
+  rateId: string;
+  searchId: string;
+  car: CarDetails;
+  supplier: CarSupplier;
+  pickupLocation: CarLocation;
+  dropoffLocation: CarLocation;
+  totalAmount: Money;
+  conditions: CarCondition[];
+  charges: CarCharge[];
+  mileage?: CarMileage;
+  /**
+   * Privacy policies the user must acknowledge before booking. Adapter
+   * surfaces them verbatim; consent is the orchestration layer's job.
+   * See DQ-C4.
+   */
+  privacyPolicies: string[];
+}
+
+export interface CarDriver {
+  givenName: string;
+  familyName: string;
+  email: string;
+  phoneNumber: string;
+  /** ISO date. */
+  dateOfBirth?: string;
+}
+
+/**
+ * Payment object passed through to Duffel verbatim. Card creation is
+ * out of scope for this adapter (DQ-C5) — callers construct the payment
+ * object using whatever Duffel-stored card they have.
+ */
+export type CarPayment =
+  | { method: 'card'; cardId: string }
+  | { method: string; [k: string]: unknown };
+
+export interface CarBookRequest {
+  quoteId: string;
+  driver: CarDriver;
+  payment?: CarPayment;
+  inboundFlightNumber?: string;
+  metadata?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+export interface CarBookResponse {
+  bookingId: string;
+  status: CarBookingStatus;
+  /** Supplier-issued booking reference. */
+  reference: string;
+  confirmedAt: string;
+  car: CarDetails;
+  supplier: CarSupplier;
+  pickupLocation: CarLocation;
+  dropoffLocation: CarLocation;
+  totalAmount: Money;
+}
+
+export interface CarCancelResponse {
+  status: 'cancelled';
+  cancelledAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Wire types — Duffel Cars API responses
+// ---------------------------------------------------------------------------
+
+export interface DuffelCarsSearchRequest {
+  data: {
+    pickup_date: string;
+    pickup_time: string;
+    pickup_location: { radius?: number; geographic_coordinates: GeoCoordinates };
+    dropoff_date: string;
+    dropoff_time: string;
+    dropoff_location: { radius?: number; geographic_coordinates: GeoCoordinates };
+    driver: { age: number; residence_country_code: string };
+  };
+}
+
+export interface DuffelCarWire {
+  name?: string;
+  category?: string;
+  type?: string;
+  transmission?: 'automatic' | 'manual' | string;
+  fuel?: string;
+  code?: string;
+  max_passengers?: number;
+  baggage?: { small?: number; large?: number };
+  air_conditioning?: boolean;
+  images?: Array<string | { url?: string }>;
+}
+
+export interface DuffelCarsLocationWire {
+  address?: string;
+  geographic_coordinates?: { latitude?: number; longitude?: number };
+  phone?: string;
+  opening_hours?: string;
+}
+
+export interface DuffelCarsRateWire {
+  id: string;
+  car?: DuffelCarWire;
+  supplier?: { name?: string; logo_url?: string };
+  pickup_location?: DuffelCarsLocationWire;
+  dropoff_location?: DuffelCarsLocationWire;
+  base_amount?: string;
+  base_currency?: string;
+  total_amount?: string;
+  total_currency?: string;
+  payment_type?: string;
+}
+
+export interface DuffelCarsSearchResponse {
+  data: {
+    id: string;
+    rates?: DuffelCarsRateWire[];
+  };
+}
+
+export interface DuffelCarsQuoteRequest {
+  data: { rate_id: string };
+}
+
+export interface DuffelCarsQuoteWire extends DuffelCarsRateWire {
+  search_id?: string;
+  rate_id?: string;
+  conditions?: Array<{ title?: string; text?: string }>;
+  charges?: Array<{ amount?: string; currency?: string; description?: string }>;
+  mileage?: { unlimited?: boolean; included?: number; unit?: string };
+  privacy_policies?: Array<string | { text?: string; url?: string }>;
+}
+
+export interface DuffelCarsQuoteResponse {
+  data: DuffelCarsQuoteWire;
+}
+
+export interface DuffelCarsBookingRequest {
+  data: {
+    quote_id: string;
+    driver: {
+      given_name: string;
+      family_name: string;
+      email: string;
+      phone_number: string;
+      date_of_birth?: string;
+    };
+    payment?: CarPayment;
+    metadata?: Record<string, string>;
+    inbound_flight_number?: string;
+  };
+}
+
+export interface DuffelCarsBookingWire {
+  id: string;
+  status?: string;
+  reference?: string;
+  confirmed_at?: string;
+  car?: DuffelCarWire;
+  supplier?: { name?: string; logo_url?: string };
+  pickup_location?: DuffelCarsLocationWire;
+  dropoff_location?: DuffelCarsLocationWire;
+  total_amount?: string;
+  total_currency?: string;
+}
+
+export interface DuffelCarsBookingResponse {
+  data: DuffelCarsBookingWire;
+}
+
+export interface DuffelCarsCancelResponse {
+  data: {
+    id?: string;
+    status?: string;
+    cancelled_at?: string;
+  };
+}

--- a/packages/adapters/duffel/src/duffel-adapter.ts
+++ b/packages/adapters/duffel/src/duffel-adapter.ts
@@ -23,6 +23,28 @@ import type {
 import { fetchWithRetry } from '@otaip/core';
 import Decimal from 'decimal.js';
 
+import type {
+  CarBookRequest,
+  CarBookResponse,
+  CarCancelResponse,
+  CarQuote,
+  CarSearchRequest,
+  CarSearchResult,
+  DuffelCarsBookingRequest,
+  DuffelCarsBookingResponse,
+  DuffelCarsCancelResponse,
+  DuffelCarsQuoteRequest,
+  DuffelCarsQuoteResponse,
+  DuffelCarsSearchRequest,
+  DuffelCarsSearchResponse,
+} from './cars-types.js';
+import {
+  mapBookingResponse as mapCarBookingResponse,
+  mapCancelResponse as mapCarCancelResponse,
+  mapQuoteResponse as mapCarQuoteResponse,
+  mapSearchResponse as mapCarSearchResponse,
+} from './cars-mapper.js';
+
 const DUFFEL_BASE_URL = 'https://api.duffel.com';
 
 /**
@@ -351,11 +373,125 @@ export class DuffelAdapter implements DistributionAdapter {
     };
   }
 
+  // -------------------------------------------------------------------------
+  // Cars API — search → quote → book
+  //
+  // Three-step flow (search → quote → book), unlike the two-step flight
+  // flow (search → book). Geo-coordinate based, not IATA codes. See
+  // `docs/knowledge-base/cars.md` for the authoritative domain input
+  // and outstanding DOMAIN_QUESTIONs.
+  // -------------------------------------------------------------------------
+
+  async searchCars(request: CarSearchRequest): Promise<CarSearchResult> {
+    const body: DuffelCarsSearchRequest = {
+      data: {
+        pickup_date: request.pickupDate,
+        pickup_time: request.pickupTime,
+        pickup_location: {
+          ...(request.pickupLocation.radius !== undefined
+            ? { radius: request.pickupLocation.radius }
+            : {}),
+          geographic_coordinates: {
+            latitude: request.pickupLocation.latitude,
+            longitude: request.pickupLocation.longitude,
+          },
+        },
+        dropoff_date: request.dropoffDate,
+        dropoff_time: request.dropoffTime,
+        dropoff_location: {
+          ...(request.dropoffLocation.radius !== undefined
+            ? { radius: request.dropoffLocation.radius }
+            : {}),
+          geographic_coordinates: {
+            latitude: request.dropoffLocation.latitude,
+            longitude: request.dropoffLocation.longitude,
+          },
+        },
+        driver: {
+          age: request.driver.age,
+          residence_country_code: request.driver.residenceCountryCode,
+        },
+      },
+    };
+    const response = (await this.request(
+      'POST',
+      '/cars/search',
+      body as unknown as Record<string, unknown>,
+      request.signal ? { signal: request.signal } : {},
+    )) as DuffelCarsSearchResponse;
+    return mapCarSearchResponse(response);
+  }
+
+  async quoteCar(rateId: string, signal?: AbortSignal): Promise<CarQuote> {
+    const body: DuffelCarsQuoteRequest = { data: { rate_id: rateId } };
+    const response = (await this.request(
+      'POST',
+      '/cars/quotes',
+      body as unknown as Record<string, unknown>,
+      signal ? { signal } : {},
+    )) as DuffelCarsQuoteResponse;
+    return mapCarQuoteResponse(response);
+  }
+
+  async bookCar(request: CarBookRequest): Promise<CarBookResponse> {
+    const body: DuffelCarsBookingRequest = {
+      data: {
+        quote_id: request.quoteId,
+        driver: {
+          given_name: request.driver.givenName,
+          family_name: request.driver.familyName,
+          email: request.driver.email,
+          phone_number: request.driver.phoneNumber,
+          ...(request.driver.dateOfBirth ? { date_of_birth: request.driver.dateOfBirth } : {}),
+        },
+        ...(request.payment ? { payment: request.payment } : {}),
+        ...(request.metadata ? { metadata: request.metadata } : {}),
+        ...(request.inboundFlightNumber
+          ? { inbound_flight_number: request.inboundFlightNumber }
+          : {}),
+      },
+    };
+    const response = (await this.request(
+      'POST',
+      '/cars/bookings',
+      body as unknown as Record<string, unknown>,
+      request.signal ? { signal: request.signal } : {},
+    )) as DuffelCarsBookingResponse;
+    return mapCarBookingResponse(response);
+  }
+
+  async getCarBooking(bookingId: string, signal?: AbortSignal): Promise<CarBookResponse> {
+    const response = (await this.request(
+      'GET',
+      `/cars/bookings/${encodeURIComponent(bookingId)}`,
+      undefined,
+      signal ? { signal } : {},
+    )) as DuffelCarsBookingResponse;
+    return mapCarBookingResponse(response);
+  }
+
+  async cancelCarBooking(
+    bookingId: string,
+    signal?: AbortSignal,
+  ): Promise<CarCancelResponse> {
+    const response = (await this.request(
+      'POST',
+      `/cars/bookings/${encodeURIComponent(bookingId)}/actions/cancel`,
+      undefined,
+      signal ? { signal } : {},
+    )) as DuffelCarsCancelResponse;
+    return mapCarCancelResponse(response);
+  }
+
   private async request(
     method: string,
     path: string,
     body?: Record<string, unknown>,
+    options: { signal?: AbortSignal } = {},
   ): Promise<unknown> {
+    if (options.signal?.aborted) {
+      throw new Error('Duffel API request aborted before dispatch');
+    }
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,

--- a/packages/adapters/duffel/src/index.ts
+++ b/packages/adapters/duffel/src/index.ts
@@ -3,3 +3,51 @@ export { DuffelAdapter, parseDurationToMinutes } from './duffel-adapter.js';
 export type { BookRequest, BookResponse } from './duffel-adapter.js';
 export { DuffelOrderBridge } from './order-bridge.js';
 export { duffelCapabilities } from './capabilities.js';
+
+// Cars — types
+export type {
+  CarBaggage,
+  CarBookRequest,
+  CarBookResponse,
+  CarBookingStatus,
+  CarCancelResponse,
+  CarCategory,
+  CarCharge,
+  CarCondition,
+  CarDetails,
+  CarDriver,
+  CarLocation,
+  CarMileage,
+  CarPayment,
+  CarPaymentType,
+  CarQuote,
+  CarRate,
+  CarSearchLocation,
+  CarSearchRequest,
+  CarSearchResult,
+  CarSupplier,
+  CarTransmission,
+  DuffelCarWire,
+  DuffelCarsBookingRequest,
+  DuffelCarsBookingResponse,
+  DuffelCarsBookingWire,
+  DuffelCarsCancelResponse,
+  DuffelCarsLocationWire,
+  DuffelCarsQuoteRequest,
+  DuffelCarsQuoteResponse,
+  DuffelCarsQuoteWire,
+  DuffelCarsRateWire,
+  DuffelCarsSearchRequest,
+  DuffelCarsSearchResponse,
+  GeoCoordinates,
+  Money,
+} from './cars-types.js';
+
+// Cars — mappers
+export {
+  mapBookingResponse as mapCarBookingResponse,
+  mapCancelResponse as mapCarCancelResponse,
+  mapQuoteResponse as mapCarQuoteResponse,
+  mapRate as mapCarRate,
+  mapSearchResponse as mapCarSearchResponse,
+} from './cars-mapper.js';

--- a/packages/adapters/duffel/src/mock-duffel-adapter.ts
+++ b/packages/adapters/duffel/src/mock-duffel-adapter.ts
@@ -15,6 +15,16 @@ import type {
   PriceResponse,
 } from '@otaip/core';
 
+import type {
+  CarBookRequest,
+  CarBookResponse,
+  CarCancelResponse,
+  CarQuote,
+  CarRate,
+  CarSearchRequest,
+  CarSearchResult,
+} from './cars-types.js';
+
 // ---------------------------------------------------------------------------
 // Mock flight data
 // ---------------------------------------------------------------------------
@@ -330,4 +340,208 @@ export class MockDuffelAdapter implements DistributionAdapter {
   async isAvailable(): Promise<boolean> {
     return this.available;
   }
+
+  // -------------------------------------------------------------------------
+  // Cars — synthetic three-step (search → quote → book) flow
+  //
+  // Same interface as the live `DuffelAdapter`. State is in-memory and
+  // shared across calls so the search/quote/book chain works without
+  // hitting the network.
+  // -------------------------------------------------------------------------
+
+  private nextSearchSeq = 1;
+  private nextQuoteSeq = 1;
+  private nextBookingSeq = 1;
+  private readonly carQuotes = new Map<string, CarQuote>();
+  private readonly carBookings = new Map<string, CarBookResponse>();
+  /** Maps a synthetic rate ID back to the underlying mock car so we can quote it. */
+  private readonly carRatesById = new Map<string, CarRate>();
+
+  async searchCars(request: CarSearchRequest): Promise<CarSearchResult> {
+    if (request.signal?.aborted) {
+      throw new Error('Mock Duffel Cars searchCars aborted before dispatch');
+    }
+    const searchId = `seh_mock_${String(this.nextSearchSeq++).padStart(6, '0')}`;
+    const rates: CarRate[] = MOCK_CAR_FIXTURES.map((fixture, i) => ({
+      ...fixture,
+      rateId: `rae_mock_${searchId}_${i}`,
+      searchId,
+      pickupLocation: {
+        ...fixture.pickupLocation,
+        latitude: request.pickupLocation.latitude,
+        longitude: request.pickupLocation.longitude,
+      },
+      dropoffLocation: {
+        ...fixture.dropoffLocation,
+        latitude: request.dropoffLocation.latitude,
+        longitude: request.dropoffLocation.longitude,
+      },
+    }));
+    for (const rate of rates) this.carRatesById.set(rate.rateId, rate);
+    return { searchId, rates };
+  }
+
+  async quoteCar(rateId: string, signal?: AbortSignal): Promise<CarQuote> {
+    if (signal?.aborted) {
+      throw new Error('Mock Duffel Cars quoteCar aborted before dispatch');
+    }
+    const rate = this.carRatesById.get(rateId);
+    if (!rate) throw new Error(`Mock Duffel Cars: unknown rateId ${rateId}`);
+    const quoteId = `qut_mock_${String(this.nextQuoteSeq++).padStart(6, '0')}`;
+    const quote: CarQuote = {
+      quoteId,
+      rateId: rate.rateId,
+      searchId: rate.searchId,
+      car: rate.car,
+      supplier: rate.supplier,
+      pickupLocation: rate.pickupLocation,
+      dropoffLocation: rate.dropoffLocation,
+      totalAmount: rate.totalAmount,
+      conditions: [
+        {
+          title: 'Free cancellation',
+          text: 'Cancel up to 48 hours before pickup for a full refund.',
+        },
+        { title: 'Fuel policy', text: 'Full-to-full. Return with a full tank.' },
+      ],
+      charges: [
+        {
+          amount: '5.00',
+          currency: rate.totalAmount.currency,
+          description: 'Mock airport surcharge',
+        },
+      ],
+      mileage: { unlimited: true },
+      privacyPolicies: [
+        'Mock supplier privacy policy: data is shared with the rental agency.',
+      ],
+    };
+    this.carQuotes.set(quoteId, quote);
+    return quote;
+  }
+
+  async bookCar(request: CarBookRequest): Promise<CarBookResponse> {
+    if (request.signal?.aborted) {
+      throw new Error('Mock Duffel Cars bookCar aborted before dispatch');
+    }
+    const quote = this.carQuotes.get(request.quoteId);
+    if (!quote) throw new Error(`Mock Duffel Cars: unknown quoteId ${request.quoteId}`);
+    const bookingId = `boo_mock_${String(this.nextBookingSeq++).padStart(6, '0')}`;
+    const booking: CarBookResponse = {
+      bookingId,
+      status: 'confirmed',
+      reference: `MOCK-CAR-${bookingId.slice(-6).toUpperCase()}`,
+      confirmedAt: new Date().toISOString(),
+      car: quote.car,
+      supplier: quote.supplier,
+      pickupLocation: quote.pickupLocation,
+      dropoffLocation: quote.dropoffLocation,
+      totalAmount: quote.totalAmount,
+    };
+    this.carBookings.set(bookingId, booking);
+    return booking;
+  }
+
+  async getCarBooking(bookingId: string, signal?: AbortSignal): Promise<CarBookResponse> {
+    if (signal?.aborted) {
+      throw new Error('Mock Duffel Cars getCarBooking aborted before dispatch');
+    }
+    const booking = this.carBookings.get(bookingId);
+    if (!booking) {
+      throw new Error(`Mock Duffel Cars: unknown bookingId ${bookingId}`);
+    }
+    return booking;
+  }
+
+  async cancelCarBooking(
+    bookingId: string,
+    signal?: AbortSignal,
+  ): Promise<CarCancelResponse> {
+    if (signal?.aborted) {
+      throw new Error('Mock Duffel Cars cancelCarBooking aborted before dispatch');
+    }
+    const booking = this.carBookings.get(bookingId);
+    if (!booking) {
+      throw new Error(`Mock Duffel Cars: unknown bookingId ${bookingId}`);
+    }
+    if (booking.status === 'cancelled') {
+      throw new Error(`Mock Duffel Cars: booking ${bookingId} already cancelled`);
+    }
+    this.carBookings.set(bookingId, { ...booking, status: 'cancelled' });
+    return { status: 'cancelled', cancelledAt: new Date().toISOString() };
+  }
 }
+
+// ---------------------------------------------------------------------------
+// Mock car fixtures
+//
+// Each fixture is location-agnostic — coordinates are filled in from the
+// search request so the response matches what the caller asked for.
+// ---------------------------------------------------------------------------
+
+const MOCK_CAR_FIXTURES: ReadonlyArray<Omit<CarRate, 'rateId' | 'searchId'>> = [
+  {
+    car: {
+      name: 'Toyota Corolla',
+      category: 'compact',
+      type: 'four_door',
+      transmission: 'automatic',
+      fuel: 'petrol',
+      acrissCode: 'CDAR',
+      maxPassengers: 5,
+      baggage: { small: 2, large: 1 },
+      airConditioning: true,
+      images: ['https://example.invalid/img/corolla.jpg'],
+    },
+    supplier: { name: 'Mock Rentals', logoUrl: 'https://example.invalid/logo/mock.png' },
+    pickupLocation: {
+      address: 'Mock Airport Pickup Counter',
+      latitude: 0,
+      longitude: 0,
+      phone: '+1-555-0100',
+      openingHours: '06:00–22:00',
+    },
+    dropoffLocation: {
+      address: 'Mock Airport Dropoff Counter',
+      latitude: 0,
+      longitude: 0,
+      phone: '+1-555-0100',
+      openingHours: '06:00–22:00',
+    },
+    baseAmount: { amount: '180.00', currency: 'USD' },
+    totalAmount: { amount: '212.40', currency: 'USD' },
+    paymentType: 'prepaid',
+  },
+  {
+    car: {
+      name: 'Volkswagen Tiguan',
+      category: 'suv',
+      type: 'suv',
+      transmission: 'automatic',
+      fuel: 'diesel',
+      acrissCode: 'IFAD',
+      maxPassengers: 5,
+      baggage: { small: 3, large: 2 },
+      airConditioning: true,
+      images: ['https://example.invalid/img/tiguan.jpg'],
+    },
+    supplier: { name: 'Mock Rentals', logoUrl: 'https://example.invalid/logo/mock.png' },
+    pickupLocation: {
+      address: 'Mock Airport Pickup Counter',
+      latitude: 0,
+      longitude: 0,
+      phone: '+1-555-0100',
+      openingHours: '06:00–22:00',
+    },
+    dropoffLocation: {
+      address: 'Mock Airport Dropoff Counter',
+      latitude: 0,
+      longitude: 0,
+      phone: '+1-555-0100',
+      openingHours: '06:00–22:00',
+    },
+    baseAmount: { amount: '320.00', currency: 'USD' },
+    totalAmount: { amount: '378.00', currency: 'USD' },
+    paymentType: 'guarantee',
+  },
+];


### PR DESCRIPTION
## Summary

Duffel launched **Cars** as a full API vertical alongside Flights and Stays. This PR extends `@otaip/adapter-duffel` with the rental-car surface — same Bearer auth, same `Duffel-Version: v2`, just under the `/cars/` namespace. Patterned identically to the Hotelbeds Activities/Transfers extension ([#90](https://github.com/telivity-otaip/otaip/pull/90)): one adapter class, new product surface.

## What's new on `DuffelAdapter`

| Method                  | Endpoint                                        |
| ----------------------- | ----------------------------------------------- |
| `searchCars`            | `POST /cars/search`                             |
| `quoteCar`              | `POST /cars/quotes`                             |
| `bookCar`               | `POST /cars/bookings`                           |
| `getCarBooking`         | `GET /cars/bookings/{id}`                       |
| `cancelCarBooking`      | `POST /cars/bookings/{id}/actions/cancel`       |

**Three-step flow** (search → quote → book), unlike the two-step flight flow. Search is geo-coordinate based; the brief explicitly defers IATA-to-coordinate conversion (DQ-C8). The adapter accepts only `{ latitude, longitude, radius? }` per location.

The shared `request()` helper now accepts an optional `AbortSignal` (pre-flight check; in-flight cancel needs an upstream change to `fetchWithRetry`, same caveat the Hotelbeds adapter carries).

## Files

- New: `cars-types.ts` (canonical + wire types — `CarRate`, `CarQuote`, `CarBookResponse`, etc., plus a `Money` type), `cars-mapper.ts` (decimal.js-backed wire→canonical mapping), `__tests__/cars.test.ts` (18 cases), `docs/knowledge-base/cars.md`.
- Edit: `duffel-adapter.ts` (5 methods + `request()` signal threading), `mock-duffel-adapter.ts` (full three-step mock flow + 2 car fixtures), `index.ts` (re-exports), `package.json` (0.7.1 → 0.7.2).

## Domain knowledge

`docs/knowledge-base/cars.md` captures the vendor brief verbatim and enumerates **8 open `DOMAIN_QUESTION` markers (DQ-C1..C8)** for the gaps the brief leaves open:

- DQ-C1 — `radius` upper bound
- DQ-C2 — `pickup_time` / `dropoff_time` timezone
- DQ-C3 — `car.category` / `car.type` enum closure
- DQ-C4 — `privacy_policies` consent flow
- DQ-C5 — Card creation (explicitly out of scope)
- DQ-C6 — `inbound_flight_number` format (IATA vs ICAO)
- DQ-C7 — Refund computation on cancellation
- DQ-C8 — IATA-to-coordinate conversion (deferred per brief)

Per the constitution's no-invent rule, these are surfaced rather than guessed. The adapter falls back to the safe choice where it must (e.g. unknown `payment_type` → `'postpaid'` so we never mis-charge) and documents the assumption inline.

## Verification

- `pnpm exec vitest run packages/adapters/duffel` — **58 passed / 3 skipped** (sandbox-gated).
- `pnpm exec eslint packages/adapters/duffel/src` — clean.
- `pnpm --filter @otaip/adapter-duffel typecheck` — clean.

## Versioning

`@otaip/adapter-duffel` 0.7.1 → 0.7.2 (single-package patch bump per [VERSIONING.md](VERSIONING.md)). The workspace-wide v0.7.2 release follows separately, same shape as #92 / #96. The brief asked for a "next minor" bump (0.8.0); flagging that we're sticking with the patch-bump policy unless you want to ratify another exception like the v0.7.0 hotelbeds case — let me know.

## Out of scope (intentional)

- Card creation (`POST /payments/cards`) — separate Duffel API.
- IATA → coordinate conversion — DQ-C8.
- Refund amount computation — DQ-C7.
- Sandbox integration test — could land in a follow-up; the unit + mock surface validates the full happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)