### PR TITLE
fix(deps): bump hono override + add ip-address override (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "pnpm": {
     "onlyBuiltDependencies": [],
     "overrides": {
-      "hono": ">=4.12.14"
+      "hono": ">=4.12.16",
+      "ip-address": ">=10.1.1"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.14'
+  hono: '>=4.12.16'
+  ip-address: '>=10.1.1'
 
 importers:
 
@@ -860,7 +861,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.14'
+      hono: '>=4.12.16'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1842,8 +1843,8 @@ packages:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -1869,8 +1870,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3124,9 +3125,9 @@ snapshots:
       fastq: 1.20.1
       glob: 13.0.6
 
-  '@hono/node-server@1.19.13(hono@4.12.14)':
+  '@hono/node-server@1.19.13(hono@4.12.18)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.18
 
   '@humanfs/core@0.19.1': {}
 
@@ -3162,7 +3163,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.14)
+      '@hono/node-server': 1.19.13(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -3172,7 +3173,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.14
+      hono: 4.12.18
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3916,7 +3917,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -4118,7 +4119,7 @@ snapshots:
 
   helmet@8.1.0: {}
 
-  hono@4.12.14: {}
+  hono@4.12.18: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4140,7 +4141,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary

Closes the three open Dependabot advisories. All three are transitive deps via `@modelcontextprotocol/sdk` in `packages/connect`. None are exploitable in our usage, but all three are easy clears via `pnpm.overrides` — the hono one is just a floor lift on an override that already exists.

| # | Module | Patch | Advisory | Why we're not exploitable |
|---|---|---|---|---|
| [#19](https://github.com/telivity-otaip/otaip/security/dependabot/19) | `ip-address` | `>=10.1.1` | [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) | XSS in `Address6.group()` / `link()` / `parseMessage`. We never render those to HTML. Advisory itself notes zero consumers across all 425 dependent npm packages. |
| [#22](https://github.com/telivity-otaip/otaip/security/dependabot/22) | `hono` (jsx) | `>=4.12.16` | [GHSA-69xw-7hcm-h432](https://github.com/advisories/GHSA-69xw-7hcm-h432) | Unvalidated JSX tag names. We don't use Hono JSX. |
| [#23](https://github.com/telivity-otaip/otaip/security/dependabot/23) | `hono` (bodyLimit) | `>=4.12.16` | [GHSA-9vqf-7f2p-gf9v](https://github.com/advisories/GHSA-9vqf-7f2p-gf9v) | `bodyLimit()` bypass on `Transfer-Encoding: chunked`. We don't run a Hono server (the OTA server is Fastify). |

## Change

```diff
   "pnpm": {
     "onlyBuiltDependencies": [],
     "overrides": {
-      "hono": ">=4.12.14"
+      "hono": ">=4.12.16",
+      "ip-address": ">=10.1.1"
     }
   },
```

`pnpm install` resolves to `hono@4.12.18` and `ip-address@10.2.0` (latest within the floors).

## Test plan

- [x] `pnpm audit --json` returns 0 advisories (was 3 moderate).
- [x] No source changes — only `package.json` overrides + lockfile.
- [ ] CI green on this PR.
- [ ] After merge: GitHub Dependabot security alerts #19, #22, #23 close automatically once they re-scan the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)