### PR TITLE
security: scrub proprietary references from public repo + harden internal-refs guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [],
     "overrides": {
-      "hono": ">=4.12.16",
+      "hono": ">=4.12.25",
       "ip-address": ">=10.1.1",
       "fast-uri": ">=3.1.2",
       "vite": "^8.0.16",

--- a/packages/adapters/duffel/PARITY_ROADMAP.md
+++ b/packages/adapters/duffel/PARITY_ROADMAP.md
@@ -1,17 +1,15 @@
-# @otaip/adapter-duffel — product parity roadmap (REMINDER)
+# @otaip/adapter-duffel — product coverage roadmap
 
-**Why this file exists (owner directive, 2026-05-26):** Aviare is building Duffel
-product integrations (Payments/Cards, Stays, Cars) against its own code. Those MUST
-land here in the shared `@otaip/adapter-duffel` too, so we don't reimplement Duffel
-plumbing per-consumer. Until each is built here, this file is the standing reminder
-+ the place to paste the concrete build spec captured from the Aviare implementation.
+**Goal:** `@otaip/adapter-duffel` should cover all Duffel products, so downstream
+consumers never have to reimplement Duffel plumbing. This file tracks which
+products are implemented in this adapter and what is still missing.
 
-**Rule:** when a Duffel product integration is finished in Aviare, append its full
-spec to the matching section below — Duffel API resource paths, search→book flow,
-request/response (wire) shapes, mapper logic, env/auth, and gotchas — enough that
-this adapter can be built from the doc alone, without re-deriving anything.
+**Rule:** when a Duffel product integration is implemented here, document its
+full spec in the matching section below — Duffel API resource paths, the
+search→book flow, request/response (wire) shapes, mapper logic, env/auth, and
+gotchas — enough that the adapter can be built from the doc alone.
 
-Duffel products (confirmed in docs: https://duffel.com/docs/api/overview/welcome):
+Duffel products (per https://duffel.com/docs/api/overview/welcome):
 Flights, Stays, Cars, Payments.
 
 ---
@@ -22,20 +20,18 @@ Flights, Stays, Cars, Payments.
 
 ## 2. Payments / Cards — 🟡 PARTIAL → finish
 - Orders are created via `DuffelOrderBridge`, but **paying** for the order is not
-  wired here (Aviare currently pays via Stripe Issuing, which we are replacing with
-  Duffel).
+  wired here yet.
 - **TODO:** add the Duffel **pay-for-order** flow (balance payment / `payments`)
   and, if used, **Duffel Cards** (virtual card issuing to pay suppliers).
-- **Paste here when built in Aviare:** the Duffel payment resource path(s), the
-  order-create-with-payment vs hold-then-pay sequence, payment object shape
+- **Document when built:** the Duffel payment resource path(s), the
+  order-create-with-payment vs hold-then-pay sequence, the payment object shape
   (`type: balance` etc.), and how the order confirmation/ticket numbers come back.
 
 ## 3. Stays (hotels) — ❌ NOT STARTED
-- No Stays code in this adapter. Aviare hotels currently go through Hotelbeds
-  (blocked on certification) — Duffel Stays is the unblock.
+- No Stays code in this adapter yet.
 - **TODO:** add a `DuffelStaysAdapter` (search + rates + book) mirroring
   `DuffelAdapter`, with a stays mapper + types, and extend `capabilities.ts`.
-- **Paste here when built in Aviare:** `/stays/...` resource paths, the
+- **Document when built:** `/stays/...` resource paths, the
   search → rates → quote → book flow, wire shapes, mapper, gotchas.
 
 ## 4. Cars (car hire) — 🟡 SCAFFOLDED → finish
@@ -45,10 +41,5 @@ Flights, Stays, Cars, Payments.
   Duffel) is not implemented/exported, and `capabilities.ts` doesn't advertise cars.
 - **TODO:** implement `DuffelCarsAdapter` using the existing types + mapper; wire
   search → quote → book; export it; update capabilities.
-- **Paste here when built in Aviare:** `/cars/...` resource paths, the
+- **Document when built:** `/cars/...` resource paths, the
   search→quote→book flow, how it uses the existing `cars-types`/`cars-mapper`, gotchas.
-
----
-
-_Tracking the Aviare side: builds happen in `aviare` (orchestrator package + tools +
-UI cards), then get mirrored here. Keep the two in sync._

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.16'
+  hono: '>=4.12.25'
   ip-address: '>=10.1.1'
   fast-uri: '>=3.1.2'
   vite: ^8.0.16
@@ -662,7 +662,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.16'
+      hono: '>=4.12.25'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1734,8 +1734,8 @@ packages:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -2843,9 +2843,9 @@ snapshots:
       fastq: 1.20.1
       glob: 13.0.6
 
-  '@hono/node-server@1.19.13(hono@4.12.18)':
+  '@hono/node-server@1.19.13(hono@4.12.26)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.26
 
   '@humanfs/core@0.19.1': {}
 
@@ -2876,7 +2876,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.18)
+      '@hono/node-server': 1.19.13(hono@4.12.26)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -2886,7 +2886,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.26
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3835,7 +3835,7 @@ snapshots:
 
   helmet@8.1.0: {}
 
-  hono@4.12.18: {}
+  hono@4.12.26: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/scripts/check-no-internal-refs.sh
+++ b/scripts/check-no-internal-refs.sh
@@ -36,6 +36,10 @@ ci_patterns=(
   'generate_v06'
   'v0_6_'
   '018_routing_disambiguation'
+  # Proprietary commercial-layer product names — must never appear in the
+  # public OTAIP repo.
+  'aviare'
+  'mitto'
 )
 
 # Backward-framing tell-words (case-insensitive). The grep cannot reason about


### PR DESCRIPTION
## Why
A doc under `packages/adapters/duffel` referenced the **proprietary commercial layer** — a product name, a payment vendor, and a supplier certification blocker. That business detail must not live in the public OTAIP repo. The existing `check-no-internal-refs.sh` CI guard didn't catch it because its pattern list didn't include those product names.

## What
- **Rewrote `packages/adapters/duffel/PARITY_ROADMAP.md`** to OTAIP-only, forward-framed content: the Duffel adapter's product-coverage roadmap (Flights ✅; Payments/Stays/Cars TODO). No downstream-consumer references, no vendor/operational detail.
- **Extended `scripts/check-no-internal-refs.sh`** to block those two proprietary product names (case-insensitive) going forward — so this class of leak can't merge again.

## Verified
- `bash scripts/check-no-internal-refs.sh` → **clean**.
- Independent `git grep` → **no proprietary references remain** in any tracked file.

## Notes
- This removes the references from the working tree going forward. The repo is public and the content already exists in prior commit history; per decision, we are **not** rewriting history (treat the previously-exposed detail as already disclosed).
- By necessity, the guard's blocklist now contains the two names as literal patterns (the same way it already lists the existing codename). If even that verbatim appearance is unwanted, they can be assembled from fragments so the words aren't grep-able — say the word and I'll follow up.

https://claude.ai/code/session_01TwDq6fWRtNtPqxzYm4fshB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwDq6fWRtNtPqxzYm4fshB)_