### PR TITLE
feat(integration): live Duffel availability search through the gates + durable, readable traces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   "parserOptions": {
     "ecmaVersion": 2022,
     "sourceType": "module",
-    "project": ["./packages/core/tsconfig.json", "./packages/agents/reference/tsconfig.json", "./packages/agents/search/tsconfig.json", "./packages/agents/pricing/tsconfig.json", "./packages/agents/booking/tsconfig.json", "./packages/agents/ticketing/tsconfig.json", "./packages/agents/exchange/tsconfig.json", "./packages/agents/settlement/tsconfig.json", "./packages/agents/reconciliation/tsconfig.json", "./packages/agents/lodging/tsconfig.json", "./packages/agents-tmc/tsconfig.json", "./packages/agents-platform/tsconfig.json", "./packages/adapters/duffel/tsconfig.json", "./packages/connect/tsconfig.json"]
+    "project": ["./packages/core/tsconfig.json", "./packages/agents/reference/tsconfig.json", "./packages/agents/search/tsconfig.json", "./packages/agents/pricing/tsconfig.json", "./packages/agents/booking/tsconfig.json", "./packages/agents/ticketing/tsconfig.json", "./packages/agents/exchange/tsconfig.json", "./packages/agents/settlement/tsconfig.json", "./packages/agents/reconciliation/tsconfig.json", "./packages/agents/lodging/tsconfig.json", "./packages/agents-tmc/tsconfig.json", "./packages/agents-platform/tsconfig.json", "./packages/adapters/duffel/tsconfig.json", "./packages/connect/tsconfig.json", "./packages/integration/tsconfig.json"]
   },
   "plugins": ["@typescript-eslint"],
   "extends": [
@@ -20,5 +20,5 @@
     "@typescript-eslint/require-await": "off",
     "no-console": ["warn", { "allow": ["warn", "error"] }]
   },
-  "ignorePatterns": ["dist", "node_modules", "data", "*.js", "*.mjs", "**/__tests__/**"]
+  "ignorePatterns": ["dist", "node_modules", "data", "*.js", "*.mjs", "**/__tests__/**", "**/scripts/**"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # reference data
 /data/*
 
+# OTAIP run/gate traces (durable JSONL written by @otaip/integration)
+traces/
+
 # Logs
 logs
 *.log

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -1,0 +1,315 @@
+# OTAIP Integration Guide
+
+How to run a contracted OTAIP agent against a **live distribution supplier** through
+the six pipeline gates, and how to read the run's **execution + gate trace** back by id.
+
+This guide covers exactly one proven path, end to end:
+
+> **Agent 1.1 — Availability Search → Duffel NDC sandbox → real offers → durable trace**
+
+It is implemented in a single caller-facing package, [`@otaip/integration`](packages/integration),
+which wires the **real** components together with **no parallel execution or validation path**:
+
+```
+runAvailabilitySearch()                    ← packages/integration
+  └─ AvailabilitySearch (Agent 1.1)        ← @otaip/agents-search   (unchanged)
+       └─ DuffelAdapter (DistributionAdapter) ← @otaip/adapter-duffel (live Duffel REST)
+  └─ PipelineOrchestrator.runAgent()       ← @otaip/core            (the six gates)
+       └─ availabilitySearchContract        ← @otaip/agents-search   (Zod + semantic gate)
+       └─ ReferenceAgentDataProvider        ← @otaip/agents-reference (OurAirports data)
+  └─ agent.executed + adapter.health events → EventStore (in-memory or FileEventStore)
+```
+
+The gates, event types, and unified output model are the existing ones in `@otaip/core`.
+The integration package only adds the glue function, a durable file-backed `EventStore`,
+and a by-id trace reader.
+
+---
+
+## 1. Adapter execution — run Agent 1.1 via Duffel
+
+**Mechanism:** in-process (package import). There is no HTTP server in this path.
+
+```ts
+import { runAvailabilitySearch, getRunTrace } from '@otaip/integration';
+
+const result = await runAvailabilitySearch(
+  {
+    origin: 'JFK',          // IATA, 3 letters
+    destination: 'LHR',     // IATA, 3 letters
+    departure_date: '2026-07-23', // ISO YYYY-MM-DD, must be in the future
+    passengers: [{ type: 'ADT', count: 1 }],
+    cabin_class: 'economy', // economy | premium_economy | business | first
+    currency: 'GBP',        // optional ISO 4217 (see sandbox note below)
+    max_results: 3,
+    sort_by: 'price',
+  },
+  {
+    duffelApiKey: process.env.DUFFEL_API_KEY, // see "Credentials" below
+    // eventStore, reference, adapter, now are all optional — sensible defaults
+  },
+);
+
+if (result.ok) {
+  console.log(result.output.offers.length, 'offers'); // unified SearchOffer[]
+} else {
+  console.error(result.failure.reason, result.failure.issues); // gate rejection
+}
+```
+
+### Input shape — `AvailabilitySearchInput`
+
+The input is Agent 1.1's own contract input (`@otaip/agents-search`), validated by the
+`schema_in` Zod gate and the `semantic_in` gate before the adapter is ever called:
+
+| Field            | Type                                   | Required | Notes |
+|------------------|----------------------------------------|----------|-------|
+| `origin`         | `string` (len 3)                       | yes      | resolved against reference data (semantic gate) |
+| `destination`    | `string` (len 3)                       | yes      | must differ from `origin` |
+| `departure_date` | `string` `YYYY-MM-DD`                  | yes      | must not be in the past (semantic gate) |
+| `return_date`    | `string` `YYYY-MM-DD`                  | no       | if set, must be ≥ `departure_date` |
+| `passengers`     | `{ type: 'ADT'\|'CHD'\|'INF'\|…; count: number }[]` | yes | ≥ 1 |
+| `cabin_class`    | `'economy'\|'premium_economy'\|'business'\|'first'` | no | |
+| `currency`       | `string` (len 3)                       | no       | ISO 4217 |
+| `max_connections`, `direct_only`, `max_results`, `sort_by`, `sort_order`, `sources` | various | no | see [types.ts](packages/agents/search/src/availability-search/types.ts) |
+
+### Credentials-injection contract
+
+The Duffel API key is read **once, at adapter construction**, from either:
+
+1. **`options.duffelApiKey`** passed to `runAvailabilitySearch`, **or**
+2. **`process.env.DUFFEL_API_KEY`** if (1) is omitted (the `DuffelAdapter` default).
+
+A `duffel_test_…` key targets the **sandbox**; a `duffel_live_…` key targets **production**.
+The environment is determined by the key prefix, not by code.
+
+**The key is server-side only.** It is never written to an event, a trace, a log line, or
+the returned payload. The trace contains only `OtaipEvent` objects (gate booleans, timing,
+adapter id, status) — there is no field that can carry a credential or PII. The offline test
+[`run-search.test.ts`](packages/integration/src/__tests__/run-search.test.ts) asserts the
+on-disk trace file never matches `/duffel_test_|duffel_live_|Bearer/`.
+
+To target a different supplier or a recorded-fixture server, inject a pre-built adapter:
+`runAvailabilitySearch(input, { adapter: myAdapter })` (then `duffelApiKey` is ignored).
+
+### Output shape — `RunSearchResult`
+
+```ts
+interface RunSearchResult {
+  sessionId: string;                  // use this to read the trace back
+  ok: boolean;                        // true ⇔ every gate passed
+  output?: AvailabilitySearchOutput;  // present iff ok (the unified model)
+  failure?: { reason: string; failureClass: 'infra'|'execution'|'validation'; issues: SemanticIssue[] };
+  trace: RunTrace;                    // also durably in eventStore
+  eventStore: EventStore;             // the store this run wrote to
+}
+```
+
+`output` is the existing unified output model — `AvailabilitySearchOutput` with
+`offers: SearchOffer[]` (`offer_id`, `source`, `itinerary`, `price`, …), `total_raw_offers`,
+`source_status[]`, `truncated`. The Duffel adapter normalizes the raw NDC response into this
+model; nothing here forks the shape.
+
+`failureClass` distinguishes an infrastructure/setup problem (`infra`) from a real agent
+execution error (`execution`) from a genuine contract-gate rejection (`validation`) — so a
+caller never mistakes a wiring bug for a data/model rejection.
+
+> **Runtime note:** the default `ReferenceAgentDataProvider` loads airport data from
+> `${process.cwd()}/data/reference/airports.json`. Run `pnpm run data:download` once, and
+> invoke from the **repo root** (or pass your own `reference` provider). If the data is
+> missing, the run fails at the semantic gate, not silently.
+
+---
+
+## 2. Trace read — fetch a run's trace by id
+
+**Mechanism:** in-process API over the same `EventStore` the run wrote to.
+
+```ts
+import { getRunTrace, FileEventStore } from '@otaip/integration';
+
+// Durable: a DIFFERENT process can re-open the same file and read the trace by id.
+const store = await FileEventStore.open('./traces/run.jsonl');
+const result = await runAvailabilitySearch(input, { eventStore: store });
+
+// …later, anywhere with access to the file:
+const reopened = await FileEventStore.open('./traces/run.jsonl');
+const trace = await getRunTrace(reopened, result.sessionId);
+```
+
+`getRunTrace(store, sessionId)` is a pure projection over the event store (no re-execution).
+Auth for the trace is **the same as filesystem access to the JSONL file** (or to whichever
+`EventStore` backend you supply) — there is no separate auth surface in this in-process path.
+
+### Trace response shape — `RunTrace`
+
+```ts
+interface RunTrace {
+  sessionId: string;
+  outcome: 'ok' | 'rejected' | 'empty';
+  agentExecutions: {
+    agentId: string; success: boolean; confidence: number; durationMs: number;
+    timestamp: string; gateResults: { gate: string; passed: boolean }[];
+  }[];
+  adapterHealth: { adapterId: string; status: 'healthy'|'degraded'|'unhealthy'; latencyMs?: number; timestamp: string }[];
+  events: OtaipEvent[]; // raw, chronological — the durable source of truth
+}
+```
+
+The underlying events are the existing core types: `agent.executed` (gate results + timing,
+emitted exactly as the `agentToTool` bridge does) and `adapter.health` (derived from the real
+search's per-source status). `EventStore.query({ sessionId })` / `.aggregate()` are the
+existing core APIs; `FileEventStore` reuses core's `InMemoryEventStore` for them and only adds
+durable JSONL persistence.
+
+---
+
+## 3. Package versions & environment
+
+All packages are workspace version **`0.7.2`** (Node **≥ 24.14.1**, pnpm 10):
+
+| Package                  | Role |
+|--------------------------|------|
+| `@otaip/integration@0.7.2` | the entry point in this guide (new) |
+| `@otaip/core@0.7.2`        | gates, event types, unified model |
+| `@otaip/adapter-duffel@0.7.2` | live Duffel REST adapter |
+| `@otaip/agents-search@0.7.2`  | Agent 1.1 + contract |
+| `@otaip/agents-reference@0.7.2` | airport/airline reference provider |
+
+**Environment variables a caller must set:**
+
+| Var | Required | Purpose |
+|-----|----------|---------|
+| `DUFFEL_API_KEY` | yes (unless `options.duffelApiKey` is passed) | Duffel token; `duffel_test_…` = sandbox, `duffel_live_…` = production |
+
+One-time data setup: `pnpm run data:download` (populates `data/reference/` from OurAirports;
+gitignored). No other new env vars are introduced.
+
+### Reproduce the proof yourself
+
+```bash
+pnpm install
+pnpm run data:download                     # one-time reference data
+export DUFFEL_API_KEY=duffel_test_xxx      # your sandbox key
+pnpm exec tsx packages/integration/scripts/duffel-search.ts   # run from repo root
+```
+
+Source: [`scripts/duffel-search.ts`](packages/integration/scripts/duffel-search.ts).
+
+---
+
+## 4. Sandbox proof (real Duffel sandbox, keys redacted)
+
+Captured **2026-06-23** against `https://api.duffel.com` with a `duffel_test_…` key
+(`live_mode: false`). Route **JFK → LHR**, `2026-07-23`, 1 ADT, economy.
+
+### 4a. Request the adapter POSTs to `POST /air/offer_requests?return_offers=true`
+
+```json
+{
+  "data": {
+    "slices": [{ "origin": "JFK", "destination": "LHR", "departure_date": "2026-07-23" }],
+    "passengers": [{ "type": "adult" }],
+    "cabin_class": "economy",
+    "return_offers": true
+  }
+}
+```
+
+Headers (key redacted): `Authorization: Bearer duffel_test_***REDACTED***`,
+`Duffel-Version: v2`, `Content-Type: application/json`.
+
+### 4b. Real Duffel response (first offer, trimmed — `live_mode: false` confirms sandbox)
+
+```json
+{
+  "offer_request_id": "orq_0000B7dFlto81bmCx4mQXw",
+  "offer": {
+    "id": "off_0000B7dFlu2f9ZP1g9a2CY",
+    "total_amount": "215.74",
+    "total_currency": "USD",
+    "base_amount": "182.83",
+    "tax_amount": "32.91",
+    "live_mode": false,
+    "slices": [{
+      "origin": "JFK", "destination": "LHR", "duration": "PT7H58M",
+      "segments": [{
+        "marketing_carrier": "ZZ", "flight_number": "7611",
+        "origin": "JFK", "destination": "LHR",
+        "departing_at": "2026-07-23T17:01:00", "arriving_at": "2026-07-24T05:59:00",
+        "cabin": "economy"
+      }]
+    }]
+  },
+  "total_offers": 168
+}
+```
+
+### 4c. Normalized output via `runAvailabilitySearch` (gates PASS, 168 raw offers → top 3)
+
+```
+Gate outcome: PASS (all gates)
+Session id:   sess_mqqxj2pe_bsunoc
+Raw offers:   168   |   returned: 3
+
+  1. off_0000B7dF1KBJAIvVkG0qB8  BA0107  JFK→LHR  dep 2026-07-23T17:01:00  215.15 USD  (0 stop(s), 478m)
+  2. off_0000B7dF1KAxBcdvj9qYcs  ZZ7611  JFK→LHR  dep 2026-07-23T17:01:00  228.95 USD  (0 stop(s), 478m)
+  3. off_0000B7dF1KBJAIvVkG0qBB  IB3177  JFK→LHR  dep 2026-07-23T17:01:00  229.96 USD  (0 stop(s), 478m)
+
+source_status: [{ "source": "duffel", "success": true, "offer_count": 168, "response_time_ms": 2054 }]
+```
+
+> **Sandbox note (honest):** `currency: 'GBP'` was requested but the Duffel sandbox returned
+> offers in **USD**. The unified model faithfully reports whatever the supplier returns; OTAIP
+> does not coerce it. `ZZ` is Duffel's sandbox test airline ("Duffel Airways"); real carriers
+> (BA, IB) also appear because the sandbox blends fixture and live-schedule data.
+
+### 4d. Real emitted trace for that run (durable JSONL, read back by session id)
+
+The exact two lines written to `traces/duffel-jfk-lhr-2026-07-23.jsonl` — no secrets, no PII:
+
+```json
+{"eventId":"evt_mqqxj4aj_1","type":"agent.executed","timestamp":"2026-06-23T17:39:50.779Z","sessionId":"sess_mqqxj2pe_bsunoc","agentId":"1.1","inputHash":"6fcd2f57","confidence":1,"durationMs":2057,"success":true,"gateResults":[{"gate":"intent_lock","passed":true},{"gate":"schema_in","passed":true},{"gate":"semantic_in","passed":true},{"gate":"cross_agent","passed":true},{"gate":"execute","passed":true},{"gate":"schema_out","passed":true},{"gate":"confidence","passed":true},{"gate":"action_class","passed":true}]}
+{"eventId":"evt_mqqxj4ak_2","type":"adapter.health","timestamp":"2026-06-23T17:39:50.780Z","sessionId":"sess_mqqxj2pe_bsunoc","adapterId":"duffel","status":"healthy","latencyMs":2054}
+```
+
+`getRunTrace(store, 'sess_mqqxj2pe_bsunoc')` projects this into:
+
+```json
+{
+  "sessionId": "sess_mqqxj2pe_bsunoc",
+  "outcome": "ok",
+  "agentExecutions": [{
+    "agentId": "1.1", "success": true, "confidence": 1, "durationMs": 2057,
+    "timestamp": "2026-06-23T17:39:50.779Z",
+    "gateResults": [
+      { "gate": "intent_lock", "passed": true }, { "gate": "schema_in", "passed": true },
+      { "gate": "semantic_in", "passed": true }, { "gate": "cross_agent", "passed": true },
+      { "gate": "execute", "passed": true }, { "gate": "schema_out", "passed": true },
+      { "gate": "confidence", "passed": true }, { "gate": "action_class", "passed": true }
+    ]
+  }],
+  "adapterHealth": [{ "adapterId": "duffel", "status": "healthy", "latencyMs": 2054, "timestamp": "2026-06-23T17:39:50.780Z" }]
+}
+```
+
+---
+
+## What runs end to end vs. what does not
+
+- ✅ **Live**: Duffel sandbox **availability search** (Agent 1.1) → real, normalized offers,
+  through all six gates, with a durable, re-readable trace. Verified above and by the live e2e
+  test [`duffel-e2e.test.ts`](packages/adapters/duffel/src/__tests__/duffel-e2e.test.ts)
+  (runs when `DUFFEL_API_KEY` is set; skipped otherwise).
+- ⛔ **Not claimed**: booking/ticketing against a live supplier. The Duffel adapter has
+  `book()`, but creating real orders needs more than a sandbox search key (payment/balance
+  setup, passenger PII handling, order-management lifecycle) and is **not** proven here. It is
+  left unstubbed rather than presented as a working "live" result.
+
+### Note for maintainers
+
+The previous `duffel-e2e.test.ts` was **stale**: it constructed `new DuffelAdapter({ apiKey })`
+(the real constructor is positional `(apiKey?, baseUrl?)` with `DUFFEL_API_KEY` fallback) and
+asserted on `offer.total_price` / `offer.itineraries`, which the unified model does not have
+(`offer.price` / `offer.itinerary`). It could not compile or pass against the shipped adapter.
+It has been corrected to the real API and unified output model, and now passes live (3/3).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ export default defineConfig([
     "**/*.js",
     "**/*.mjs",
     "**/__tests__/**/*",
+    "**/scripts/**",
 ]), {
 
     plugins: {
@@ -47,6 +48,7 @@ export default defineConfig([
                 "./packages/adapters/hotelbeds/tsconfig.json",
                 "./packages/connect/tsconfig.json",
                 "./packages/cli/tsconfig.json",
+                "./packages/integration/tsconfig.json",
             ],
         },
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
       "ip-address": ">=10.1.1",
       "fast-uri": ">=3.1.2",
       "vite": "^8.0.16",
-      "esbuild": ">=0.28.1"
+      "esbuild": ">=0.28.1",
+      "qs": ">=6.15.2"
     }
   },
   "devDependencies": {

--- a/packages/adapters/duffel/src/__tests__/duffel-e2e.test.ts
+++ b/packages/adapters/duffel/src/__tests__/duffel-e2e.test.ts
@@ -12,13 +12,20 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { DuffelAdapter } from '../duffel-adapter.js';
 import type { SearchRequest } from '@otaip/core';
 
-const describeE2E = process.env.DUFFEL_API_KEY ? describe : describe.skip;
+const describeE2E = process.env['DUFFEL_API_KEY'] ? describe : describe.skip;
+
+function isoDatePlusDays(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
 
 describeE2E('Duffel Sandbox E2E', () => {
   let adapter: DuffelAdapter;
 
   beforeAll(() => {
-    adapter = new DuffelAdapter({ apiKey: process.env.DUFFEL_API_KEY! });
+    // The key is read from the constructor arg or DUFFEL_API_KEY (here, the env).
+    adapter = new DuffelAdapter(process.env['DUFFEL_API_KEY']!);
   });
 
   it('is available (health check)', async () => {
@@ -26,24 +33,10 @@ describeE2E('Duffel Sandbox E2E', () => {
     expect(available).toBe(true);
   });
 
-  it('searches for flights', async () => {
-    const thirtyDaysFromNow = new Date();
-    thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
-    const departureDate = thirtyDaysFromNow.toISOString().split('T')[0]!;
-
+  it('searches for flights and returns the unified output model', async () => {
     const request: SearchRequest = {
-      segments: [
-        {
-          origin: 'LHR',
-          destination: 'CDG',
-          departure_date: departureDate,
-        },
-      ],
-      passengers: {
-        adults: 1,
-        children: 0,
-        infants: 0,
-      },
+      segments: [{ origin: 'LHR', destination: 'CDG', departure_date: isoDatePlusDays(30) }],
+      passengers: [{ type: 'ADT', count: 1 }],
       cabin_class: 'economy',
     };
 
@@ -51,49 +44,30 @@ describeE2E('Duffel Sandbox E2E', () => {
     expect(response.offers.length).toBeGreaterThan(0);
 
     const offer = response.offers[0]!;
-    expect(offer.total_price).toBeDefined();
-    expect(offer.currency).toBeDefined();
-    expect(offer.itineraries.length).toBeGreaterThan(0);
-    expect(offer.itineraries[0]!.segments.length).toBeGreaterThan(0);
+    expect(offer.offer_id).toMatch(/^off_/);
+    expect(offer.source).toBe('duffel');
+    expect(offer.price.total).toBeGreaterThan(0);
+    expect(offer.price.currency).toBeDefined();
+    expect(offer.itinerary.segments.length).toBeGreaterThan(0);
 
-    const segment = offer.itineraries[0]!.segments[0]!;
+    const segment = offer.itinerary.segments[0]!;
     expect(segment.origin).toBe('LHR');
-    expect(segment.destination).toBe('CDG');
     expect(segment.departure_time).toBeDefined();
     expect(segment.arrival_time).toBeDefined();
   });
 
   it('prices an offer', async () => {
-    // First search
-    const thirtyDaysFromNow = new Date();
-    thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
-    const departureDate = thirtyDaysFromNow.toISOString().split('T')[0]!;
-
     const searchResponse = await adapter.search({
-      segments: [{ origin: 'LHR', destination: 'CDG', departure_date: departureDate }],
-      passengers: { adults: 1, children: 0, infants: 0 },
+      segments: [{ origin: 'LHR', destination: 'CDG', departure_date: isoDatePlusDays(30) }],
+      passengers: [{ type: 'ADT', count: 1 }],
       cabin_class: 'economy',
     });
-
     expect(searchResponse.offers.length).toBeGreaterThan(0);
 
-    // Then price the cheapest offer
-    if (adapter.price) {
-      const cheapest = searchResponse.offers[0]!;
-      const priceResponse = await adapter.price({
-        offer_id: cheapest.id,
-        passengers: [
-          {
-            type: 'adult',
-            given_name: 'Test',
-            family_name: 'Passenger',
-            date_of_birth: '1990-01-01',
-            gender: 'male',
-          },
-        ],
-      });
-      expect(priceResponse.total_price).toBeDefined();
-      expect(priceResponse.currency).toBeDefined();
-    }
+    const cheapest = searchResponse.offers[0]!;
+    const priceResponse = await adapter.price({ offer_id: cheapest.offer_id });
+    expect(priceResponse.available).toBe(true);
+    expect(priceResponse.price.total).toBeGreaterThan(0);
+    expect(priceResponse.price.currency).toBeDefined();
   });
 });

--- a/packages/integration/README.md
+++ b/packages/integration/README.md
@@ -1,0 +1,38 @@
+# @otaip/integration
+
+The caller-facing seam: run a contracted OTAIP agent against a **live distribution
+adapter** through the six pipeline gates, and read the run's **execution + gate trace**
+back by id.
+
+Proven path: **Agent 1.1 (Availability Search) → Duffel NDC sandbox → real offers → durable trace.**
+
+```ts
+import { runAvailabilitySearch, getRunTrace, FileEventStore } from '@otaip/integration';
+
+const store = await FileEventStore.open('./traces/run.jsonl');
+const res = await runAvailabilitySearch(
+  { origin: 'JFK', destination: 'LHR', departure_date: '2026-07-23',
+    passengers: [{ type: 'ADT', count: 1 }], cabin_class: 'economy' },
+  { duffelApiKey: process.env.DUFFEL_API_KEY, eventStore: store },
+);
+
+if (res.ok) console.log(res.output.offers.length, 'offers');
+
+const trace = await getRunTrace(store, res.sessionId); // by-id read-back
+```
+
+- Reuses the real `PipelineOrchestrator`, gates, event types, and unified output model
+  from `@otaip/core` — **no parallel execution or validation path**.
+- The Duffel API key is read only at adapter construction; it never enters events, traces,
+  logs, or returned payloads.
+
+Full contract, credentials policy, and live sandbox proof: see
+[`INTEGRATION.md`](../../INTEGRATION.md) at the repo root.
+
+Live proof script (needs a `duffel_test_…` key, run from repo root):
+
+```bash
+pnpm run data:download
+export DUFFEL_API_KEY=duffel_test_xxx
+pnpm exec tsx packages/integration/scripts/duffel-search.ts
+```

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@otaip/integration",
+  "version": "0.7.2",
+  "description": "OTAIP integration seam — run contracted agents through the six gates against a live distribution adapter, with a durable, readable execution trace",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist",
+    "proof:duffel-search": "tsx scripts/duffel-search.ts"
+  },
+  "dependencies": {
+    "@otaip/core": "workspace:*",
+    "@otaip/adapter-duffel": "workspace:*",
+    "@otaip/agents-search": "workspace:*",
+    "@otaip/agents-reference": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  },
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=24.14.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/telivity-otaip/otaip.git",
+    "directory": "packages/integration"
+  }
+}

--- a/packages/integration/scripts/duffel-search.ts
+++ b/packages/integration/scripts/duffel-search.ts
@@ -1,0 +1,107 @@
+/**
+ * Live Duffel sandbox proof for @otaip/integration.
+ *
+ * Runs Agent 1.1 (AvailabilitySearch) against the real Duffel sandbox through
+ * OTAIP's six gates, writes a durable trace, then re-reads that trace by id
+ * from a *fresh* store instance to prove the read-back path.
+ *
+ * Requires DUFFEL_API_KEY (a duffel_test_… sandbox key) in the environment.
+ * The key is read by the adapter only; it is never printed, logged, or traced.
+ *
+ * Run:
+ *   set -a; source examples/ligare/.env; set +a   # or export DUFFEL_API_KEY=duffel_test_...
+ *   pnpm --filter @otaip/integration proof:duffel-search
+ */
+
+import { join } from 'node:path';
+import { rm } from 'node:fs/promises';
+import { runAvailabilitySearch, getRunTrace, FileEventStore } from '../src/index.js';
+
+function isoDatePlusDays(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+async function main(): Promise<void> {
+  const key = process.env['DUFFEL_API_KEY'];
+  if (!key) {
+    console.error('DUFFEL_API_KEY is not set. Export a duffel_test_… key and re-run.');
+    process.exit(2);
+  }
+  // Never print the key — only its environment kind, derived from the prefix.
+  const kind = key.startsWith('duffel_test_')
+    ? 'sandbox'
+    : key.startsWith('duffel_live_')
+      ? 'LIVE'
+      : 'unknown';
+  if (kind === 'LIVE') {
+    console.error('Refusing to run the proof against a LIVE Duffel key.');
+    process.exit(2);
+  }
+
+  const departure = isoDatePlusDays(30);
+  const tracePath = join(process.cwd(), 'traces', `duffel-jfk-lhr-${departure}.jsonl`);
+  await rm(tracePath, { force: true });
+  const store = await FileEventStore.open(tracePath);
+
+  console.log('='.repeat(72));
+  console.log('OTAIP × Duffel — live sandbox availability search (Agent 1.1, through gates)');
+  console.log('='.repeat(72));
+  console.log(`Credential:   DUFFEL_API_KEY present (${kind})`);
+  console.log(`Route:        JFK → LHR on ${departure}, 1 ADT, economy, GBP`);
+  console.log(`Trace file:   ${tracePath}`);
+  console.log('');
+
+  const res = await runAvailabilitySearch(
+    {
+      origin: 'JFK',
+      destination: 'LHR',
+      departure_date: departure,
+      passengers: [{ type: 'ADT', count: 1 }],
+      cabin_class: 'economy',
+      currency: 'GBP',
+      max_results: 3,
+      sort_by: 'price',
+    },
+    { eventStore: store },
+  );
+
+  console.log(`Gate outcome: ${res.ok ? 'PASS (all gates)' : `REJECTED → ${res.failure?.reason}`}`);
+  if (!res.ok) {
+    console.log('Issues:', JSON.stringify(res.failure?.issues, null, 2));
+    process.exit(1);
+  }
+
+  const out = res.output!;
+  console.log(`Session id:   ${res.sessionId}`);
+  console.log(`Raw offers:   ${out.total_raw_offers}   |   returned: ${out.offers.length}`);
+  console.log('');
+  console.log('--- Real Duffel sandbox offers (normalized to the unified output model) ---');
+  for (const [i, offer] of out.offers.entries()) {
+    const seg0 = offer.itinerary.segments[0]!;
+    const segN = offer.itinerary.segments[offer.itinerary.segments.length - 1]!;
+    console.log(
+      `  ${i + 1}. ${offer.offer_id}  ${seg0.carrier}${seg0.flight_number}  ` +
+        `${seg0.origin}→${segN.destination}  ` +
+        `dep ${seg0.departure_time}  ` +
+        `${offer.price.total} ${offer.price.currency}  ` +
+        `(${offer.itinerary.connection_count} stop(s), ${offer.itinerary.total_duration_minutes}m)`,
+    );
+  }
+  console.log('');
+  console.log('--- Per-source status (real adapter call) ---');
+  console.log(JSON.stringify(out.source_status, null, 2));
+
+  // Prove read-back by id from a FRESH store opened on the same durable file.
+  const reopened = await FileEventStore.open(tracePath);
+  const trace = await getRunTrace(reopened, res.sessionId);
+  console.log('');
+  console.log('--- Trace read back by session id (fresh FileEventStore on the same file) ---');
+  console.log(JSON.stringify(trace, null, 2));
+}
+
+main().catch((err: unknown) => {
+  console.error('Proof failed:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/integration/src/__tests__/run-search.test.ts
+++ b/packages/integration/src/__tests__/run-search.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Offline integration tests.
+ *
+ * These prove the wiring — gates fire, the trace is emitted, FileEventStore is
+ * durable — WITHOUT touching the network. A stub `DistributionAdapter` stands
+ * in for Duffel and a canned `ReferenceDataProvider` stands in for OurAirports.
+ * The live sandbox proof lives in scripts/duffel-search.ts (run manually with a
+ * real DUFFEL_API_KEY); see INTEGRATION.md.
+ */
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readFile, rm } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import type {
+  DistributionAdapter,
+  ReferenceDataProvider,
+  SearchRequest,
+  SearchResponse,
+} from '@otaip/core';
+import { InMemoryEventStore } from '@otaip/core';
+import type { AvailabilitySearchInput } from '@otaip/agents-search';
+import { runAvailabilitySearch } from '../run-search.js';
+import { getRunTrace } from '../trace.js';
+import { FileEventStore } from '../file-event-store.js';
+
+// ── Stubs ────────────────────────────────────────────────────────────────────
+
+function stubAdapter(name = 'duffel'): DistributionAdapter {
+  return {
+    name,
+    async isAvailable() {
+      return true;
+    },
+    async search(request: SearchRequest): Promise<SearchResponse> {
+      const seg = request.segments[0]!;
+      return {
+        offers: [
+          {
+            offer_id: 'off_stub_0001',
+            source: name,
+            itinerary: {
+              source_id: 'off_stub_0001',
+              source: name,
+              segments: [
+                {
+                  carrier: 'ZZ',
+                  flight_number: '1000',
+                  origin: seg.origin,
+                  destination: seg.destination,
+                  departure_time: `${seg.departure_date}T09:00:00Z`,
+                  arrival_time: `${seg.departure_date}T21:00:00Z`,
+                  duration_minutes: 420,
+                  cabin_class: 'economy',
+                  stops: 0,
+                },
+              ],
+              total_duration_minutes: 420,
+              connection_count: 0,
+            },
+            price: { base_fare: 300, taxes: 120, total: 420, currency: 'GBP' },
+          },
+        ],
+        truncated: false,
+        metadata: { source: name },
+      };
+    },
+  };
+}
+
+const cannedReference: ReferenceDataProvider = {
+  async resolveAirport(code) {
+    const known: Record<string, string> = { JFK: 'John F Kennedy Intl', LHR: 'London Heathrow' };
+    if (!(code in known)) return null;
+    return { iataCode: code, name: known[code]!, matchConfidence: 1 };
+  },
+  async resolveAirline(code) {
+    return { iataCode: code, name: code, matchConfidence: 1 };
+  },
+  async decodeFareBasis(code) {
+    return { fareBasis: code, matchConfidence: 1 };
+  },
+};
+
+const baseInput: AvailabilitySearchInput = {
+  origin: 'JFK',
+  destination: 'LHR',
+  departure_date: '2026-07-23',
+  passengers: [{ type: 'ADT', count: 1 }],
+  cabin_class: 'economy',
+  currency: 'GBP',
+};
+
+const fixedNow = () => new Date('2026-06-23T12:00:00Z');
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('runAvailabilitySearch (offline)', () => {
+  it('passes all gates and emits a readable trace for a valid search', async () => {
+    const res = await runAvailabilitySearch(baseInput, {
+      adapter: stubAdapter(),
+      reference: cannedReference,
+      now: fixedNow,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.output?.offers).toHaveLength(1);
+    expect(res.output?.offers[0]?.price.currency).toBe('GBP');
+
+    // Trace is readable by session id and reflects the gates.
+    const trace = await getRunTrace(res.eventStore, res.sessionId);
+    expect(trace.outcome).toBe('ok');
+    expect(trace.agentExecutions).toHaveLength(1);
+
+    const exec = trace.agentExecutions[0]!;
+    expect(exec.agentId).toBe('1.1');
+    expect(exec.success).toBe(true);
+    const passedGates = new Set(exec.gateResults.filter((g) => g.passed).map((g) => g.gate));
+    for (const gate of [
+      'intent_lock',
+      'schema_in',
+      'semantic_in',
+      'cross_agent',
+      'execute',
+      'schema_out',
+      'confidence',
+      'action_class',
+    ]) {
+      expect(passedGates.has(gate)).toBe(true);
+    }
+
+    expect(trace.adapterHealth).toHaveLength(1);
+    expect(trace.adapterHealth[0]?.status).toBe('healthy');
+  });
+
+  it('rejects an unknown airport at the semantic gate and records it in the trace', async () => {
+    const res = await runAvailabilitySearch(
+      { ...baseInput, destination: 'ZZZ' },
+      { adapter: stubAdapter(), reference: cannedReference, now: fixedNow },
+    );
+
+    expect(res.ok).toBe(false);
+    expect(res.failure?.reason).toBe('semantic_invalid');
+    expect(res.failure?.failureClass).toBe('validation');
+
+    const trace = await getRunTrace(res.eventStore, res.sessionId);
+    expect(trace.outcome).toBe('rejected');
+    expect(trace.agentExecutions[0]?.success).toBe(false);
+  });
+
+  it('writes a durable trace that a different store instance can read back', async () => {
+    const path = join(tmpdir(), `otaip-trace-${process.pid}-${Date.now()}.jsonl`);
+    try {
+      const store = await FileEventStore.open(path);
+      const res = await runAvailabilitySearch(baseInput, {
+        adapter: stubAdapter(),
+        reference: cannedReference,
+        eventStore: store,
+        now: fixedNow,
+      });
+      expect(res.ok).toBe(true);
+
+      // The on-disk file actually contains JSONL events with no secrets.
+      const raw = await readFile(path, 'utf-8');
+      const lines = raw.trim().split('\n');
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      expect(raw).not.toMatch(/duffel_test_|duffel_live_|Bearer/i);
+
+      // A fresh store, opened on the same file, reads the trace back by id.
+      const reopened = await FileEventStore.open(path);
+      const trace = await getRunTrace(reopened, res.sessionId);
+      expect(trace.outcome).toBe('ok');
+      expect(trace.agentExecutions).toHaveLength(1);
+      expect(trace.adapterHealth).toHaveLength(1);
+    } finally {
+      await rm(path, { force: true });
+    }
+  });
+
+  it('defaults to an in-memory store when none is provided', async () => {
+    const res = await runAvailabilitySearch(baseInput, {
+      adapter: stubAdapter(),
+      reference: cannedReference,
+      now: fixedNow,
+    });
+    expect(res.eventStore).toBeInstanceOf(InMemoryEventStore);
+  });
+});

--- a/packages/integration/src/file-event-store.ts
+++ b/packages/integration/src/file-event-store.ts
@@ -1,0 +1,73 @@
+/**
+ * FileEventStore — a durable, append-only `EventStore`.
+ *
+ * Writes each {@link OtaipEvent} as one JSON line (JSONL) to a file, so a
+ * run's trace survives process restarts and can be read back by a *different*
+ * process / API call than the one that produced it. This is the "durable"
+ * half of the trace deliverable.
+ *
+ * It does NOT reimplement query/aggregate — it composes the in-memory store
+ * from `@otaip/core` for those, replaying the file into it on `open()`. There
+ * is exactly one filter/aggregate implementation in the platform, and it lives
+ * in core.
+ *
+ * Events never contain credentials or PII (see {@link OtaipEvent}); this store
+ * writes events verbatim and adds nothing, so the file is safe to persist.
+ */
+
+import { appendFile, readFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { AggregateResult, EventFilter, EventStore, OtaipEvent, TimeWindow } from '@otaip/core';
+import { InMemoryEventStore } from '@otaip/core';
+
+export class FileEventStore implements EventStore {
+  private readonly mem = new InMemoryEventStore();
+
+  private constructor(private readonly filePath: string) {}
+
+  /**
+   * Open (or create) a JSONL event log at `filePath`, replaying any existing
+   * events into the in-memory index. Use this instead of `new`.
+   */
+  static async open(filePath: string): Promise<FileEventStore> {
+    const store = new FileEventStore(filePath);
+    await mkdir(dirname(filePath), { recursive: true });
+    if (existsSync(filePath)) {
+      const raw = await readFile(filePath, 'utf-8');
+      for (const line of raw.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) continue;
+        try {
+          await store.mem.append(JSON.parse(trimmed) as OtaipEvent);
+        } catch {
+          // Skip a corrupt/partial trailing line rather than failing the read.
+        }
+      }
+    }
+    return store;
+  }
+
+  /** Append durably: in-memory index first, then the on-disk log. */
+  async append(event: OtaipEvent): Promise<void> {
+    await this.mem.append(event);
+    await appendFile(this.filePath, `${JSON.stringify(event)}\n`, 'utf-8');
+  }
+
+  query(filter: EventFilter): Promise<OtaipEvent[]> {
+    return this.mem.query(filter);
+  }
+
+  aggregate(
+    metric: string,
+    window: TimeWindow,
+    filter?: Omit<EventFilter, 'window'>,
+  ): Promise<AggregateResult> {
+    return this.mem.aggregate(metric, window, filter);
+  }
+
+  /** Absolute or relative path this store persists to. */
+  get path(): string {
+    return this.filePath;
+  }
+}

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @otaip/integration — the caller-facing seam.
+ *
+ * Run a contracted agent against a live distribution adapter through OTAIP's
+ * six gates, and read the run's execution + gate trace back by id.
+ *
+ * See INTEGRATION.md at the repo root for the full contract.
+ */
+
+export { runAvailabilitySearch } from './run-search.js';
+export type { RunSearchOptions, RunSearchResult, RunSearchFailure } from './run-search.js';
+
+export { getRunTrace } from './trace.js';
+export type { RunTrace, AgentExecutionTrace, AdapterHealthTrace } from './trace.js';
+
+export { FileEventStore } from './file-event-store.js';

--- a/packages/integration/src/run-search.ts
+++ b/packages/integration/src/run-search.ts
@@ -1,0 +1,240 @@
+/**
+ * runAvailabilitySearch — the one documented entry point that runs Agent 1.1
+ * (AvailabilitySearch) against a live distribution adapter, through OTAIP's six
+ * pipeline gates, and emits a durable, readable trace.
+ *
+ * It does NOT fork execution or validation: it constructs the real
+ * `AvailabilitySearch` agent, registers it with the real `PipelineOrchestrator`
+ * under the real `availabilitySearchContract`, and calls `orchestrator.runAgent`.
+ * The gates (intent_lock, schema_in, semantic_in, cross_agent, schema_out,
+ * confidence, action_class) all fire exactly as they do everywhere else.
+ *
+ * Tracing mirrors the existing `agentToTool` bridge: one `agent.executed` event
+ * per run carrying the gate results + timing, plus an `adapter.health` event for
+ * the adapter that served the search.
+ *
+ * Credentials: the Duffel key is read once, at adapter construction, from
+ * `options.duffelApiKey` or `process.env.DUFFEL_API_KEY`. It is never written to
+ * an event, a trace, a log line, or the returned payload.
+ */
+
+import type {
+  AdapterHealthEvent,
+  AgentExecutedEvent,
+  DistributionAdapter,
+  EventStore,
+  ReferenceDataProvider,
+  SemanticIssue,
+} from '@otaip/core';
+import {
+  InMemoryEventStore,
+  PipelineOrchestrator,
+  type AgentContract,
+  type Agent,
+} from '@otaip/core';
+import { DuffelAdapter } from '@otaip/adapter-duffel';
+import {
+  AvailabilitySearch,
+  availabilitySearchContract,
+  type AvailabilitySearchInput,
+  type AvailabilitySearchOutput,
+} from '@otaip/agents-search';
+import { ReferenceAgentDataProvider } from '@otaip/agents-reference';
+import { getRunTrace, type RunTrace } from './trace.js';
+
+const AGENT_ID = '1.1';
+
+export interface RunSearchOptions {
+  /**
+   * Duffel API key. If omitted, `DuffelAdapter` reads `process.env.DUFFEL_API_KEY`.
+   * A `duffel_test_…` key targets the sandbox; `duffel_live_…` targets production.
+   * Server-side only — never logged, traced, or returned.
+   */
+  readonly duffelApiKey?: string;
+  /** Override the Duffel base URL (e.g. a recorded-fixture server in tests). */
+  readonly duffelBaseUrl?: string;
+  /**
+   * Inject a pre-built adapter (tests / alternative suppliers). When set,
+   * `duffelApiKey`/`duffelBaseUrl` are ignored.
+   */
+  readonly adapter?: DistributionAdapter;
+  /**
+   * Event store the trace is written to. Pass a {@link FileEventStore} for a
+   * durable, re-readable trace. Defaults to a fresh in-memory store (returned
+   * on the result so the caller can still read it back this process).
+   */
+  readonly eventStore?: EventStore;
+  /**
+   * Reference-data provider backing the semantic gate (airport resolution).
+   * Defaults to the real `ReferenceAgentDataProvider` (OurAirports data).
+   */
+  readonly reference?: ReferenceDataProvider;
+  /** Clock injection (tests). Defaults to `() => new Date()`. */
+  readonly now?: () => Date;
+}
+
+export interface RunSearchFailure {
+  readonly reason: string;
+  /** 'infra' | 'execution' | 'validation' — never conflate a setup bug with a real rejection. */
+  readonly failureClass: string;
+  readonly issues: readonly SemanticIssue[];
+}
+
+export interface RunSearchResult {
+  /** The pipeline session id — use it to read the trace back via {@link getRunTrace}. */
+  readonly sessionId: string;
+  /** True when the run passed every gate. */
+  readonly ok: boolean;
+  /** Normalized, gate-validated search output. Present iff `ok`. */
+  readonly output?: AvailabilitySearchOutput;
+  /** Structured rejection detail. Present iff not `ok`. */
+  readonly failure?: RunSearchFailure;
+  /** The full, by-id trace for this run (also durably in `eventStore`). */
+  readonly trace: RunTrace;
+  /** The event store this run wrote to (the caller's, or the default in-memory one). */
+  readonly eventStore: EventStore;
+}
+
+let eventSeq = 0;
+function nextEventId(prefix: string): string {
+  eventSeq += 1;
+  return `${prefix}_${Date.now().toString(36)}_${eventSeq.toString(36)}`;
+}
+
+function totalPassengers(input: AvailabilitySearchInput): number {
+  return input.passengers.reduce((sum, p) => sum + p.count, 0);
+}
+
+/**
+ * Run Agent 1.1 against a live adapter through the gates, emitting a trace.
+ *
+ * @example
+ *   const res = await runAvailabilitySearch(
+ *     { origin: 'JFK', destination: 'LHR', departure_date: '2026-07-23',
+ *       passengers: [{ type: 'ADT', count: 1 }], cabin_class: 'economy' },
+ *     { eventStore: await FileEventStore.open('./traces/run.jsonl') },
+ *   );
+ *   if (res.ok) console.log(res.output.offers.length, 'offers');
+ *   const trace = await getRunTrace(res.eventStore, res.sessionId);
+ */
+export async function runAvailabilitySearch(
+  input: AvailabilitySearchInput,
+  options: RunSearchOptions = {},
+): Promise<RunSearchResult> {
+  const now = options.now ?? ((): Date => new Date());
+  const eventStore = options.eventStore ?? new InMemoryEventStore();
+
+  const adapter: DistributionAdapter =
+    options.adapter ?? new DuffelAdapter(options.duffelApiKey, options.duffelBaseUrl);
+
+  const reference: ReferenceDataProvider = options.reference ?? new ReferenceAgentDataProvider();
+  if (reference.ready) await reference.ready();
+
+  // --- Build the real agent + orchestrator (no parallel path) ---------------
+  const agent = new AvailabilitySearch([adapter]);
+  await agent.initialize();
+
+  const orchestrator = new PipelineOrchestrator({
+    reference,
+    contracts: new Map<string, AgentContract>([[AGENT_ID, availabilitySearchContract]]),
+    agents: new Map<string, Agent>([[AGENT_ID, agent as Agent]]),
+    now,
+  });
+
+  const session = orchestrator.createSession({
+    type: input.return_date ? 'round_trip_search' : 'one_way_search',
+    origin: input.origin,
+    destination: input.destination,
+    outboundDate: input.departure_date,
+    ...(input.return_date ? { returnDate: input.return_date } : {}),
+    passengerCount: totalPassengers(input),
+    ...(input.cabin_class ? { cabinClass: input.cabin_class } : {}),
+    lockedBy: 'integration.runAvailabilitySearch',
+  });
+
+  // --- Run through the gates ------------------------------------------------
+  const result = await orchestrator.runAgent<AvailabilitySearchOutput>(session, AGENT_ID, input);
+
+  const inv = result.invocation;
+  const finishedAt = inv.finishedAt ?? inv.startedAt;
+  const durationMs = Math.max(0, Date.parse(finishedAt) - Date.parse(inv.startedAt));
+
+  // --- Emit agent.executed (mirrors the agentToTool bridge) -----------------
+  const agentEvent: AgentExecutedEvent = {
+    eventId: nextEventId('evt'),
+    type: 'agent.executed',
+    timestamp: now().toISOString(),
+    sessionId: session.sessionId,
+    agentId: AGENT_ID,
+    inputHash: hashInput(input),
+    confidence: result.ok ? (result.output.confidence ?? 0) : 0,
+    durationMs,
+    success: result.ok,
+    gateResults: inv.gateResults.map((g) => ({ gate: g.gate, passed: g.passed })),
+  };
+  await eventStore.append(agentEvent);
+
+  // --- Emit adapter.health from the real search's per-source status ---------
+  // The search output carries the actual outcome + latency of each adapter call;
+  // we derive health from it rather than issuing a second network probe.
+  const sourceStatuses = result.ok ? result.output.data.source_status : [];
+  if (sourceStatuses.length === 0) {
+    // Run was rejected before producing output — record the adapter we wired.
+    const healthEvent: AdapterHealthEvent = {
+      eventId: nextEventId('evt'),
+      type: 'adapter.health',
+      timestamp: now().toISOString(),
+      sessionId: session.sessionId,
+      adapterId: adapter.name,
+      status: 'unhealthy',
+    };
+    await eventStore.append(healthEvent);
+  } else {
+    for (const s of sourceStatuses) {
+      const healthEvent: AdapterHealthEvent = {
+        eventId: nextEventId('evt'),
+        type: 'adapter.health',
+        timestamp: now().toISOString(),
+        sessionId: session.sessionId,
+        adapterId: s.source,
+        status: s.success ? 'healthy' : 'unhealthy',
+        latencyMs: s.response_time_ms,
+      };
+      await eventStore.append(healthEvent);
+    }
+  }
+
+  const trace = await getRunTrace(eventStore, session.sessionId);
+
+  if (result.ok) {
+    return {
+      sessionId: session.sessionId,
+      ok: true,
+      output: result.output.data,
+      trace,
+      eventStore,
+    };
+  }
+
+  return {
+    sessionId: session.sessionId,
+    ok: false,
+    failure: {
+      reason: result.reason,
+      failureClass: result.failureClass,
+      issues: result.issues,
+    },
+    trace,
+    eventStore,
+  };
+}
+
+/** Lightweight, non-crypto input fingerprint — matches the bridge's dedup hash. */
+function hashInput(input: unknown): string {
+  const str = JSON.stringify(input);
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}

--- a/packages/integration/src/trace.ts
+++ b/packages/integration/src/trace.ts
@@ -1,0 +1,87 @@
+/**
+ * Run trace — a readable, by-id view over the events a run emitted.
+ *
+ * `getRunTrace(store, sessionId)` reads back everything OTAIP recorded for one
+ * pipeline session: which agents ran, every gate result, adapter health, timing
+ * and the final outcome. It is a pure projection over the {@link EventStore} —
+ * no new state, no re-execution. Pair it with {@link FileEventStore} to read a
+ * trace from a different process than the one that produced it.
+ *
+ * Events carry no secrets or PII, so a `RunTrace` is safe to log or return.
+ */
+
+import type { AdapterHealthEvent, AgentExecutedEvent, EventStore, OtaipEvent } from '@otaip/core';
+
+export interface AgentExecutionTrace {
+  readonly agentId: string;
+  readonly success: boolean;
+  readonly confidence: number;
+  readonly durationMs: number;
+  readonly timestamp: string;
+  readonly gateResults: readonly { readonly gate: string; readonly passed: boolean }[];
+}
+
+export interface AdapterHealthTrace {
+  readonly adapterId: string;
+  readonly status: 'healthy' | 'degraded' | 'unhealthy';
+  readonly latencyMs?: number;
+  readonly timestamp: string;
+}
+
+export interface RunTrace {
+  readonly sessionId: string;
+  /** Overall outcome derived from the agent executions in this session. */
+  readonly outcome: 'ok' | 'rejected' | 'empty';
+  readonly agentExecutions: readonly AgentExecutionTrace[];
+  readonly adapterHealth: readonly AdapterHealthTrace[];
+  /** Every raw event for the session, chronological — the durable source of truth. */
+  readonly events: readonly OtaipEvent[];
+}
+
+function toAgentTrace(e: AgentExecutedEvent): AgentExecutionTrace {
+  return {
+    agentId: e.agentId,
+    success: e.success,
+    confidence: e.confidence,
+    durationMs: e.durationMs,
+    timestamp: e.timestamp,
+    gateResults: e.gateResults,
+  };
+}
+
+function toHealthTrace(e: AdapterHealthEvent): AdapterHealthTrace {
+  return {
+    adapterId: e.adapterId,
+    status: e.status,
+    ...(e.latencyMs !== undefined ? { latencyMs: e.latencyMs } : {}),
+    timestamp: e.timestamp,
+  };
+}
+
+/**
+ * Read back the full trace for one run, by session id.
+ *
+ * @param store      the event store the run wrote to (in-memory or file-backed)
+ * @param sessionId  the id returned by {@link runAvailabilitySearch}
+ */
+export async function getRunTrace(store: EventStore, sessionId: string): Promise<RunTrace> {
+  const events = await store.query({ sessionId });
+
+  const agentExecutions = events
+    .filter((e): e is AgentExecutedEvent => e.type === 'agent.executed')
+    .map(toAgentTrace);
+  const adapterHealth = events
+    .filter((e): e is AdapterHealthEvent => e.type === 'adapter.health')
+    .map(toHealthTrace);
+
+  let outcome: RunTrace['outcome'];
+  if (agentExecutions.length === 0) {
+    outcome = 'empty';
+  } else if (agentExecutions.every((a) => a.success)) {
+    outcome = 'ok';
+  } else {
+    outcome = 'rejected';
+  }
+
+  return { sessionId, outcome, agentExecutions, adapterHealth, events };
+}

--- a/packages/integration/tsconfig.json
+++ b/packages/integration/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/__tests__", "scripts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,25 @@ importers:
         specifier: ^1.0.21
         version: 1.0.21
 
+  packages/integration:
+    dependencies:
+      '@otaip/adapter-duffel':
+        specifier: workspace:*
+        version: link:../adapters/duffel
+      '@otaip/agents-reference':
+        specifier: workspace:*
+        version: link:../agents/reference
+      '@otaip/agents-search':
+        specifier: workspace:*
+        version: link:../agents/search
+      '@otaip/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+
 packages:
 
   '@alloc/quick-lru@5.2.0':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   fast-uri: '>=3.1.2'
   vite: ^8.0.16
   esbuild: '>=0.28.1'
+  qs: '>=6.15.2'
 
 importers:
 
@@ -41,10 +42,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
+        version: 8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))
 
   demo:
     dependencies:
@@ -168,7 +169,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))
+        version: 6.0.3(vite@8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.14)
@@ -180,7 +181,7 @@ importers:
         version: 3.4.19(tsx@4.21.0)
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
+        version: 8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
 
   packages/adapters/duffel:
     dependencies:
@@ -446,14 +447,14 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -748,8 +749,8 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@oxc-project/types@0.133.0':
-    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+  '@oxc-project/types@0.137.0':
+    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -758,97 +759,97 @@ packages:
     resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
     engines: {node: '>=14.0.0'}
 
-  '@rolldown/binding-android-arm64@1.0.3':
-    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+  '@rolldown/binding-android-arm64@1.1.2':
+    resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
-    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+  '@rolldown/binding-darwin-arm64@1.1.2':
+    resolution: {integrity: sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.3':
-    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+  '@rolldown/binding-darwin-x64@1.1.2':
+    resolution: {integrity: sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
-    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+  '@rolldown/binding-freebsd-x64@1.1.2':
+    resolution: {integrity: sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
+    resolution: {integrity: sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
-    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.2':
+    resolution: {integrity: sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
-    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+  '@rolldown/binding-linux-arm64-musl@1.1.2':
+    resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
+    resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.2':
+    resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
-    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.2':
+    resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
-    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+  '@rolldown/binding-linux-x64-musl@1.1.2':
+    resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
-    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+  '@rolldown/binding-openharmony-arm64@1.1.2':
+    resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
-    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+  '@rolldown/binding-wasm32-wasi@1.1.2':
+    resolution: {integrity: sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.2':
+    resolution: {integrity: sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
-    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.2':
+    resolution: {integrity: sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1135,8 +1136,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1226,8 +1227,8 @@ packages:
     resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitejs/plugin-react@6.0.2':
-    resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
@@ -1741,10 +1742,6 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -1753,8 +1750,8 @@ packages:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
 
-  hono@4.12.26:
-    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -2209,8 +2206,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -2291,8 +2288,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown@1.0.3:
-    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+  rolldown@1.1.2:
+    resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2555,13 +2552,13 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vite@8.0.16:
-    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+  vite@8.1.0:
+    resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.18
+      '@vitejs/devtools': ^0.3.0
       esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -2680,18 +2677,18 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@emnapi/core@1.10.0':
+  '@emnapi/core@1.11.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2862,9 +2859,9 @@ snapshots:
       fastq: 1.20.1
       glob: 13.0.6
 
-  '@hono/node-server@1.19.13(hono@4.12.26)':
+  '@hono/node-server@1.19.13(hono@4.12.27)':
     dependencies:
-      hono: 4.12.26
+      hono: 4.12.27
 
   '@humanfs/core@0.19.1': {}
 
@@ -2895,7 +2892,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.26)
+      '@hono/node-server': 1.19.13(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -2905,7 +2902,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.26
+      hono: 4.12.27
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2915,11 +2912,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2936,59 +2933,59 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@oxc-project/types@0.133.0': {}
+  '@oxc-project/types@0.137.0': {}
 
   '@pinojs/redact@0.4.0': {}
 
   '@remix-run/router@1.23.3': {}
 
-  '@rolldown/binding-android-arm64@1.0.3':
+  '@rolldown/binding-android-arm64@1.1.2':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
+  '@rolldown/binding-darwin-arm64@1.1.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.3':
+  '@rolldown/binding-darwin-x64@1.1.2':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
+  '@rolldown/binding-freebsd-x64@1.1.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+  '@rolldown/binding-linux-arm64-gnu@1.1.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
+  '@rolldown/binding-linux-arm64-musl@1.1.2':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+  '@rolldown/binding-linux-s390x-gnu@1.1.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
+  '@rolldown/binding-linux-x64-gnu@1.1.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
+  '@rolldown/binding-linux-x64-musl@1.1.2':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
+  '@rolldown/binding-openharmony-arm64@1.1.2':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
+  '@rolldown/binding-wasm32-wasi@1.1.2':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+  '@rolldown/binding-win32-arm64-msvc@1.1.2':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
+  '@rolldown/binding-win32-x64-msvc@1.1.2':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -3145,7 +3142,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3269,10 +3266,10 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -3283,13 +3280,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -3348,7 +3345,7 @@ snapshots:
 
   amadeus@11.0.0:
     dependencies:
-      qs: 6.15.0
+      qs: 6.15.2
 
   any-promise@1.3.0: {}
 
@@ -3394,7 +3391,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -3678,7 +3675,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -3814,7 +3811,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -3844,17 +3841,13 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
   helmet@8.1.0: {}
 
-  hono@4.12.26: {}
+  hono@4.12.27: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4227,7 +4220,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -4297,26 +4290,26 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown@1.0.3:
+  rolldown@1.1.2:
     dependencies:
-      '@oxc-project/types': 0.133.0
+      '@oxc-project/types': 0.137.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.3
-      '@rolldown/binding-darwin-arm64': 1.0.3
-      '@rolldown/binding-darwin-x64': 1.0.3
-      '@rolldown/binding-freebsd-x64': 1.0.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
-      '@rolldown/binding-linux-arm64-gnu': 1.0.3
-      '@rolldown/binding-linux-arm64-musl': 1.0.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
-      '@rolldown/binding-linux-s390x-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-musl': 1.0.3
-      '@rolldown/binding-openharmony-arm64': 1.0.3
-      '@rolldown/binding-wasm32-wasi': 1.0.3
-      '@rolldown/binding-win32-arm64-msvc': 1.0.3
-      '@rolldown/binding-win32-x64-msvc': 1.0.3
+      '@rolldown/binding-android-arm64': 1.1.2
+      '@rolldown/binding-darwin-arm64': 1.1.2
+      '@rolldown/binding-darwin-x64': 1.1.2
+      '@rolldown/binding-freebsd-x64': 1.1.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.2
+      '@rolldown/binding-linux-arm64-gnu': 1.1.2
+      '@rolldown/binding-linux-arm64-musl': 1.1.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.2
+      '@rolldown/binding-linux-s390x-gnu': 1.1.2
+      '@rolldown/binding-linux-x64-gnu': 1.1.2
+      '@rolldown/binding-linux-x64-musl': 1.1.2
+      '@rolldown/binding-openharmony-arm64': 1.1.2
+      '@rolldown/binding-wasm32-wasi': 1.1.2
+      '@rolldown/binding-win32-arm64-msvc': 1.1.2
+      '@rolldown/binding-win32-x64-msvc': 1.1.2
 
   rollup@4.60.1:
     dependencies:
@@ -4493,7 +4486,7 @@ snapshots:
 
   stripe@18.5.0(@types/node@25.5.0):
     dependencies:
-      qs: 6.15.0
+      qs: 6.15.2
     optionalDependencies:
       '@types/node': 25.5.0
 
@@ -4660,12 +4653,12 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0):
+  vite@8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.3
+      rolldown: 1.1.2
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.5.0
@@ -4674,10 +4667,10 @@ snapshots:
       jiti: 1.21.7
       tsx: 4.21.0
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -4694,7 +4687,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## What

Adds **`@otaip/integration`** — the caller-facing seam that runs a contracted agent against a **live distribution adapter** through the existing **six pipeline gates**, and reads the run's **execution + gate trace** back by id. Reuses core's gates, event types, and unified output model — **no parallel execution or validation path**.

Proven path: **Agent 1.1 (Availability Search) → Duffel NDC sandbox → real offers → durable trace.**

## Deliverable 1 — one real adapter path (live sandbox)

- `runAvailabilitySearch()` runs Agent 1.1 via the live Duffel REST API and returns real, normalized offers through `PipelineOrchestrator.runAgent` + `availabilitySearchContract`.
- Verified against the Duffel sandbox (JFK→LHR, `live_mode:false`): **168 offers, all gates pass**. Real request/response + emitted trace pasted (keys redacted) in `INTEGRATION.md`.
- **Credentials:** the Duffel key is read once at adapter construction from `options.duffelApiKey` or `DUFFEL_API_KEY`. Never written to events, traces, logs, or returned payloads — asserted by test.

## Deliverable 2 — durable, readable traces

- Emits the existing `agent.executed` (gate results + timing) and `adapter.health` events.
- **`FileEventStore`** — durable JSONL `EventStore` composing core's `InMemoryEventStore` for query/aggregate (single filter implementation, not a fork).
- **`getRunTrace(store, sessionId)`** — by-id trace read-back, proven across a fresh store on the same file.

## Output

`INTEGRATION.md`: adapter execution (in-process), trace read, versions + env vars, and the real sandbox request/response + emitted trace.

## Also

- **Fixes a stale `duffel-e2e.test.ts`** that couldn't compile against the shipped adapter (object constructor + `total_price`/`itineraries` vs unified `price`/`itinerary`). Now passes live **3/3**.
- Registers the new package's tsconfig in both eslint configs; ignores `scripts/`; gitignores `traces/`.

## Honesty notes

- Booking/ticketing against a live supplier is **explicitly not claimed** — left unstubbed.
- Sandbox returned **USD despite a GBP request** — documented faithfully; OTAIP doesn't coerce supplier output.

## Verification

- `typecheck` ✅ · integration 4/4 ✅ · live `duffel-e2e` 3/3 ✅
- full suite **3297 passed / 17 skipped** ✅ · `pnpm verify` (build + verify:dist, 17 bundles incl. `@otaip/integration`) ✅
- lint + prettier clean ✅ · `check:no-internal-refs` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)