### PR TITLE
chore(release): v0.7.3 — republish agents with inlined JSON data

### DIFF
--- a/examples/platform-ui/package.json
+++ b/examples/platform-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/platform-ui",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP distribution adapter for Duffel NDC API — Flights and Cars (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapters/hotelbeds/package.json
+++ b/packages/adapters/hotelbeds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-hotelbeds",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP distribution adapter for the Hotelbeds APItude APIs — Hotels, Activities, and Transfers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/integration",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "OTAIP integration seam — run contracted agents through the six gates against a live distribution adapter, with a durable, readable execution trace",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Why

Importing `@otaip/agents-exchange@0.7.2` from npm throws at module load:

```
Cannot find module './data/eu-countries.json'
```

**This is not a current-source bug — npm's `0.7.2` is a stale pre-fix build.**

- The data load was fixed after `0.7.2` shipped: #104 switched to a plain ESM `import` (tsup inlines it), and #111 added the `pnpm verify:dist` pre-publish gate + per-package `dist-runtime.test.ts`.
- `git merge-base --is-ancestor 28f0a4d 56bc01d` = **true**: the `v0.7.2` release commit predates every JSON-inlining fix. Since `dist/` is gitignored, the registry still serves the broken build, and the `verify:dist` gate did not exist when `0.7.2` was published.
- Same staleness affects `pricing`/`booking`/`ticketing@0.7.2` (fixed in the same window).

## What

Workspace-wide lockstep bump `0.7.2 → 0.7.3` (root + 18 manifests). **No source/tsup change** — the ESM-import inlining is the established, guarded pattern. A full synced bump is required because `agents-exchange` depends on `@otaip/agents-ticketing` / `@otaip/agents-search` via `workspace:*`, which pnpm pins to the published version at publish time.

Merging to `main` triggers `release.yml` (cuts `v0.7.3`) → `publish.yml` (build → **`verify:dist` gate** → publish all `@otaip/*@0.7.3` → live-on-npm check).

## Verified locally
- `pnpm verify` → 17/17 bundles load cleanly (incl. `@otaip/agents-exchange`)
- `pnpm test` → **3297 passed**, 17 skipped
- Import repro against the built bundle prints `ok`