### PR TITLE
fix(ota): redact credential hints in multi-search adapter errors

### DIFF
--- a/examples/ota/src/__tests__/multi-search-sanitize.test.ts
+++ b/examples/ota/src/__tests__/multi-search-sanitize.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for multi-search error sanitization (QA fix-forward candidate).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { DistributionAdapter, SearchRequest, SearchResponse } from '@otaip/core';
+import { MultiSearchService } from '../services/multi-search-service.js';
+
+function failingAdapter(name: string, message: string): DistributionAdapter {
+  return {
+    name,
+    async isAvailable() {
+      return true;
+    },
+    async search(_req: SearchRequest): Promise<SearchResponse> {
+      throw new Error(message);
+    },
+  };
+}
+
+describe('MultiSearchService — error sanitization', () => {
+  it('redacts credential hints from per-adapter error metadata', async () => {
+    const service = new MultiSearchService({
+      adapters: new Map([
+        [
+          'leaky',
+          failingAdapter('leaky', 'Adapter failed with key hint: sk_live_secret123'),
+        ],
+      ]),
+    });
+
+    const result = await service.search({
+      segments: [{ origin: 'JFK', destination: 'LAX', departure_date: '2026-07-15' }],
+      passengers: [{ type: 'ADT', count: 1 }],
+      cabin_class: 'economy',
+      currency: 'USD',
+    });
+
+    expect(result.sources[0]?.error).not.toContain('sk_live_secret123');
+    expect(result.sources[0]?.error).toContain('[redacted]');
+  });
+});

--- a/examples/ota/src/services/multi-search-service.ts
+++ b/examples/ota/src/services/multi-search-service.ts
@@ -44,9 +44,13 @@ export interface AggregatedSearchResult {
   readonly sources: readonly SourceStatus[];
 }
 
-// ---------------------------------------------------------------------------
-// Timeout helper
-// ---------------------------------------------------------------------------
+/** Strip credential-like substrings from adapter errors before exposing to clients. */
+function sanitizeAdapterError(message: string): string {
+  return message
+    .replace(/(?:api[_-]?key|secret|token|Bearer)\s*[:=]?\s*\S+/gi, '[redacted]')
+    .replace(/\b(sk|pk)_(live|test)_[A-Za-z0-9]+\b/g, '[redacted]')
+    .replace(/key hint:\s*\S+/gi, 'key hint: [redacted]');
+}
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -116,10 +120,11 @@ export class MultiSearchService {
           durationMs,
         });
       } else {
-        const errorMessage =
+        const errorMessage = sanitizeAdapterError(
           result.reason instanceof Error
             ? result.reason.message
-            : String(result.reason);
+            : String(result.reason),
+        );
         sources.push({
           adapter: adapterName,
           success: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the BUG-003 security fix

When a multi-adapter search fails, adapter error messages are sanitized before inclusion in `sources[].error` so credential hints (API keys, secrets, tokens) are not exposed to HTTP clients.

## Changes

- `examples/ota/src/services/multi-search-service.ts` — add `sanitizeAdapterError()`
- `examples/ota/src/__tests__/multi-search-sanitize.test.ts` — regression test

## Test plan

- [x] `pnpm vitest run examples/ota/src/__tests__/multi-search-sanitize.test.ts`
- [ ] `pnpm test` (full suite in CI)


