### PR TITLE
ci: guard against internal/pre-release references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Fail fast (before install/build) if internal/pre-release references
+      # leak into the public repo. Recurrence guard for the 018 incident.
+      - name: Guard against internal references
+        run: bash scripts/check-no-internal-refs.sh
+
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typecheck": "pnpm -r run typecheck",
     "data:download": "tsx scripts/download-airport-data.ts",
     "count:agents": "tsx scripts/count-agents.ts",
+    "check:no-internal-refs": "bash scripts/check-no-internal-refs.sh",
     "clean": "pnpm -r run clean && rm -rf node_modules"
   },
   "pnpm": {

--- a/scripts/check-no-internal-refs.sh
+++ b/scripts/check-no-internal-refs.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Recurrence guard for the routing-disambiguation handoff incident.
+#
+# Internal / pre-release artifacts (the downstream router's eval data,
+# corpus, version cadence, and codename) must never land in the public
+# OTAIP repo. This fails the build if any forbidden reference appears in a
+# tracked file — turning "remember to check" into "can't merge it".
+#
+# Override a legitimate hit by adding the marker `internal-ref-allow` on the
+# same line (e.g. regulatory "tarmac delays" — note that is lowercase and is
+# NOT matched by the case-sensitive `Tarmac` pattern below anyway).
+#
+# Run locally: pnpm run check:no-internal-refs
+set -euo pipefail
+
+# Restrict the scan to tracked files, excluding this script (it necessarily
+# names the patterns) and the lockfile.
+exclude=(':(exclude)scripts/check-no-internal-refs.sh' ':(exclude)pnpm-lock.yaml')
+
+# Case-sensitive proper noun: the router codename. Kept case-sensitive so the
+# regulatory phrase "tarmac delays" (lowercase) does not false-positive.
+cs_patterns=('Tarmac')
+
+# Case-insensitive internal tokens — specific enough to carry no false positives.
+ci_patterns=(
+  'eval-runs'
+  'routing_truth'
+  'routing_accuracy'
+  'generate_v06'
+  'v0_6_'
+  '018_routing_disambiguation'
+)
+
+found=0
+
+scan() {
+  local flags="$1" pattern="$2" hits
+  # `|| true` so a no-match (git grep exit 1) doesn't trip `set -e`.
+  hits=$(git grep $flags -nI -e "$pattern" -- "${exclude[@]}" 2>/dev/null || true)
+  # Drop explicitly allow-listed lines.
+  hits=$(printf '%s\n' "$hits" | grep -v 'internal-ref-allow' || true)
+  if [ -n "$hits" ]; then
+    echo "::error::Forbidden internal reference '$pattern' found:"
+    printf '%s\n' "$hits"
+    found=1
+  fi
+}
+
+for p in "${cs_patterns[@]}"; do scan "" "$p"; done
+for p in "${ci_patterns[@]}"; do scan "-i" "$p"; done
+
+if [ "$found" -ne 0 ]; then
+  echo ""
+  echo "Internal/pre-release references must not land in the public OTAIP repo."
+  echo "If a hit is genuinely legitimate, add 'internal-ref-allow' on that line"
+  echo "or narrow the pattern in scripts/check-no-internal-refs.sh."
+  exit 1
+fi
+
+echo "check:no-internal-refs — clean"


### PR DESCRIPTION
## What
Adds a CI guard (`scripts/check-no-internal-refs.sh`, run as the **first** CI step) that fails the build if internal/pre-release references land in the public repo.

## Why
Recurrence fix for the 018 handoff incident. Converts "remember to grep before pushing" into an enforced merge gate — if the forbidden tokens are in any tracked file, CI is red and it cannot merge.

## How
- **Case-sensitive `Tarmac`** (proper-noun codename) so the regulatory phrase `tarmac delays` (lowercase, in `knowledge/index.ts`) does **not** false-positive.
- Case-insensitive tokens: `eval-runs`, `routing_truth`, `routing_accuracy`, `generate_v06`, `v0_6_`, `018_routing_disambiguation`.
- **Escape hatch:** add `internal-ref-allow` on a line to whitelist a genuine hit.
- Excludes the script itself (it names the patterns) and the lockfile.
- Runs before install/build → fails fast and cheap.

## Tested
- Clean tree → pass (exit 0).
- Planted `Tarmac` / `eval-runs` / `routing_truth` / `v0_6_` → fail (exit 1) with clear errors.
- Allow-list marker → ignored (exit 0).

Also runnable locally: `pnpm run check:no-internal-refs`.

## Scope
CI + script + one `package.json` script entry. No runtime/package code touched.