### PR TITLE
ci: block backward-framing tell-words in the guard

### DIFF
--- a/scripts/check-no-internal-refs.sh
+++ b/scripts/check-no-internal-refs.sh
@@ -2,10 +2,16 @@
 #
 # Recurrence guard for the routing-disambiguation handoff incident.
 #
-# Internal / pre-release artifacts (the downstream router's eval data,
-# corpus, version cadence, and codename) must never land in the public
-# OTAIP repo. This fails the build if any forbidden reference appears in a
-# tracked file — turning "remember to check" into "can't merge it".
+# Blocks two kinds of leak from the public OTAIP repo:
+#   1. Internal/pre-release references — the downstream router's eval data,
+#      corpus, version cadence, and codename.
+#   2. Backward-framing tell-words — prose that implies an external consumer
+#      finds the agents "confusing". That is a *conceptual* leak even when no
+#      internal string is present: docs must use forward ownership framing
+#      ("agent X owns responsibility Y"), not "these are commonly confused".
+#
+# Fails the build if either appears in a tracked file — turning "remember to
+# check" into "can't merge it".
 #
 # Override a legitimate hit by adding the marker `internal-ref-allow` on the
 # same line (e.g. regulatory "tarmac delays" — note that is lowercase and is
@@ -32,29 +38,44 @@ ci_patterns=(
   '018_routing_disambiguation'
 )
 
+# Backward-framing tell-words (case-insensitive). The grep cannot reason about
+# framing, but it can catch these specific phrases the next time someone writes
+# a boundaries-style doc. Reword to forward ownership instead.
+framing_patterns=(
+  'commonly[ -]confused'
+  'easy to confuse'
+  'trap word'
+  'seem to overlap'
+  'seems to overlap'
+)
+
 found=0
 
 scan() {
-  local flags="$1" pattern="$2" hits
+  local flags="$1" pattern="$2" label="$3" hits
   # `|| true` so a no-match (git grep exit 1) doesn't trip `set -e`.
   hits=$(git grep $flags -nI -e "$pattern" -- "${exclude[@]}" 2>/dev/null || true)
   # Drop explicitly allow-listed lines.
   hits=$(printf '%s\n' "$hits" | grep -v 'internal-ref-allow' || true)
   if [ -n "$hits" ]; then
-    echo "::error::Forbidden internal reference '$pattern' found:"
+    echo "::error::$label '$pattern' found:"
     printf '%s\n' "$hits"
     found=1
   fi
 }
 
-for p in "${cs_patterns[@]}"; do scan "" "$p"; done
-for p in "${ci_patterns[@]}"; do scan "-i" "$p"; done
+for p in "${cs_patterns[@]}"; do scan "" "$p" "Forbidden internal reference"; done
+for p in "${ci_patterns[@]}"; do scan "-i" "$p" "Forbidden internal reference"; done
+for p in "${framing_patterns[@]}"; do scan "-i" "$p" "Backward-framing tell-word"; done
 
 if [ "$found" -ne 0 ]; then
   echo ""
-  echo "Internal/pre-release references must not land in the public OTAIP repo."
+  echo "Blocked from the public OTAIP repo:"
+  echo "  1. Internal/pre-release references (codename, eval/corpus tokens)."
+  echo "  2. Backward-framing tell-words that imply a consumer finds agents"
+  echo "     'confusing' — use forward ownership framing (agent X owns Y) instead."
   echo "If a hit is genuinely legitimate, add 'internal-ref-allow' on that line"
-  echo "or narrow the pattern in scripts/check-no-internal-refs.sh."
+  echo "or adjust the pattern in scripts/check-no-internal-refs.sh."
   exit 1
 fi
 


### PR DESCRIPTION
Hardens `check-no-internal-refs.sh` to catch the *conceptual* leak class the string-grep missed.

## Why
The guard blocked `tarmac`/`eval-runs`/`routing_truth`, but a boundaries doc still shipped backward-framing prose ("commonly confused", "trap word", "seem to overlap") — which implies an external consumer finds the agents confusing. That is moat-adjacent even with zero internal strings, and it took a human re-read to catch. This turns that into a permanent rule.

## What
- New **`Backward-framing tell-word`** category (distinct error from internal references): `commonly[ -]confused`, `easy to confuse`, `trap word`, `seem(s) to overlap`.
- Same `internal-ref-allow` per-line escape hatch.
- No legit current usage in the repo (verified), so nothing to whitelist.

## Tested
- Clean tree → pass.
- Planted framing + internal strings → fail, each with the correct category label.
- Allow-marker → ignored.

Docs/CI only.