### PR TITLE
ci(release): build + download reference data before tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Tests need the same provisioning as CI: built @otaip/* bundles and the
+      # downloaded reference data. Without these, runtime/playground tests (e.g.
+      # executing agent 0.1 over HTTP) fail with 500s even though `ci.yml` is
+      # green — `ci.yml` builds and downloads data before testing; this job did
+      # not, so a release could be blocked by a false-failing test.
+      - name: Build all packages
+        run: pnpm -r run build
+
+      - name: Download reference data
+        run: pnpm run data:download
+
       - name: Run tests
         run: pnpm test 2>&1 | tee /tmp/test-output.log
 


### PR DESCRIPTION
## Problem

The `Release` workflow runs `pnpm test` immediately after `pnpm install`, with **no build and no reference-data download** — unlike `ci.yml`, which does `pnpm -r run build` → `verify:dist` → `pnpm run data:download` before testing.

Runtime/playground tests that execute agents over HTTP (e.g. agent `0.1` AirportCodeResolver in `examples/ota`) need the built `@otaip/*` bundles and the downloaded airport dataset. Without them they return `500` and **falsely fail the release**, even though `ci.yml` is green on the same commit. This just blocked a release from cutting its tag and publishing.

## Fix

Add two steps before `Run tests` in `release.yml`, mirroring `ci.yml`:

```yaml
- name: Build all packages
  run: pnpm -r run build
- name: Download reference data
  run: pnpm run data:download
```

No other change. This makes the release gate provision tests the same way CI does, so a green CI can't be contradicted by a false-failing release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; no application, auth, or publish logic is modified beyond test prerequisites.
> 
> **Overview**
> The **Release** workflow previously ran `pnpm test` right after install, so HTTP/runtime tests that depend on built `@otaip/*` packages and downloaded reference data could **500 and fail the release** while **`ci.yml` stayed green** on the same commit.
> 
> This adds **`pnpm -r run build`** and **`pnpm run data:download`** immediately before **Run tests**, aligning release test provisioning with CI (without changing tag creation or publish steps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c253520736d74fb8a3546f5dd30d12d064e146d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->