### PR TITLE
docs(1.7): assert hotel-search ownership belongs to 20.1

### DIFF
--- a/docs/agents/stage-1-search.md
+++ b/docs/agents/stage-1-search.md
@@ -159,7 +159,9 @@ Aggregates search results from multiple adapters with deduplication, price compa
 **Class:** `HotelCarSearchAgent`
 **Status:** Implemented (adapter-dependent)
 
-Hotel and car rental search via pluggable adapters. Returns empty results when no adapters configured.
+Car rental search (and, pending a deferred car-only migration, hotel) via pluggable adapters. Returns empty results when no adapters configured.
+
+**Routing ownership:** hotel search intent is owned by Hotel Search Aggregator (20.1) for all hotel queries -- standalone or within a trip. 1.7 owns car rental; it may compose with 20.1 for a combined hotel+car trip but does not own hotel intent. Route hotel queries to 20.1.
 
 **Input (`HotelCarSearchInput`):**
 - `operation` -- `'searchHotels' | 'searchCars'`

--- a/packages/agents/search/src/hotel-car-search/index.ts
+++ b/packages/agents/search/src/hotel-car-search/index.ts
@@ -6,6 +6,13 @@
  * offer with its source, applies filters, sorts, and returns with
  * per-adapter status metadata.
  *
+ * Routing ownership: 1.7 owns CAR rental search. HOTEL search intent is owned
+ * by Hotel Search Aggregator (20.1) for every hotel query — standalone or
+ * within a trip. 1.7 may compose with 20.1 for a combined hotel+car trip, but
+ * it does NOT own hotel intent; route all hotel queries to 20.1. (This agent
+ * still fans out to hotel adapters for backward compatibility; the car-only
+ * schema narrowing is deferred to its own migration — see TODO below.)
+ *
  * Pattern mirrors MultiSourceAggregatorAgent (1.6) but fetches from
  * adapters directly rather than receiving already-fetched results.
  */
@@ -30,6 +37,9 @@ import type {
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
+// TODO: Hotel intent is owned by 20.1 (Hotel Search Aggregator). The hotel
+// fan-out here is retained for backward compatibility only; narrow 1.7 to
+// car-only (schema/types/output/tests) in a separate, product-gated migration.
 export class HotelCarSearchAgent
   implements Agent<HotelCarSearchInput, HotelCarSearchOutput>
 {


### PR DESCRIPTION
## What
Documents the routing-ownership boundary for **Agent 1.7 (Hotel & Car Search)**:
- **Hotel search intent is owned by Agent 20.1 (Hotel Search Aggregator)** for *all* hotel queries — standalone or within a trip.
- **1.7 owns car rental.** It may compose with 20.1 for a combined hotel+car trip but does **not** own hotel intent — route hotel queries to 20.1.

## Why
Implements the 1.7↔20.1 disambiguation: 20.1 is the dedicated lodging-stage hotel owner (feeds the 20.2 dedup → 20.4 rate pipeline); 1.7 is the stage-1 aggregator. Wording deliberately avoids a *context-split* — hotel always routes to 20.1, consistent with the documented routing rule.

## Scope
**Comment/doc only** — JSDoc + a TODO + one line in `stage-1-search.md`. No schema, types, output contract, or runtime change. Non-breaking.

The breaking **car-only narrowing** of 1.7 (remove hotel from schema/types/output/tests) is deferred to its own product-gated migration — flagged via TODO in `index.ts`.

## Verification
- Diff scanned — clean.
- Comment/doc-only ⇒ no typecheck impact.