### PR TITLE
chore(ci): revalidate Telivity website on README change

### DIFF
--- a/.github/workflows/telivity-revalidate.yml
+++ b/.github/workflows/telivity-revalidate.yml
@@ -1,0 +1,22 @@
+name: Revalidate Telivity website
+
+# When the README changes on main, ping the Telivity site so /otaip
+# rebuilds from the fresh README within seconds instead of waiting for the
+# 1-hour ISR cache to expire.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  revalidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Telivity revalidate endpoint
+        run: |
+          curl -sS -X POST https://telivity.app/api/revalidate             -H "Authorization: Bearer 2TELIVITY_REVALIDATE_SECRET"             -H "Content-Type: application/json"             -d '{"paths":["/otaip"]}'             --fail-with-body
+        env:
+          TELIVITY_REVALIDATE_SECRET: 2{{ secrets.TELIVITY_REVALIDATE_SECRET }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that pings the Telivity website revalidate endpoint whenever  changes on .

The website's  and  pages render the README with 1-hour ISR caching. This hook makes updates visible within seconds without shortening the cache or increasing GitHub API load.

Uses the  Actions secret already set on the repo. Endpoint whitelists paths so the secret only revalidates the intended product page — nothing else is reachable.