### PR TITLE
Triage good-first-issues: implement #7 #8 #12 #14, add tests #16 #18 #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The full airline and hotel booking lifecycle — search, pricing, booking, ticketing, exchange, refund, and BSP/ARC settlement — modeled as typed, testable agents with a pipeline contract system that prevents LLM hallucinations at every step.
 
-**75 agents. 6 distribution adapters. 14 pipeline-contracted agents. 3,092 tests. TypeScript strict.**
+**75 agents. 6 distribution adapters. 14 pipeline-contracted agents. 3,342 tests. TypeScript strict.**
 
 ```bash
 pnpm add @otaip/core @otaip/agents-booking @otaip/connect
@@ -10,7 +10,7 @@ pnpm add @otaip/core @otaip/agents-booking @otaip/connect
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CI](https://github.com/telivity-otaip/otaip/actions/workflows/ci.yml/badge.svg)](https://github.com/telivity-otaip/otaip/actions)
-[![Tests](https://img.shields.io/badge/tests-3092%20passing-brightgreen)](https://github.com/telivity-otaip/otaip/actions)
+[![Tests](https://img.shields.io/badge/tests-3342%20passing-brightgreen)](https://github.com/telivity-otaip/otaip/actions)
 
 ---
 
@@ -34,7 +34,7 @@ git clone https://github.com/telivity-otaip/otaip.git
 cd otaip
 pnpm install --frozen-lockfile
 pnpm run data:download       # one-time: airport reference data
-pnpm test                    # 3,092 tests
+pnpm test                    # 3,342 tests
 pnpm lint                    # 0 errors
 pnpm -r run typecheck        # 16 packages, all green
 ```
@@ -191,7 +191,7 @@ docs/                       Architecture, agents, adapters, getting started
 - **TypeScript** (`strict: true`, plus `noUncheckedIndexedAccess`, `noImplicitOverride`, `noPropertyAccessFromIndexSignature`; `exactOptionalPropertyTypes` is off — enabling it would require call-site changes across dozens of files, tracked as a separate cleanup)
 - **Node.js** >=24
 - **pnpm** 10+ (workspace monorepo, 16 packages)
-- **Vitest** for testing (3,092 tests)
+- **Vitest** for testing (3,342 tests)
 - **tsup** for building (ESM + DTS)
 - **ESLint** + **Prettier** for linting/formatting
 - **Zod** 4 for schema validation + JSON Schema generation

--- a/agents.manifest.json
+++ b/agents.manifest.json
@@ -36,6 +36,11 @@
           },
           "include_decommissioned": {
             "type": "boolean"
+          },
+          "max_results": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
           }
         },
         "required": [

--- a/packages/agents/lodging/src/content-normalization/__tests__/room-normalizer.test.ts
+++ b/packages/agents/lodging/src/content-normalization/__tests__/room-normalizer.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Room type taxonomy mapping tests for chain-specific naming patterns
+ * (Agent 20.x content-normalization, issue #18).
+ *
+ * These assert the *actual* keyword-extraction behavior of `normalizeRoomType`
+ * (category/bedType/bedCount) across real chain room descriptions — including
+ * the important negative cases where a chain's marketing word ("Regency",
+ * "Executive", "Club", "M Club") carries no taxonomy signal and the room falls
+ * back to `standard`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { normalizeRoomType, resetRoomIdCounter } from '../room-normalizer.js';
+import type { RawRoomType } from '../../types/hotel-common.js';
+
+function norm(description: string, code?: string) {
+  const raw: RawRoomType = code
+    ? { roomTypeId: description, description, code }
+    : { roomTypeId: description, description };
+  return normalizeRoomType(raw, 'test-source');
+}
+
+describe('normalizeRoomType — chain-specific descriptions', () => {
+  beforeEach(() => resetRoomIdCounter());
+
+  it('Marriott: "Deluxe King" → deluxe / king', () => {
+    const r = norm('Deluxe King');
+    expect(r?.category).toBe('deluxe');
+    expect(r?.bedType).toBe('king');
+  });
+
+  it('Marriott: "Executive Suite" → suite, no bed keyword falls back to double', () => {
+    const r = norm('Executive Suite');
+    expect(r?.category).toBe('suite');
+    expect(r?.bedType).toBe('double');
+  });
+
+  it('Marriott: "M Club Lounge King" → standard (no category keyword) / king', () => {
+    const r = norm('M Club Lounge King');
+    expect(r?.category).toBe('standard');
+    expect(r?.bedType).toBe('king');
+  });
+
+  it('Hilton: "King Hilton Executive" → standard / king', () => {
+    const r = norm('King Hilton Executive');
+    expect(r?.category).toBe('standard');
+    expect(r?.bedType).toBe('king');
+  });
+
+  it('Hilton: "Twin Hilton Guest Room" → standard / twin (2 beds)', () => {
+    const r = norm('Twin Hilton Guest Room');
+    expect(r?.category).toBe('standard');
+    expect(r?.bedType).toBe('twin');
+    expect(r?.bedCount).toBe(2);
+  });
+
+  it('IHG: "Standard King" → standard / king', () => {
+    const r = norm('Standard King');
+    expect(r?.category).toBe('standard');
+    expect(r?.bedType).toBe('king');
+  });
+
+  it('IHG: "Club InterContinental Suite" → suite / double', () => {
+    const r = norm('Club InterContinental Suite');
+    expect(r?.category).toBe('suite');
+    expect(r?.bedType).toBe('double');
+  });
+
+  it('Hyatt: "Regency King" → standard (Regency is not a category) / king', () => {
+    const r = norm('Regency King');
+    expect(r?.category).toBe('standard');
+    expect(r?.bedType).toBe('king');
+  });
+
+  it('Hyatt: "Grand Suite" → suite / double', () => {
+    const r = norm('Grand Suite');
+    expect(r?.category).toBe('suite');
+    expect(r?.bedType).toBe('double');
+  });
+
+  it('Boutique: "Artist Loft" → standard / double', () => {
+    const r = norm('Artist Loft');
+    expect(r?.category).toBe('standard');
+    expect(r?.bedType).toBe('double');
+  });
+
+  it('Boutique: "Penthouse Studio" → penthouse wins over studio (pattern order)', () => {
+    const r = norm('Penthouse Studio');
+    expect(r?.category).toBe('penthouse');
+  });
+
+  it('Budget: "Economy Room" → standard / double', () => {
+    const r = norm('Economy Room');
+    expect(r?.category).toBe('standard');
+    expect(r?.bedType).toBe('double');
+  });
+
+  it('Budget: "Value Double" → standard / double', () => {
+    const r = norm('Value Double');
+    expect(r?.category).toBe('standard');
+    expect(r?.bedType).toBe('double');
+  });
+
+  it('assigns a unique otaipRoomId per normalized room', () => {
+    resetRoomIdCounter();
+    const a = norm('Deluxe King');
+    const b = norm('Standard Twin');
+    expect(a?.otaipRoomId).not.toBe(b?.otaipRoomId);
+  });
+});

--- a/packages/agents/lodging/src/hotel-modification/__tests__/booked-rate-penalty.test.ts
+++ b/packages/agents/lodging/src/hotel-modification/__tests__/booked-rate-penalty.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Verifies cancellation/no-show penalties are computed against the BOOKED
+ * nightly rate passed in the input (not a hardcoded or current rate), and the
+ * fallback when `nightlyRate` is omitted (Agent 20.6, issue #19).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { HotelModificationAgent } from '../index.js';
+import type { ModificationInput } from '../types.js';
+import type { CancellationPolicy } from '../../types/hotel-common.js';
+
+const refundablePolicy: CancellationPolicy = {
+  refundable: true,
+  deadlines: [{ hoursBeforeCheckin: 24, penaltyType: 'nights', penaltyValue: 1 }],
+  freeCancel24hrBooking: true,
+};
+
+// Past the 24hr deadline (check-in 12h away) and past the California 24hr
+// booking window (booked 48h ago) → a real 1-night penalty applies.
+function pastDeadlineDates() {
+  const now = new Date();
+  return {
+    checkInDate: new Date(now.getTime() + 12 * 60 * 60 * 1000).toISOString(),
+    bookedAt: new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString(),
+  };
+}
+
+function cancelInput(nightlyRate?: ModificationInput['nightlyRate']): ModificationInput {
+  const { checkInDate, bookedAt } = pastDeadlineDates();
+  const base: ModificationInput = {
+    operation: 'cancel',
+    bookingId: 'HB-0001',
+    cancellationPolicy: refundablePolicy,
+    checkInDate,
+    bookedAt,
+  };
+  return nightlyRate ? { ...base, nightlyRate } : base;
+}
+
+let agent: HotelModificationAgent;
+beforeAll(async () => {
+  agent = new HotelModificationAgent();
+  await agent.initialize();
+});
+afterAll(() => agent.destroy());
+
+describe('penalty is calculated against the booked rate', () => {
+  it('uses the booked nightly rate from the input (299)', async () => {
+    const res = await agent.execute({
+      data: cancelInput({ amount: '299.00', currency: 'USD' }),
+    });
+    expect(res.data.penalty?.isWithinFreeWindow).toBe(false);
+    expect(res.data.penalty?.penaltyAmount.amount).toBe('299.00');
+    expect(res.data.penalty?.penaltyAmount.currency).toBe('USD');
+  });
+
+  it('reflects a different booked rate (450) — proves it is not hardcoded', async () => {
+    const res = await agent.execute({
+      data: cancelInput({ amount: '450.00', currency: 'USD' }),
+    });
+    expect(res.data.penalty?.penaltyAmount.amount).toBe('450.00');
+  });
+
+  it('honors the booked currency (EUR)', async () => {
+    const res = await agent.execute({
+      data: cancelInput({ amount: '200.00', currency: 'EUR' }),
+    });
+    expect(res.data.penalty?.penaltyAmount.currency).toBe('EUR');
+  });
+
+  it('no-show penalty (one night) also uses the booked rate', async () => {
+    const res = await agent.execute({
+      data: { operation: 'process_no_show', bookingId: 'HB-0002', nightlyRate: { amount: '350.00', currency: 'USD' } },
+    });
+    expect(res.data.penalty?.penaltyType).toBe('one_night');
+    expect(res.data.penalty?.penaltyAmount.amount).toBe('350.00');
+  });
+});
+
+describe('fallback when nightlyRate is omitted', () => {
+  it('cancellation falls back to 0.00 USD when no booked rate is supplied', async () => {
+    const res = await agent.execute({ data: cancelInput() });
+    expect(res.data.penalty?.penaltyAmount.amount).toBe('0.00');
+    expect(res.data.penalty?.penaltyAmount.currency).toBe('USD');
+  });
+
+  it('no-show falls back to 0.00 USD when no booked rate is supplied', async () => {
+    const res = await agent.execute({
+      data: { operation: 'process_no_show', bookingId: 'HB-0003' },
+    });
+    expect(res.data.penalty?.penaltyAmount.amount).toBe('0.00');
+    expect(res.data.penalty?.penaltyAmount.currency).toBe('USD');
+  });
+});

--- a/packages/agents/lodging/src/property-dedup/__tests__/edge-cases.test.ts
+++ b/packages/agents/lodging/src/property-dedup/__tests__/edge-cases.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Edge-case tests for the property deduplication scoring algorithms
+ * (Agent 20.x property-dedup, issue #16).
+ *
+ * Covers transliteration/unicode, co-located vs same-name-different-city,
+ * and missing/null components (coordinates, star rating, chain code) — asserting
+ * the actual behavior of the exported scoring functions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  jaroWinkler,
+  haversineScore,
+  starRatingScore,
+  chainCodeScore,
+  compositeScore,
+} from '../matching/scorer.js';
+import { normalizeName } from '../matching/normalizer.js';
+
+const base = {
+  name: 0,
+  address: 0,
+  coordinates: 0,
+  chainCode: 0.5,
+  starRating: 0.5,
+};
+
+describe('dedup scoring — edge cases', () => {
+  describe('transliteration & unicode', () => {
+    it('normalizes accented and transliterated spellings to the same string', () => {
+      expect(normalizeName('Hotel München')).toBe(normalizeName('Hotel Munchen'));
+      expect(normalizeName('Café Rouge')).toBe(normalizeName('Cafe Rouge'));
+    });
+
+    it('scores transliterated names as an exact match after normalization', () => {
+      const a = normalizeName('Hotel München');
+      const b = normalizeName('Hotel Munchen');
+      expect(jaroWinkler(a, b)).toBe(1.0);
+    });
+
+    it('handles unicode combining marks (NFD vs NFC) consistently', () => {
+      const nfc = 'Hôtel'.normalize('NFC');
+      const nfd = 'Hôtel'.normalize('NFD');
+      expect(normalizeName(nfc)).toBe(normalizeName(nfd));
+    });
+  });
+
+  describe('coordinates', () => {
+    it('co-located properties (identical coordinates) score 1.0', () => {
+      expect(haversineScore(40.7, -74.0, 40.7, -74.0)).toBe(1.0);
+    });
+
+    it('same name in a different city scores 0.0 on proximity', () => {
+      // "Hilton" in New York vs London — identical name, far apart.
+      expect(haversineScore(40.7128, -74.006, 51.5074, -0.1278)).toBe(0.0);
+    });
+
+    it('co-located but different names ranks below co-located same-name', () => {
+      const sameName = compositeScore({ ...base, name: 1.0, coordinates: 1.0 });
+      const diffName = compositeScore({ ...base, name: 0.2, coordinates: 1.0 });
+      expect(diffName.weighted).toBeLessThan(sameName.weighted);
+    });
+
+    it('same name but far apart ranks below same name co-located', () => {
+      const near = compositeScore({ ...base, name: 1.0, coordinates: 1.0 });
+      const far = compositeScore({ ...base, name: 1.0, coordinates: 0.0 });
+      expect(far.weighted).toBeLessThan(near.weighted);
+    });
+  });
+
+  describe('missing / null components', () => {
+    it('missing star rating (one or both) yields a neutral 0.5', () => {
+      expect(starRatingScore(undefined, 4)).toBe(0.5);
+      expect(starRatingScore(4, undefined)).toBe(0.5);
+      expect(starRatingScore(undefined, undefined)).toBe(0.5);
+    });
+
+    it('exact star rating match yields 1.0; >0.5 apart yields 0.0', () => {
+      expect(starRatingScore(4, 4)).toBe(1.0);
+      expect(starRatingScore(3, 5)).toBe(0.0);
+    });
+
+    it('missing chain code (one or both) yields a neutral 0.5', () => {
+      expect(chainCodeScore(undefined, 'HH')).toBe(0.5);
+      expect(chainCodeScore('HH', undefined)).toBe(0.5);
+      expect(chainCodeScore(undefined, undefined)).toBe(0.5);
+    });
+
+    it('matching chain codes 1.0, differing 0.0 (case-insensitive)', () => {
+      expect(chainCodeScore('hh', 'HH')).toBe(1.0);
+      expect(chainCodeScore('HH', 'MC')).toBe(0.0);
+    });
+
+    it('compositeScore stays finite when all components are neutral/zero', () => {
+      const s = compositeScore(base);
+      expect(Number.isFinite(s.weighted)).toBe(true);
+      expect(s.weighted).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/packages/agents/reference/src/airport-code-resolver/__tests__/fuzzy-match.test.ts
+++ b/packages/agents/reference/src/airport-code-resolver/__tests__/fuzzy-match.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for fuzzy match result limiting (Agent 0.1, issue #7 — max_results).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { initFuzzyIndex, fuzzySearch, resetFuzzyIndex } from '../fuzzy-match.js';
+import type { ProcessedAirport } from '../types.js';
+
+function airport(iata: string, name: string, city: string): ProcessedAirport {
+  return {
+    iata_code: iata,
+    icao_code: null,
+    name,
+    city_name: city,
+    city_code: null,
+    country_code: 'GB',
+    country_name: 'United Kingdom',
+    timezone: 'Europe/London',
+    latitude: 0,
+    longitude: 0,
+    elevation_ft: null,
+    type: 'large_airport',
+    status: 'active',
+  };
+}
+
+// Several airports share the "London" prefix so a single query yields many
+// fuzzy candidates — enough to observe the limit taking effect.
+const AIRPORTS: ProcessedAirport[] = [
+  airport('LHR', 'London Heathrow Airport', 'London'),
+  airport('LGW', 'London Gatwick Airport', 'London'),
+  airport('STN', 'London Stansted Airport', 'London'),
+  airport('LTN', 'London Luton Airport', 'London'),
+  airport('LCY', 'London City Airport', 'London'),
+  airport('SEN', 'London Southend Airport', 'London'),
+];
+
+describe('fuzzySearch result limiting', () => {
+  beforeAll(() => initFuzzyIndex(AIRPORTS));
+  afterAll(() => resetFuzzyIndex());
+
+  it('max_results=1 returns at most 1 match', () => {
+    const results = fuzzySearch('London', 1);
+    expect(results).toHaveLength(1);
+  });
+
+  it('max_results=5 returns at most 5 matches', () => {
+    const results = fuzzySearch('London', 5);
+    expect(results.length).toBeLessThanOrEqual(5);
+    expect(results.length).toBeGreaterThan(1);
+  });
+
+  it('omitted limit falls back to the default (<= 5)', () => {
+    const results = fuzzySearch('London');
+    expect(results.length).toBeLessThanOrEqual(5);
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('returns matches sorted by confidence (highest first)', () => {
+    const results = fuzzySearch('London', 5);
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1]!.confidence).toBeGreaterThanOrEqual(results[i]!.confidence);
+    }
+  });
+});

--- a/packages/agents/reference/src/airport-code-resolver/__tests__/health.test.ts
+++ b/packages/agents/reference/src/airport-code-resolver/__tests__/health.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Health-check degradation tests (Agent 0.1, issue #8).
+ *
+ * `airports.json` is required; `metro-areas.json` and `decommissioned.json` are
+ * optional. Missing optional datasets → `degraded`; missing core → cannot
+ * initialize (→ `unhealthy`); all present → `healthy`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { AirportCodeResolver } from '../index.js';
+import type { ProcessedAirport } from '../types.js';
+
+const AIRPORTS: ProcessedAirport[] = [
+  {
+    iata_code: 'JFK',
+    icao_code: 'KJFK',
+    name: 'John F Kennedy International Airport',
+    city_name: 'New York',
+    city_code: 'NYC',
+    country_code: 'US',
+    country_name: 'United States',
+    timezone: 'America/New_York',
+    latitude: 40.6413,
+    longitude: -73.7781,
+    elevation_ft: 13,
+    type: 'large_airport',
+    status: 'active',
+    primary: true,
+  },
+];
+
+const dirs: string[] = [];
+
+async function makeDir(files: Record<string, unknown>): Promise<string> {
+  const dir = join(tmpdir(), `otaip-health-${Date.now()}-${dirs.length}`);
+  await mkdir(dir, { recursive: true });
+  for (const [name, contents] of Object.entries(files)) {
+    await writeFile(join(dir, name), JSON.stringify(contents));
+  }
+  dirs.push(dir);
+  return dir;
+}
+
+afterAll(async () => {
+  await Promise.all(dirs.map((d) => rm(d, { recursive: true, force: true })));
+});
+
+describe('AirportCodeResolver.health()', () => {
+  it('returns healthy when all datasets are present', async () => {
+    const dir = await makeDir({
+      'airports.json': AIRPORTS,
+      'metro-areas.json': [],
+      'decommissioned.json': [],
+    });
+    const agent = new AirportCodeResolver({ dataDir: dir });
+    await agent.initialize();
+    expect((await agent.health()).status).toBe('healthy');
+    agent.destroy();
+  });
+
+  it('returns degraded when optional datasets are missing', async () => {
+    const dir = await makeDir({ 'airports.json': AIRPORTS });
+    const agent = new AirportCodeResolver({ dataDir: dir });
+    await agent.initialize();
+    const health = await agent.health();
+    expect(health.status).toBe('degraded');
+    expect(health.details).toContain('metro-areas.json');
+    expect(health.details).toContain('decommissioned.json');
+    agent.destroy();
+  });
+
+  it('names only the missing optional dataset', async () => {
+    const dir = await makeDir({
+      'airports.json': AIRPORTS,
+      'metro-areas.json': [],
+    });
+    const agent = new AirportCodeResolver({ dataDir: dir });
+    await agent.initialize();
+    const health = await agent.health();
+    expect(health.status).toBe('degraded');
+    expect(health.details).toContain('decommissioned.json');
+    expect(health.details).not.toContain('metro-areas.json');
+    agent.destroy();
+  });
+
+  it('reports unhealthy (cannot initialize) when core airports.json is missing', async () => {
+    const dir = await makeDir({ 'metro-areas.json': [] });
+    const agent = new AirportCodeResolver({ dataDir: dir });
+    await expect(agent.initialize()).rejects.toThrow(/Airport data not found/);
+    // Without initialization the agent is unhealthy.
+    expect((await agent.health()).status).toBe('unhealthy');
+  });
+});

--- a/packages/agents/reference/src/airport-code-resolver/__tests__/tz-offset.test.ts
+++ b/packages/agents/reference/src/airport-code-resolver/__tests__/tz-offset.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for UTC offset derivation (Agent 0.1, issue #14).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveUtcOffset } from '../tz-offset.js';
+
+// Fixed instants so DST-sensitive assertions are deterministic.
+const WINTER = new Date('2026-01-15T12:00:00Z');
+const SUMMER = new Date('2026-07-15T12:00:00Z');
+
+describe('deriveUtcOffset', () => {
+  it('returns +00:00 for UTC', () => {
+    expect(deriveUtcOffset('UTC', WINTER)).toBe('+00:00');
+    expect(deriveUtcOffset('Etc/UTC', SUMMER)).toBe('+00:00');
+  });
+
+  it('returns a positive offset (with half-hour zones)', () => {
+    // India Standard Time — no DST, always +05:30.
+    expect(deriveUtcOffset('Asia/Kolkata', WINTER)).toBe('+05:30');
+    expect(deriveUtcOffset('Asia/Kolkata', SUMMER)).toBe('+05:30');
+  });
+
+  it('returns a negative offset', () => {
+    // US Pacific: -08:00 in winter (PST), -07:00 in summer (PDT).
+    expect(deriveUtcOffset('America/Los_Angeles', WINTER)).toBe('-08:00');
+    expect(deriveUtcOffset('America/Los_Angeles', SUMMER)).toBe('-07:00');
+  });
+
+  it('handles DST transitions for the same timezone', () => {
+    // US Eastern: -05:00 (EST) in winter, -04:00 (EDT) in summer.
+    expect(deriveUtcOffset('America/New_York', WINTER)).toBe('-05:00');
+    expect(deriveUtcOffset('America/New_York', SUMMER)).toBe('-04:00');
+
+    // Europe/London: +00:00 (GMT) in winter, +01:00 (BST) in summer.
+    expect(deriveUtcOffset('Europe/London', WINTER)).toBe('+00:00');
+    expect(deriveUtcOffset('Europe/London', SUMMER)).toBe('+01:00');
+  });
+
+  it('returns null for missing or invalid timezones', () => {
+    expect(deriveUtcOffset(null)).toBeNull();
+    expect(deriveUtcOffset(undefined)).toBeNull();
+    expect(deriveUtcOffset('')).toBeNull();
+    expect(deriveUtcOffset('Not/ARealZone', WINTER)).toBeNull();
+  });
+});

--- a/packages/agents/reference/src/airport-code-resolver/data-loader.ts
+++ b/packages/agents/reference/src/airport-code-resolver/data-loader.ts
@@ -15,6 +15,15 @@ export interface AirportDataset {
   metroAreas: MetroArea[];
   decommissioned: DecommissionedAirport[];
   loadedAt: Date;
+  /**
+   * Which optional datasets were present on disk at load time. `airports.json`
+   * is required (load throws if missing); these two are optional and drive a
+   * `degraded` health status when absent.
+   */
+  optionalDatasets: {
+    metroAreas: boolean;
+    decommissioned: boolean;
+  };
 }
 
 const DATA_DIR = join(process.cwd(), 'data', 'reference');
@@ -43,9 +52,12 @@ export async function loadAirportData(dataDir?: string): Promise<AirportDataset>
 
   const airports = await loadJsonFile<ProcessedAirport[]>(airportsPath);
 
-  const metroAreas = existsSync(metroPath) ? await loadJsonFile<MetroArea[]>(metroPath) : [];
+  const hasMetro = existsSync(metroPath);
+  const hasDecommissioned = existsSync(decommissionedPath);
 
-  const decommissioned = existsSync(decommissionedPath)
+  const metroAreas = hasMetro ? await loadJsonFile<MetroArea[]>(metroPath) : [];
+
+  const decommissioned = hasDecommissioned
     ? await loadJsonFile<DecommissionedAirport[]>(decommissionedPath)
     : [];
 
@@ -54,5 +66,9 @@ export async function loadAirportData(dataDir?: string): Promise<AirportDataset>
     metroAreas,
     decommissioned,
     loadedAt: new Date(),
+    optionalDatasets: {
+      metroAreas: hasMetro,
+      decommissioned: hasDecommissioned,
+    },
   };
 }

--- a/packages/agents/reference/src/airport-code-resolver/index.ts
+++ b/packages/agents/reference/src/airport-code-resolver/index.ts
@@ -92,6 +92,18 @@ export class AirportCodeResolver implements Agent<
       return { status: 'degraded', details: 'Airport data is stale (>30 days old).' };
     }
 
+    // Optional datasets missing → degraded (core airports.json is present, so
+    // resolution still works, but metro/decommissioned lookups are unavailable).
+    const missing: string[] = [];
+    if (!this.dataset.optionalDatasets.metroAreas) missing.push('metro-areas.json');
+    if (!this.dataset.optionalDatasets.decommissioned) missing.push('decommissioned.json');
+    if (missing.length > 0) {
+      return {
+        status: 'degraded',
+        details: `Optional dataset(s) missing: ${missing.join(', ')}.`,
+      };
+    }
+
     return { status: 'healthy' };
   }
 

--- a/packages/agents/reference/src/airport-code-resolver/resolver.ts
+++ b/packages/agents/reference/src/airport-code-resolver/resolver.ts
@@ -18,6 +18,7 @@ import type {
 } from './types.js';
 import type { AirportDataset } from './data-loader.js';
 import { fuzzySearch } from './fuzzy-match.js';
+import { deriveUtcOffset } from './tz-offset.js';
 
 /** Indexes built from the loaded dataset for O(1) lookups */
 interface AirportIndexes {
@@ -118,7 +119,7 @@ function toResolvedAirport(airport: ProcessedAirport): ResolvedAirport {
     country_code: airport.country_code,
     country_name: airport.country_name,
     timezone: airport.timezone,
-    utc_offset: null, // UTC offset derived at runtime or from timezone data
+    utc_offset: deriveUtcOffset(airport.timezone), // DST-correct offset from IANA tz
     latitude: airport.latitude,
     longitude: airport.longitude,
     elevation_ft: airport.elevation_ft,
@@ -250,7 +251,7 @@ export function resolve(
 
   // Step 5: Fuzzy name search
   if (detectedType === 'name' || (detectedType === 'iata' && !indexes.byIata.has(upper))) {
-    const fuzzyResults = fuzzySearch(code, 1);
+    const fuzzyResults = fuzzySearch(code, input.max_results ?? 1);
     if (fuzzyResults.length > 0) {
       const best = fuzzyResults[0]!;
       if (best.confidence >= 0.5) {

--- a/packages/agents/reference/src/airport-code-resolver/schema.ts
+++ b/packages/agents/reference/src/airport-code-resolver/schema.ts
@@ -12,6 +12,7 @@ export const airportCodeResolverInputSchema = z.object({
   code_type: z.enum(['iata', 'icao', 'city', 'name', 'auto']).optional(),
   include_metro: z.boolean().optional(),
   include_decommissioned: z.boolean().optional(),
+  max_results: z.number().int().positive().optional(),
 });
 
 const airportTypeSchema = z.enum([

--- a/packages/agents/reference/src/airport-code-resolver/types.ts
+++ b/packages/agents/reference/src/airport-code-resolver/types.ts
@@ -26,6 +26,8 @@ export interface AirportCodeResolverInput {
   include_metro?: boolean;
   /** If true, resolve codes that have been retired/reassigned. Default: false */
   include_decommissioned?: boolean;
+  /** Cap on fuzzy-name matches considered during resolution. Omit for the default. */
+  max_results?: number;
 }
 
 export interface ResolvedAirport {

--- a/packages/agents/reference/src/airport-code-resolver/tz-offset.ts
+++ b/packages/agents/reference/src/airport-code-resolver/tz-offset.ts
@@ -1,0 +1,42 @@
+/**
+ * UTC offset derivation for Airport Code Resolver.
+ *
+ * Derives a `±HH:MM` UTC offset from an IANA timezone name (e.g.
+ * "America/New_York") using the built-in `Intl.DateTimeFormat` — no external
+ * timezone library. Because the offset is computed for a specific instant, DST
+ * is handled automatically: the same timezone yields a different offset in
+ * summer vs winter.
+ */
+
+/**
+ * Derive the UTC offset for an IANA timezone at a given instant.
+ *
+ * @param timeZone - IANA timezone name (e.g. "America/New_York", "Asia/Kolkata").
+ * @param at - Instant to evaluate the offset at. Defaults to now. Pass an
+ *   explicit date to get a DST-correct offset for a specific season.
+ * @returns Offset string like "+05:30", "-08:00", or "+00:00"; `null` if the
+ *   timezone is empty/invalid.
+ */
+export function deriveUtcOffset(timeZone: string | null | undefined, at: Date = new Date()): string | null {
+  if (!timeZone) return null;
+
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      timeZoneName: 'longOffset',
+    }).formatToParts(at);
+
+    const tzName = parts.find((p) => p.type === 'timeZoneName')?.value;
+    if (!tzName) return null;
+
+    // "longOffset" yields e.g. "GMT+05:30", "GMT-08:00", or bare "GMT" for UTC.
+    const match = tzName.match(/GMT([+-]\d{2}:\d{2})/);
+    if (match) return match[1]!;
+    if (/^GMT$/.test(tzName) || /^UTC$/.test(tzName)) return '+00:00';
+
+    return null;
+  } catch {
+    // Invalid timezone name → RangeError from Intl.
+    return null;
+  }
+}

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -5,29 +5,85 @@
  * This ensures a uniform contract for initialization, execution, and health checks.
  */
 
+/**
+ * Wrapper for the input passed to {@link Agent.execute}.
+ *
+ * The agent-specific payload lives in {@link AgentInput.data}; `metadata`
+ * carries out-of-band context (trace ids, caller info, pipeline gates) that is
+ * not part of the domain input. This wrapper keeps the domain type (`T`) clean
+ * while allowing the runtime to thread cross-cutting concerns.
+ *
+ * @typeParam T - The agent-specific input payload type.
+ */
 export interface AgentInput<T = unknown> {
+  /** The agent-specific input payload. */
   data: T;
+  /** Optional out-of-band context (e.g. trace ids, caller metadata). */
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * Wrapper for the result returned by {@link Agent.execute}.
+ *
+ * Mirrors {@link AgentInput}: the domain result is in {@link AgentOutput.data},
+ * while `confidence`, `warnings`, and `metadata` describe the result without
+ * polluting the domain type (`T`).
+ *
+ * @typeParam T - The agent-specific output payload type.
+ */
 export interface AgentOutput<T = unknown> {
+  /** The agent-specific output payload. */
   data: T;
+  /** Optional 0–1 confidence score for the result. */
   confidence?: number;
+  /** Optional out-of-band context (e.g. dataset version, timing). */
   metadata?: Record<string, unknown>;
+  /** Non-fatal notes about the result (e.g. stale data, fallbacks used). */
   warnings?: string[];
 }
 
+/**
+ * Health snapshot returned by {@link Agent.health}.
+ *
+ * The three states are:
+ * - `healthy` — fully operational; all required and optional data present.
+ * - `degraded` — operational but impaired (e.g. stale or missing *optional*
+ *   datasets); results may be incomplete.
+ * - `unhealthy` — cannot serve requests (e.g. not initialized, required data
+ *   missing).
+ */
 export interface AgentHealthStatus {
+  /** Overall health state. */
   status: 'healthy' | 'degraded' | 'unhealthy';
+  /** Human-readable explanation, required in practice for non-healthy states. */
   details?: string;
 }
 
+/**
+ * The base contract every OTAIP agent implements.
+ *
+ * Lifecycle: `initialize()` → `execute()` → `health()`.
+ * - {@link Agent.initialize} must be called once before {@link Agent.execute};
+ *   calling `execute` first throws `AgentNotInitializedError`.
+ * - {@link Agent.execute} is stateless per call — agents hold no per-request
+ *   state between invocations.
+ * - {@link Agent.health} may be called at any time to probe readiness.
+ *
+ * @typeParam TInput - The agent-specific input payload type.
+ * @typeParam TOutput - The agent-specific output payload type.
+ */
 export interface Agent<TInput = unknown, TOutput = unknown> {
+  /** Stable agent identifier (e.g. `"0.1"`). */
   readonly id: string;
+  /** Human-readable agent name. */
   readonly name: string;
+  /** Agent implementation version (semver). */
   readonly version: string;
 
+  /** Load data and prepare the agent. Call once before {@link Agent.execute}. */
   initialize(): Promise<void>;
+  /** Run the agent against a single input. Must be called after {@link Agent.initialize}. */
   execute(input: AgentInput<TInput>): Promise<AgentOutput<TOutput>>;
+  /** Report current health; see {@link AgentHealthStatus}. */
   health(): Promise<AgentHealthStatus>;
 }


### PR DESCRIPTION
Triages the open `good first issue` backlog. Closes the stale ones and implements the rest. No domain logic invented — tests assert existing deterministic behavior.

## Implemented
- **#14** Airport resolver `utc_offset` derived from IANA timezone via `Intl.DateTimeFormat` (DST-correct, no external tz lib). New `tz-offset.ts` + tests (UTC, +/- offsets, DST, invalid).
- **#7** `max_results` input option on the resolver, threaded to `fuzzySearch`; limit tests (1 / 5 / omitted).
- **#8** `health()` returns `degraded` when optional datasets (`metro-areas.json` / `decommissioned.json`) are missing; loader now tracks per-file presence. `unhealthy` still for missing core / uninitialized.
- **#12** JSDoc on `Agent` / `AgentInput` / `AgentOutput` / `AgentHealthStatus` incl. the initialize→execute→health lifecycle and the three health states.

## Tests added
- **#16** property-dedup edge cases — transliteration/unicode normalization, co-located vs same-name-different-city, null star / missing chain code.
- **#18** content-normalization chain-specific room types (Marriott/Hilton/IHG/Hyatt/boutique/budget), asserting the normalizer's actual keyword-derived category/bed type.
- **#19** hotel-modification — penalty computed against the booked `nightlyRate` (not a fixed/current rate) + `0.00` fallback when omitted.

## Closed separately (stale/superseded)
- **#6** decommissioned-code tests already exist · **#10** superseded by `agents.manifest.json` + discovery (#112) · **#17** fee tests already exist.

## Verification
- Full suite: **3342 passed**, 17 skipped (+45 new).
- `typecheck` clean on core / reference / lodging.