### PR TITLE
ci(build): repo-wide verify:dist self-check (and fix a live un-inlined JSON bundle)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Build
         run: pnpm -r run build
 
+      # Fail loud if any built bundle can't be imported (e.g. a data file that
+      # tsup didn't inline → MODULE_NOT_FOUND on import). Catches the silent
+      # footgun before it can ship to npm.
+      - name: Verify built bundles load
+        run: pnpm verify:dist
+
       - name: Type check
         run: pnpm run typecheck
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Build all packages
         run: pnpm -r run build
 
+      # Pre-publish gate: every built bundle must import cleanly. A package
+      # whose dist throws MODULE_NOT_FOUND (e.g. an un-inlined data file) must
+      # never reach npm — `pnpm publish` would otherwise print success anyway.
+      - name: Verify built bundles load
+        run: pnpm verify:dist
+
       - name: Dry-run publish
         run: pnpm -r publish --access public --no-git-checks --dry-run
         env:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "typecheck": "pnpm -r run typecheck",
     "data:download": "tsx scripts/download-airport-data.ts",
     "count:agents": "tsx scripts/count-agents.ts",
+    "verify:dist": "tsx scripts/verify-dist.ts",
+    "verify": "pnpm -r run build && pnpm verify:dist",
     "check:no-internal-refs": "bash scripts/check-no-internal-refs.sh",
     "clean": "pnpm -r run clean && rm -rf node_modules"
   },

--- a/packages/agents/exchange/src/__tests__/dist-runtime.test.ts
+++ b/packages/agents/exchange/src/__tests__/dist-runtime.test.ts
@@ -1,0 +1,55 @@
+/**
+ * dist-runtime test — proves the BUILT bundle (not source) loads cleanly.
+ *
+ * Bug guarded against (B0a):
+ *   `involuntary-rebook/rebook-engine.ts` loaded `./data/eu-countries.json`
+ *   via `createRequire`. tsup bundles src/index.ts → dist/index.js without
+ *   emitting the JSON file, so on `import @otaip/agents-exchange` (after
+ *   publish) the bundled require resolved nothing → MODULE_NOT_FOUND the
+ *   moment the package was imported. This shipped broken until the repo-wide
+ *   `pnpm verify:dist` self-check caught it.
+ *
+ * Fix: the JSON file is imported via a plain ESM `import`, which esbuild
+ * inlines into dist/index.js.
+ *
+ * This test imports the dist artifact DIRECTLY (not the package alias —
+ * vitest.config.ts aliases `@otaip/agents-*` to `src/index.ts`, which would
+ * defeat the test). The engine loads JSON at module top level, so a
+ * successful `await import(dist)` already proves no MODULE_NOT_FOUND.
+ *
+ * Skips with a clear message when dist/index.js is missing. CI runs
+ * `pnpm -r run build` before tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DIST_INDEX = resolve(__dirname, '..', '..', 'dist', 'index.js');
+const DIST_AVAILABLE = existsSync(DIST_INDEX);
+
+const describeIfBuilt = DIST_AVAILABLE ? describe : describe.skip;
+
+if (!DIST_AVAILABLE) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[skip] @otaip/agents-exchange dist-runtime test: ${DIST_INDEX} not found.\n` +
+      '       Run `pnpm --filter @otaip/agents-exchange build` first.',
+  );
+}
+
+describeIfBuilt('@otaip/agents-exchange — built bundle loads + invokes', () => {
+  it('importing dist/index.js does not throw MODULE_NOT_FOUND', async () => {
+    const mod = await import(pathToFileURL(DIST_INDEX).href);
+    expect(typeof mod).toBe('object');
+    expect(mod).not.toBeNull();
+  });
+
+  it('exports the agent class that depends on JSON data', async () => {
+    const mod = (await import(pathToFileURL(DIST_INDEX).href)) as Record<string, unknown>;
+    expect(typeof mod['InvoluntaryRebook']).toBe('function');
+  });
+});

--- a/packages/agents/exchange/src/involuntary-rebook/rebook-engine.ts
+++ b/packages/agents/exchange/src/involuntary-rebook/rebook-engine.ts
@@ -19,7 +19,6 @@
  * // non-involuntary and emit a warning.
  */
 
-import { createRequire } from 'node:module';
 import { applyEU261 } from '@otaip/core';
 import type {
   InvoluntaryRebookInput,
@@ -31,9 +30,12 @@ import type {
   RegulatoryFlag,
 } from './types.js';
 
-const require = createRequire(import.meta.url);
-const euData = require('./data/eu-countries.json') as { countries: string[] };
-const EU_COUNTRIES = new Set(euData.countries);
+// Plain ESM JSON import — esbuild/tsup inlines this into dist/index.js. Do NOT
+// switch to `createRequire('./data/...json')`: tsup does not copy data files to
+// dist, so a runtime require resolves nothing → MODULE_NOT_FOUND on import.
+// (Guarded repo-wide by `pnpm verify:dist`.)
+import euCountriesJson from './data/eu-countries.json';
+const EU_COUNTRIES = new Set((euCountriesJson as { countries: string[] }).countries);
 
 // ---------------------------------------------------------------------------
 // Trigger assessment

--- a/scripts/verify-dist.ts
+++ b/scripts/verify-dist.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env tsx
+/**
+ * Build self-check — proves every published `@otaip/*` bundle actually LOADS.
+ *
+ * The footgun this guards against (B0a):
+ *   tsup bundles `src/index.ts` → `dist/index.js` but does NOT copy
+ *   `data/*.json`. An engine that loaded JSON via `createRequire(...)` emits a
+ *   runtime `require('./data/x.json')` into the bundle that resolves nothing →
+ *   `MODULE_NOT_FOUND` the moment a downstream consumer imports the package.
+ *   Agent discovery never catches this (it reads source, never imports), and
+ *   `pnpm publish` prints success regardless — so a broken package ships
+ *   silently and a consumer gets a plausible-but-wrong validation rate.
+ *
+ * Two per-package `dist-runtime.test.ts` files (booking, ticketing) guard
+ * this for those two packages only. This script generalises the same check to
+ * EVERY publishable package and fails loud on the first load error, naming the
+ * package and cause.
+ *
+ * Run after `pnpm -r run build` (the root `verify` script chains both).
+ *
+ * Usage:
+ *   pnpm verify:dist            # after a build
+ *   pnpm verify                 # build, then verify:dist
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { discoverAgents } from '../packages/core/src/discovery/agent-discovery.js';
+
+/** Hard floor for the agent roster — mirrors the CLI discovery test. */
+const MIN_AGENTS = 60;
+
+/**
+ * Packages we must NOT `import()` here because doing so has side effects.
+ * `@otaip/cli` calls `program.parse()` at module top level, so importing its
+ * bundle would parse THIS script's argv. It is an executable entrypoint, not a
+ * data-dependent library, and is covered by its own test suite.
+ */
+const IMPORT_EXCLUDE = new Set<string>(['@otaip/cli']);
+
+interface WorkspacePackage {
+  readonly name?: string;
+  readonly path: string;
+  readonly private?: boolean;
+}
+
+/**
+ * Enumerate publishable `@otaip/*` packages exactly the way the publish
+ * workflow does (`pnpm m ls --json`), so this self-check covers the same set
+ * that actually ships to npm.
+ */
+function listPublishablePackages(): { name: string; path: string }[] {
+  const raw = execSync('pnpm m ls --json --depth=-1', { encoding: 'utf8' });
+  const arr = JSON.parse(raw) as WorkspacePackage[];
+  return arr
+    .filter((p) => !p.private && p.name?.startsWith('@otaip/'))
+    .map((p) => ({ name: p.name as string, path: p.path }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function main(): Promise<void> {
+  const pkgs = listPublishablePackages();
+  if (pkgs.length === 0) {
+    console.error(
+      'verify-dist: no publishable @otaip/* packages discovered — refusing to claim success.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`verify-dist: checking ${pkgs.length} built packages…`);
+  const errors: string[] = [];
+
+  for (const pkg of pkgs) {
+    const dist = join(pkg.path, 'dist', 'index.js');
+    if (!existsSync(dist)) {
+      errors.push(`${pkg.name}: missing ${dist} — run \`pnpm -r run build\` first.`);
+      console.log(`  MISSING  ${pkg.name}`);
+      continue;
+    }
+    if (IMPORT_EXCLUDE.has(pkg.name)) {
+      console.log(`  SKIP     ${pkg.name}  (executable entrypoint — built artifact present)`);
+      continue;
+    }
+    try {
+      // Engines load their JSON at module top level, so a clean import is
+      // sufficient evidence the bundle inlined every data file (see the
+      // existing dist-runtime tests).
+      await import(pathToFileURL(dist).href);
+      console.log(`  OK       ${pkg.name}`);
+    } catch (err) {
+      const msg = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+      errors.push(`${pkg.name}: dist failed to import — ${msg}`);
+      console.log(`  FAIL     ${pkg.name}  (${msg})`);
+    }
+  }
+
+  // Roster sanity: discovery must still enumerate a non-trivial set of agents.
+  const agents = discoverAgents();
+  console.log(`verify-dist: discovered ${agents.length} agents across the workspace.`);
+  if (agents.length < MIN_AGENTS) {
+    errors.push(
+      `agent discovery returned only ${agents.length} agents (expected >= ${MIN_AGENTS}) — the discovery walk is likely broken.`,
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error('\nverify-dist FAILED:');
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+
+  console.log(`\nverify-dist passed: all ${pkgs.length} built bundles load cleanly.`);
+}
+
+main().catch((err) => {
+  console.error('verify-dist crashed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why
Field feedback: the bundling build silently breaks data-dependent agents — only a subset register and the consumer gets a plausible-but-wrong result instead of an error. Two per-package `dist-runtime.test.ts` files guarded this for booking/ticketing only.

## What
- New `scripts/verify-dist.ts` (`pnpm verify:dist`, `pnpm verify`): imports every publishable `@otaip/*` bundle and **hard-fails on `MODULE_NOT_FOUND`**, naming the package + cause. Wired into CI (after build) and as a pre-publish gate in `publish.yml`.
- **It caught a real bug on `main`:** `@otaip/agents-exchange` shipped a broken `dist` — `involuntary-rebook/rebook-engine.ts` loaded `eu-countries.json` via `createRequire`, which tsup never copies into `dist`. Importing the package threw `MODULE_NOT_FOUND`. Fixed to a plain ESM JSON import (esbuild inlines it) + added a matching `dist-runtime.test.ts`.

## Verify
`pnpm -r run build && pnpm verify:dist` → all 16 bundles load; exchange/involuntary-rebook tests (39) and the new dist-runtime test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)