### PR TITLE
chore(release): v0.7.2 — Duffel Cars + auto-publish + post-#93 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 > **Versioning policy:** Pre-v1.0, every release is a patch bump (`0.6.0 → 0.6.1 → 0.6.2 → …`). See [VERSIONING.md](VERSIONING.md) for the full policy and an explanation of the early-history version jumps (0.3.4 → 0.5.0 → 0.5.1 → 0.6.0) that predate this rule. v0.6.4 → v0.7.0 is the one post-policy exception — see VERSIONING.md.
 
+## 0.7.2 — Duffel Cars + auto-publish workflow + post-#93 release fix
+
+Patch bump. Three pieces of substantive work in this window:
+
+### `@otaip/adapter-duffel` — Cars API ([#99](https://github.com/telivity-otaip/otaip/pull/99))
+
+Duffel launched **Cars** as a full API vertical alongside Flights and Stays. `DuffelAdapter` now spans both surfaces. Five new direct methods on the same class:
+
+- **Cars** (`/cars/`) — `searchCars`, `quoteCar`, `bookCar`, `getCarBooking`, `cancelCarBooking`. Three-step flow (search → quote → book) unlike the two-step flight flow. Geo-coordinate based — no IATA codes — per the brief; IATA-to-coordinate conversion is explicitly deferred (DQ-C8).
+- The shared private `request()` helper now accepts an optional `AbortSignal` (pre-flight check; in-flight cancel needs an upstream change to `fetchWithRetry`, same caveat the Hotelbeds adapter carries).
+
+New canonical types (`CarRate`, `CarQuote`, `CarBookResponse`, etc.), wire types, decimal.js-backed mapper, and a full mock three-step flow on `MockDuffelAdapter` (two synthetic fixtures: Toyota Corolla compact + VW Tiguan SUV). 18 new test cases covering body shapes, headers, mapper output, abort handling, 429 retry-then-error, and round-trip mock flow. Domain knowledge captured verbatim in `docs/knowledge-base/cars.md` with **8 numbered DOMAIN_QUESTION markers (DQ-C1..C8)** for the gaps the brief leaves open. Per the constitution's no-invent rule, those are surfaced rather than guessed.
+
+### Auto-publish workflow wiring ([#97](https://github.com/telivity-otaip/otaip/pull/97), [#98](https://github.com/telivity-otaip/otaip/pull/98))
+
+Post-mortem on why `@otaip/core` etc. sat at v0.6.4 on npm despite v0.7.0 and v0.7.1 GitHub releases existing:
+
+- **#97** — `scripts/count-agents.ts` had been importing `discoverAgents` through the CLI re-export added in [#93](https://github.com/telivity-otaip/otaip/pull/93). The Release workflow's *Count agents* step ran before any package was built, and the indirection forced tsx to resolve `@otaip/core` through its `package.json` `exports` map → `dist/index.js` (which doesn't exist on the runner) → `ERR_PACKAGE_PATH_NOT_EXPORTED`. Result: every push-to-main since #93 was failing the Release workflow silently, blocking tag creation. Fixed by importing directly from the source path.
+- **#98** — The Release workflow's `gh release create` was authenticated with `GITHUB_TOKEN`, but [GitHub Actions intentionally does not trigger downstream workflows for events fired by `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). That's why the Publish workflow never auto-fired off `release: published` for v0.7.0 or v0.7.1 — packages only made it to npm when someone clicked *Run workflow* manually. Switched the create-release step to a Personal Access Token (`RELEASE_PAT` secret) so the event is "user-fired" and propagates. Falls back to `GITHUB_TOKEN` when the secret is unset, so the workflow still functions in environments without the PAT.
+
+After v0.7.2 merges and tags, this is the first release that will auto-publish to npm without a manual workflow_dispatch.
+
+### Verification
+
+- `pnpm exec vitest run packages/adapters/duffel` — 58 passed / 3 skipped (sandbox-gated).
+- `pnpm -r typecheck` — clean across the workspace.
+- `pnpm exec eslint packages/adapters/duffel/src` — clean.
+
+### Versioning note
+
+Patch bump off v0.7.1 per VERSIONING.md. The Cars vendor brief asked for a "next minor" (0.8.0) bump; we honoured the policy and stuck with 0.7.2 instead. The next release is **v0.7.3**.
+
 ## 0.7.1 — Platform UI + agent-discovery promoted to `@otaip/core`
 
 Patch bump per the policy reset in v0.7.0. The headline of this window is the **Platform UI** ([#93](https://github.com/telivity-otaip/otaip/pull/93)) — a new React/Vite app at `examples/platform-ui/` that gives developers a visual control plane for an OTAIP instance: agent registry, adapter status, health sidebar, and an interactive Playground for searches/agents/adapters. The Platform UI is private (`examples/*` is not published to npm); the npm-visible delta is one additive export on `@otaip/core`.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -41,7 +41,7 @@ The jumps from 0.3.4 to 0.5.0 and 0.5.1 to 0.6.0 came from mechanically followin
 
 The v0.6.4 → v0.7.0 jump is the one exception that came after this policy document was written. It exists because `@otaip/adapter-hotelbeds@0.7.0` was published to npm as a per-package minor bump before the corresponding repo-wide release was cut; rather than leave the rest of the ecosystem stuck behind a non-existent v0.6.5 tag, we ratify the bump and re-sync.
 
-**Going forward, all releases are patch bumps off v0.7.x until v1.0.** The next release is v0.7.2.
+**Going forward, all releases are patch bumps off v0.7.x until v1.0.** The next release is v0.7.3.
 
 ## How to bump
 

--- a/examples/platform-ui/package.json
+++ b/examples/platform-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/platform-ui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/hotelbeds/package.json
+++ b/packages/adapters/hotelbeds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-hotelbeds",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP distribution adapter for the Hotelbeds APItude APIs — Hotels, Activities, and Transfers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Patch bump off v0.7.1. Three pieces of substantive work since v0.7.1, all merged green individually:

- **[#99](https://github.com/telivity-otaip/otaip/pull/99)** — `@otaip/adapter-duffel` gains the **Cars** API (search → quote → book → get → cancel). Three-step flow, geo-coordinate based, same Bearer + `Duffel-Version` headers as flights. 8 open `DOMAIN_QUESTION` markers (DQ-C1..C8) captured in `docs/knowledge-base/cars.md`.
- **[#97](https://github.com/telivity-otaip/otaip/pull/97)** — Hotfix that unbroke the Release workflow's *Count agents* step. #93's CLI re-export indirection was forcing tsx to resolve `@otaip/core` through its `package.json` `exports` map → `dist/index.js` (missing on the runner) → `ERR_PACKAGE_PATH_NOT_EXPORTED`. Every push-to-main since #93 was silently failing the Release workflow.
- **[#98](https://github.com/telivity-otaip/otaip/pull/98)** — Switched `gh release create` to `RELEASE_PAT` so `release: published` events propagate to the Publish workflow. This is the **first release** that should auto-publish to npm without a manual workflow_dispatch.

## What npm sees

- All 16 published packages bump 0.7.1 → 0.7.2.
- The Cars surface lands on `@otaip/adapter-duffel@0.7.2` for the first time — `@otaip/adapter-duffel` was already at 0.7.2 in source ([#99](https://github.com/telivity-otaip/otaip/pull/99)) but unpublished until this release tag fires.

## Files changed

- 18 `package.json` files bumped `0.7.1 → 0.7.2` (root + 16 workspace + `@otaip/platform-ui`; `@otaip/adapter-duffel` was already at 0.7.2).
- `CHANGELOG.md` — new `## 0.7.2` entry covering #99, #97, #98.
- `VERSIONING.md` — next-release pointer updated to `v0.7.3`.

## Test plan

- [x] `pnpm -r typecheck` — clean.
- [x] No source changes — purely version + docs.
- [x] **On merge: this is the first release with `RELEASE_PAT` wired up.** Expected chain:
  1. Release workflow runs on the merge commit → creates `v0.7.2` tag + GitHub release.
  2. `release: published` event auto-fires Publish workflow.
  3. `npm view @otaip/core version` returns `0.7.2`. `npm view @otaip/adapter-duffel version` returns `0.7.2` (Cars now consumable from npm).

If the chain breaks: check `RELEASE_PAT` hasn't expired or lost `Contents: write`; manual `gh workflow run publish.yml` is the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)