### PR TITLE
feat: Duffel ticket enrichment + activity/transfer agents 20.8/20.9

### DIFF
--- a/agents.manifest.json
+++ b/agents.manifest.json
@@ -1,6 +1,6 @@
 {
   "generated_by": "scripts/generate-manifest.ts",
-  "total": 75,
+  "total": 77,
   "with_contract": 18,
   "agents": [
     {
@@ -6136,6 +6136,24 @@
       "contract_status": "active",
       "has_contract": false,
       "source_path": "packages/agents/lodging/src/confirmation-verification/index.ts"
+    },
+    {
+      "id": "20.8",
+      "name": "Activity Search",
+      "stage": "lodging",
+      "version": "0.1.0",
+      "contract_status": "active",
+      "has_contract": false,
+      "source_path": "packages/agents/lodging/src/activity-search/index.ts"
+    },
+    {
+      "id": "20.9",
+      "name": "Transfer Search",
+      "stage": "lodging",
+      "version": "0.1.0",
+      "contract_status": "active",
+      "has_contract": false,
+      "source_path": "packages/agents/lodging/src/transfer-search/index.ts"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -36,10 +36,14 @@
     "overrides": {
       "hono": ">=4.12.25",
       "ip-address": ">=10.1.1",
-      "fast-uri": ">=3.1.2",
+      "fast-uri": ">=3.1.3",
       "vite": "^8.0.16",
       "esbuild": ">=0.28.1",
-      "qs": ">=6.15.2"
+      "qs": ">=6.15.2",
+      "postcss": ">=8.5.18",
+      "brace-expansion": ">=5.0.8",
+      "find-my-way": ">=9.7.0",
+      "@fastify/static": ">=10.1.1"
     }
   },
   "devDependencies": {

--- a/packages/adapters/duffel/src/__tests__/duffel-adapter.test.ts
+++ b/packages/adapters/duffel/src/__tests__/duffel-adapter.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { DuffelAdapter, parseDurationToMinutes } from '../duffel-adapter.js';
+import {
+  DuffelAdapter,
+  mapOrderToBookResponse,
+  parseDurationToMinutes,
+  type DuffelOrder,
+} from '../duffel-adapter.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -339,5 +344,245 @@ describe('DuffelAdapter error handling', () => {
   it('throws on 500 server error', async () => {
     mockFetchResponse(500, {});
     await expect(adapter.search(SEARCH_REQUEST)).rejects.toThrow('Duffel API error 500');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapOrderToBookResponse()
+// ---------------------------------------------------------------------------
+
+const SAMPLE_ORDER: DuffelOrder = {
+  id: 'ord_00009hthhsUZ8W4LxQgkjo',
+  booking_reference: 'RZPNX8',
+  total_amount: '90.80',
+  total_currency: 'GBP',
+  base_amount: '60.60',
+  tax_amount: '30.20',
+  created_at: '2020-04-11T15:48:11.642Z',
+  owner: { iata_code: 'BA', name: 'British Airways' },
+  passengers: [
+    {
+      id: 'pas_00009hj8USM7Ncg31cBCLL',
+      given_name: 'Amelia',
+      family_name: 'Earhart',
+      born_on: '1987-07-24',
+      type: 'adult',
+      title: 'mrs',
+      gender: 'f',
+      email: 'amelia@duffel.com',
+      phone_number: '+442080160509',
+    },
+  ],
+  documents: [
+    {
+      type: 'electronic_ticket',
+      unique_identifier: '1252106312810',
+      passenger_ids: ['pas_00009hj8USM7Ncg31cBCLL'],
+    },
+  ],
+  slices: [
+    {
+      segments: [
+        {
+          marketing_carrier: { iata_code: 'BA' },
+          marketing_carrier_flight_number: '1234',
+          origin: { iata_code: 'LHR' },
+          destination: { iata_code: 'JFK' },
+          departing_at: '2020-06-13T16:38:02',
+          passengers: [
+            {
+              cabin_class: 'economy',
+              fare_basis_code: 'Y26NR',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  conditions: {
+    refund_before_departure: {
+      allowed: false,
+      penalty_amount: null,
+      penalty_currency: null,
+    },
+    change_before_departure: {
+      allowed: true,
+      penalty_amount: '100.00',
+      penalty_currency: 'GBP',
+    },
+  },
+};
+
+describe('mapOrderToBookResponse', () => {
+  it('maps existing BookResponse fields and enriched ticket/fare data', () => {
+    const result = mapOrderToBookResponse(SAMPLE_ORDER);
+
+    expect(result.booking_reference).toBe('RZPNX8');
+    expect(result.order_id).toBe('ord_00009hthhsUZ8W4LxQgkjo');
+    expect(result.total_amount).toBe('90.80');
+    expect(result.total_currency).toBe('GBP');
+    expect(result.passengers).toHaveLength(1);
+    expect(result.passengers[0]!.given_name).toBe('Amelia');
+    expect(result.passengers[0]!.family_name).toBe('Earhart');
+
+    expect(result.ticketNumbers).toEqual([
+      { number: '1252106312810', issuingCarrier: 'BA' },
+    ]);
+    expect(result.segments).toEqual([
+      {
+        carrier: 'BA',
+        flightNumber: '1234',
+        origin: 'LHR',
+        destination: 'JFK',
+        departureDate: '2020-06-13',
+        bookingClass: '',
+        fareBasis: 'Y26NR',
+      },
+    ]);
+    expect(result.baseAmount).toBe('60.60');
+    expect(result.taxAmount).toBe('30.20');
+    expect(result.recordLocator).toBe('RZPNX8');
+    expect(result.passengerNames).toEqual(['Amelia Earhart']);
+    expect(result.issuedAt).toBe('2020-04-11T15:48:11.642Z');
+    expect(result.bookingDate).toBe('2020-04-11T15:48:11.642Z');
+    expect(result.refundable).toBe(false);
+    expect(result.changeable).toBe(true);
+  });
+
+  it('omits optional fields when Duffel does not return them', () => {
+    const result = mapOrderToBookResponse({
+      id: 'ord_minimal',
+      booking_reference: 'ABC123',
+      total_amount: '10.00',
+      total_currency: 'USD',
+    });
+
+    expect(result.order_id).toBe('ord_minimal');
+    expect(result.ticketNumbers).toBeUndefined();
+    expect(result.segments).toBeUndefined();
+    expect(result.baseAmount).toBeUndefined();
+    expect(result.taxAmount).toBeUndefined();
+    expect(result.passengerNames).toBeUndefined();
+    expect(result.issuedAt).toBeUndefined();
+    expect(result.refundable).toBeUndefined();
+    expect(result.changeable).toBeUndefined();
+    expect(result.recordLocator).toBe('ABC123');
+  });
+
+  it('ignores non-ticket documents', () => {
+    const result = mapOrderToBookResponse({
+      ...SAMPLE_ORDER,
+      documents: [
+        {
+          type: 'electronic_miscellaneous_document_associated',
+          unique_identifier: 'EMD123',
+        },
+      ],
+    });
+    expect(result.ticketNumbers).toBeUndefined();
+  });
+
+  it('leaves fareBasis empty when order segment has no fare_basis_code', () => {
+    const result = mapOrderToBookResponse({
+      ...SAMPLE_ORDER,
+      slices: [
+        {
+          segments: [
+            {
+              marketing_carrier: { iata_code: 'BA' },
+              marketing_carrier_flight_number: '1',
+              origin: { iata_code: 'LHR' },
+              destination: { iata_code: 'JFK' },
+              departing_at: '2020-06-13T16:38:02',
+              passengers: [{ cabin_class: 'economy' }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.segments?.[0]?.fareBasis).toBe('');
+    expect(result.segments?.[0]?.bookingClass).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getOrder()
+// ---------------------------------------------------------------------------
+
+describe('DuffelAdapter getOrder', () => {
+  it('GETs /air/orders/{id} and returns enriched BookResponse', async () => {
+    mockFetchResponse(200, { data: SAMPLE_ORDER });
+    const adapter = new DuffelAdapter('duffel_test_key');
+
+    const result = await adapter.getOrder('ord_00009hthhsUZ8W4LxQgkjo');
+
+    expect(result.ticketNumbers?.[0]?.number).toBe('1252106312810');
+    expect(result.baseAmount).toBe('60.60');
+    expect(result.recordLocator).toBe('RZPNX8');
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0]!;
+    expect(fetchCall[0]).toBe(
+      'https://api.duffel.com/air/orders/ord_00009hthhsUZ8W4LxQgkjo',
+    );
+    expect((fetchCall[1] as RequestInit).method).toBe('GET');
+  });
+
+  it('throws when order payload is missing', async () => {
+    mockFetchResponse(200, { data: null });
+    const adapter = new DuffelAdapter('duffel_test_key');
+    await expect(adapter.getOrder('ord_missing')).rejects.toThrow('not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// book() enriched mapping
+// ---------------------------------------------------------------------------
+
+describe('DuffelAdapter book', () => {
+  it('returns enriched fields from the created order', async () => {
+    const offerWithPax = {
+      ...DUFFEL_OFFER,
+      passengers: [{ id: 'pas_offer_1', type: 'adult' }],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({ data: offerWithPax }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({ data: SAMPLE_ORDER }),
+        }),
+    );
+
+    const adapter = new DuffelAdapter('duffel_test_key');
+    const result = await adapter.book({
+      offer_id: 'off_test_123',
+      passengers: [
+        {
+          title: 'mrs',
+          given_name: 'Amelia',
+          family_name: 'Earhart',
+          born_on: '1987-07-24',
+          email: 'amelia@duffel.com',
+          phone_number: '+442080160509',
+          gender: 'f',
+          type: 'adult',
+        },
+      ],
+    });
+
+    expect(result.order_id).toBe('ord_00009hthhsUZ8W4LxQgkjo');
+    expect(result.ticketNumbers?.[0]?.number).toBe('1252106312810');
+    expect(result.segments?.[0]?.fareBasis).toBe('Y26NR');
+    expect(result.baseAmount).toBe('60.60');
+    expect(result.taxAmount).toBe('30.20');
   });
 });

--- a/packages/adapters/duffel/src/duffel-adapter.ts
+++ b/packages/adapters/duffel/src/duffel-adapter.ts
@@ -93,7 +93,10 @@ interface DuffelSegment {
   passengers?: Array<{
     cabin_class?: string;
     cabin_class_marketing_name?: string;
+    /** Present on offers; may be absent on some order responses. */
     fare_basis_code?: string;
+    // TODO: DOMAIN_QUESTION: Does Duffel expose RBD / booking class (single letter) on order segments?
+    // Official OrderSegmentPassenger schema lists cabin_class only — not booking_class.
   }>;
 }
 
@@ -133,14 +136,58 @@ interface DuffelOfferResponse {
   data: DuffelOffer;
 }
 
-interface DuffelOrderResponse {
-  data: {
-    id?: string;
-    booking_reference?: string;
-    total_amount?: string;
-    total_currency?: string;
-    passengers?: Array<Record<string, unknown>>;
+/** Ticket / EMD document on a Duffel order (`documents[]`). */
+interface DuffelOrderDocument {
+  /**
+   * Duffel returns `electronic_ticket` (and EMD types). The handoff shorthand
+   * `type === "ticket"` is treated as an alias for electronic tickets.
+   */
+  type?: string;
+  unique_identifier?: string;
+  passenger_ids?: string[];
+}
+
+interface DuffelOrderCondition {
+  allowed?: boolean | null;
+  penalty_amount?: string | null;
+  penalty_currency?: string | null;
+}
+
+interface DuffelOrderPassenger {
+  id?: string;
+  given_name?: string;
+  family_name?: string;
+  born_on?: string;
+  type?: string;
+  title?: string;
+  gender?: string;
+  email?: string;
+  phone_number?: string;
+}
+
+/** Raw Duffel order payload from POST/GET /air/orders. */
+export interface DuffelOrder {
+  id?: string;
+  booking_reference?: string;
+  total_amount?: string;
+  total_currency?: string;
+  base_amount?: string;
+  base_currency?: string;
+  tax_amount?: string;
+  tax_currency?: string;
+  created_at?: string;
+  passengers?: DuffelOrderPassenger[];
+  slices?: DuffelSlice[];
+  documents?: DuffelOrderDocument[];
+  owner?: { iata_code?: string; name?: string; id?: string };
+  conditions?: {
+    refund_before_departure?: DuffelOrderCondition | null;
+    change_before_departure?: DuffelOrderCondition | null;
   };
+}
+
+interface DuffelOrderResponse {
+  data: DuffelOrder;
 }
 
 interface DuffelOfferWithPassengers {
@@ -228,12 +275,164 @@ export interface BookRequest {
   }>;
 }
 
+export interface BookTicketNumber {
+  number: string;
+  issuingCarrier: string;
+}
+
+export interface BookSegment {
+  carrier: string;
+  flightNumber: string;
+  origin: string;
+  destination: string;
+  departureDate: string;
+  bookingClass: string;
+  fareBasis: string;
+}
+
+export interface BookPassenger {
+  id?: string;
+  given_name?: string;
+  family_name?: string;
+  born_on?: string;
+  type?: string;
+  title?: string;
+  gender?: string;
+  email?: string;
+  phone_number?: string;
+}
+
+/**
+ * Enriched booking / order retrieve response.
+ *
+ * Mapping to agent inputs (distribution → product):
+ *   OriginalTicketSummary (5.1/5.5):
+ *     ticket_number       ← ticketNumbers[0].number
+ *     issuing_carrier     ← ticketNumbers[0].issuingCarrier (= order.owner.iata_code)
+ *     passenger_name      ← passengerNames[0] (given + family; agent may reformat LAST/FIRST)
+ *     record_locator      ← recordLocator (= booking_reference)
+ *     issue_date          ← issuedAt (= created_at)
+ *     booking_date        ← bookingDate (= created_at)
+ *     base_fare           ← baseAmount
+ *     total_tax           ← taxAmount
+ *     total_amount        ← total_amount
+ *     base_fare_currency  ← total_currency (Duffel base_currency when present matches)
+ *     fare_basis          ← segments[0].fareBasis when present
+ *     is_refundable       ← refundable
+ *   RefundProcessingInput (6.1):
+ *     same ticket / fare / refundable fields as above
+ *   // TODO: DOMAIN_QUESTION: ATPCO Cat31/Cat33 filed penalty rules are NOT on a Duffel
+ *   // order — leave absent; agents default to ATPCO behavior when rules are omitted.
+ *   // TODO: DOMAIN_QUESTION: Single-letter RBD booking class is not on Duffel order
+ *   // segments (cabin_class is economy|business|… only) — bookingClass left empty when absent.
+ */
 export interface BookResponse {
   booking_reference: string;
   order_id: string;
   total_amount: string;
   total_currency: string;
-  passengers: unknown[];
+  passengers: BookPassenger[];
+  ticketNumbers?: BookTicketNumber[];
+  segments?: BookSegment[];
+  baseAmount?: string;
+  taxAmount?: string;
+  recordLocator?: string;
+  passengerNames?: string[];
+  issuedAt?: string;
+  bookingDate?: string;
+  refundable?: boolean;
+  changeable?: boolean;
+}
+
+function isTicketDocument(type: string | undefined): boolean {
+  if (!type) return false;
+  // Duffel schema: electronic_ticket. Handoff shorthand: "ticket".
+  return type === 'electronic_ticket' || type === 'ticket';
+}
+
+/**
+ * Map a Duffel order payload to the enriched BookResponse shape.
+ * Pure — no network. Surfaces only fields Duffel actually returns.
+ */
+export function mapOrderToBookResponse(order: DuffelOrder): BookResponse {
+  const bookingReference = order.booking_reference ?? '';
+  const issuingCarrier = order.owner?.iata_code ?? '';
+
+  const ticketNumbers: BookTicketNumber[] = [];
+  for (const doc of order.documents ?? []) {
+    if (!isTicketDocument(doc.type)) continue;
+    if (!doc.unique_identifier) continue;
+    ticketNumbers.push({
+      number: doc.unique_identifier,
+      issuingCarrier,
+    });
+  }
+
+  const segments: BookSegment[] = [];
+  for (const slice of order.slices ?? []) {
+    for (const seg of slice.segments ?? []) {
+      const pax0 = seg.passengers?.[0];
+      const departingAt = seg.departing_at ?? '';
+      segments.push({
+        carrier: seg.marketing_carrier?.iata_code ?? '',
+        flightNumber: seg.marketing_carrier_flight_number ?? '',
+        origin: seg.origin?.iata_code ?? '',
+        destination: seg.destination?.iata_code ?? '',
+        // Date portion of departing_at when present; empty if Duffel omitted the field.
+        departureDate: departingAt.length >= 10 ? departingAt.slice(0, 10) : departingAt,
+        // Not inventing RBD from cabin_class — see DOMAIN_QUESTION on BookResponse.
+        bookingClass: '',
+        // fare_basis_code is documented on offer segment passengers; include when order has it.
+        fareBasis: pax0?.fare_basis_code ?? '',
+      });
+    }
+  }
+
+  const passengers: BookPassenger[] = (order.passengers ?? []).map((p) => ({
+    id: p.id,
+    given_name: p.given_name,
+    family_name: p.family_name,
+    born_on: p.born_on,
+    type: p.type,
+    title: p.title,
+    gender: p.gender,
+    email: p.email,
+    phone_number: p.phone_number,
+  }));
+
+  const passengerNames = passengers
+    .map((p) => [p.given_name, p.family_name].filter(Boolean).join(' ').trim())
+    .filter((name) => name.length > 0);
+
+  const refundAllowed = order.conditions?.refund_before_departure?.allowed;
+  const changeAllowed = order.conditions?.change_before_departure?.allowed;
+
+  const response: BookResponse = {
+    booking_reference: bookingReference,
+    order_id: order.id ?? '',
+    total_amount: order.total_amount ?? '0',
+    total_currency: order.total_currency ?? 'GBP',
+    passengers,
+  };
+
+  if (ticketNumbers.length > 0) response.ticketNumbers = ticketNumbers;
+  if (segments.length > 0) response.segments = segments;
+  if (order.base_amount !== undefined && order.base_amount !== null) {
+    response.baseAmount = order.base_amount;
+  }
+  if (order.tax_amount !== undefined && order.tax_amount !== null) {
+    response.taxAmount = order.tax_amount;
+  }
+  if (bookingReference) response.recordLocator = bookingReference;
+  if (passengerNames.length > 0) response.passengerNames = passengerNames;
+  if (order.created_at) {
+    response.issuedAt = order.created_at;
+    response.bookingDate = order.created_at;
+  }
+  if (typeof refundAllowed === 'boolean') response.refundable = refundAllowed;
+  if (typeof changeAllowed === 'boolean') response.changeable = changeAllowed;
+
+  return response;
 }
 
 export class DuffelAdapter implements DistributionAdapter {
@@ -364,13 +563,24 @@ export class DuffelAdapter implements DistributionAdapter {
       throw new Error('Duffel order creation returned no data');
     }
 
-    return {
-      booking_reference: order.booking_reference ?? '',
-      order_id: order.id ?? '',
-      total_amount: order.total_amount ?? '0',
-      total_currency: order.total_currency ?? 'GBP',
-      passengers: order.passengers ?? [],
-    };
+    return mapOrderToBookResponse(order);
+  }
+
+  /**
+   * Re-fetch an order by id (GET /air/orders/{id}) and return the same enriched
+   * BookResponse shape as book(). Useful when documents (ticket numbers) populate
+   * shortly after instant issue.
+   */
+  async getOrder(orderId: string): Promise<BookResponse> {
+    const response = (await this.request(
+      'GET',
+      `/air/orders/${encodeURIComponent(orderId)}`,
+    )) as DuffelOrderResponse;
+    const order = response.data;
+    if (!order) {
+      throw new Error(`Duffel order not found: ${orderId}`);
+    }
+    return mapOrderToBookResponse(order);
   }
 
   // -------------------------------------------------------------------------

--- a/packages/adapters/duffel/src/index.ts
+++ b/packages/adapters/duffel/src/index.ts
@@ -1,6 +1,17 @@
 export { MockDuffelAdapter } from './mock-duffel-adapter.js';
-export { DuffelAdapter, parseDurationToMinutes } from './duffel-adapter.js';
-export type { BookRequest, BookResponse } from './duffel-adapter.js';
+export {
+  DuffelAdapter,
+  mapOrderToBookResponse,
+  parseDurationToMinutes,
+} from './duffel-adapter.js';
+export type {
+  BookPassenger,
+  BookRequest,
+  BookResponse,
+  BookSegment,
+  BookTicketNumber,
+  DuffelOrder,
+} from './duffel-adapter.js';
 export { DuffelOrderBridge } from './order-bridge.js';
 export { duffelCapabilities } from './capabilities.js';
 

--- a/packages/agents/lodging/src/activity-search/index.ts
+++ b/packages/agents/lodging/src/activity-search/index.ts
@@ -4,7 +4,7 @@
  * Thin typed wrapper around Hotelbeds Activities search for route→fill
  * orchestration and product-layer activity_search mapping.
  */
-import type { Agent, AgentInput, AgentOutput } from '@otaip/core';
+import type { Agent, AgentHealthStatus, AgentInput, AgentOutput } from '@otaip/core';
 import { AgentNotInitializedError, AgentInputValidationError } from '@otaip/core';
 import type { ActivitySearchAgentInput, ActivitySearchAgentOutput } from './types.js';
 
@@ -75,7 +75,17 @@ export class ActivitySearchAgent
     return { data: { offers } };
   }
 
-  async healthCheck() {
-    return { status: 'healthy' as const, agentId: this.id };
+  async health(): Promise<AgentHealthStatus> {
+    if (!this.initialized) {
+      return { status: 'unhealthy', details: 'Not initialized. Call initialize() first.' };
+    }
+    if (!this.adapter) {
+      return { status: 'degraded', details: 'No adapter injected.' };
+    }
+    return { status: 'healthy' };
+  }
+
+  destroy(): void {
+    this.initialized = false;
   }
 }

--- a/packages/agents/lodging/src/activity-search/index.ts
+++ b/packages/agents/lodging/src/activity-search/index.ts
@@ -1,8 +1,8 @@
 /**
  * Agent 20.8 — Activity Search
  *
- * Thin typed wrapper around Hotelbeds Activities search so Tarmac can
- * route→fill and Aviare can map to activity_search.
+ * Thin typed wrapper around Hotelbeds Activities search for route→fill
+ * orchestration and product-layer activity_search mapping.
  */
 import type { Agent, AgentInput, AgentOutput } from '@otaip/core';
 import { AgentNotInitializedError, AgentInputValidationError } from '@otaip/core';

--- a/packages/agents/lodging/src/activity-search/index.ts
+++ b/packages/agents/lodging/src/activity-search/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Agent 20.8 — Activity Search
+ *
+ * Thin typed wrapper around Hotelbeds Activities search so Tarmac can
+ * route→fill and Aviare can map to activity_search.
+ */
+import type { Agent, AgentInput, AgentOutput } from '@otaip/core';
+import { AgentNotInitializedError, AgentInputValidationError } from '@otaip/core';
+import type { ActivitySearchAgentInput, ActivitySearchAgentOutput } from './types.js';
+
+export type {
+  ActivitySearchAgentInput,
+  ActivitySearchAgentOutput,
+  ActivitySearchAgentOffer,
+} from './types.js';
+
+export interface ActivitySearchAdapter {
+  searchActivities(req: {
+    destination: string;
+    from: string;
+    to: string;
+    paxes?: Array<{ age: number }>;
+  }): Promise<Array<{ code?: string; name?: string; amountsFrom?: Array<{ amount?: string; currency?: string }> }>>;
+}
+
+export class ActivitySearchAgent
+  implements Agent<ActivitySearchAgentInput, ActivitySearchAgentOutput>
+{
+  readonly id = '20.8';
+  readonly name = 'Activity Search';
+  readonly version = '0.1.0';
+
+  private initialized = false;
+  constructor(private readonly adapter?: ActivitySearchAdapter) {}
+
+  async initialize(): Promise<void> {
+    this.initialized = true;
+  }
+
+  async execute(
+    input: AgentInput<ActivitySearchAgentInput>,
+  ): Promise<AgentOutput<ActivitySearchAgentOutput>> {
+    if (!this.initialized) throw new AgentNotInitializedError(this.id);
+    const d = input.data;
+    if (!d.destination || !d.dateFrom || !d.dateTo) {
+      throw new AgentInputValidationError(
+        this.id,
+        'destination/dateFrom/dateTo',
+        'Required.',
+      );
+    }
+    if (!this.adapter) {
+      return {
+        data: { offers: [] },
+        metadata: { note: 'No adapter injected — envelope validated only.' },
+      };
+    }
+    const adults = d.adults ?? 1;
+    const paxes = [
+      ...Array.from({ length: adults }, () => ({ age: 30 })),
+      ...(d.childrenAges ?? []).map((age) => ({ age })),
+    ];
+    const raw = await this.adapter.searchActivities({
+      destination: d.destination,
+      from: d.dateFrom,
+      to: d.dateTo,
+      paxes,
+    });
+    const offers = raw.slice(0, 3).map((o) => ({
+      activityCode: String(o.code ?? ''),
+      name: String(o.name ?? 'Activity'),
+      fromPrice: String(o.amountsFrom?.[0]?.amount ?? '0'),
+      currency: String(o.amountsFrom?.[0]?.currency ?? 'EUR'),
+    }));
+    return { data: { offers } };
+  }
+
+  async healthCheck() {
+    return { status: 'healthy' as const, agentId: this.id };
+  }
+}

--- a/packages/agents/lodging/src/activity-search/types.ts
+++ b/packages/agents/lodging/src/activity-search/types.ts
@@ -1,0 +1,21 @@
+/** Agent 20.8 — Activity Search (Hotelbeds Activities wrapper). */
+
+export interface ActivitySearchAgentInput {
+  destination: string;
+  dateFrom: string;
+  dateTo: string;
+  adults?: number;
+  childrenAges?: number[];
+  category?: string;
+}
+
+export interface ActivitySearchAgentOffer {
+  activityCode: string;
+  name: string;
+  fromPrice: string;
+  currency: string;
+}
+
+export interface ActivitySearchAgentOutput {
+  offers: ActivitySearchAgentOffer[];
+}

--- a/packages/agents/lodging/src/index.ts
+++ b/packages/agents/lodging/src/index.ts
@@ -24,6 +24,8 @@ export { RateComparisonAgent } from './rate-comparison/index.js';
 export { HotelBookingAgent } from './hotel-booking/index.js';
 export { HotelModificationAgent } from './hotel-modification/index.js';
 export { ConfirmationVerificationAgent } from './confirmation-verification/index.js';
+export { ActivitySearchAgent } from './activity-search/index.js';
+export { TransferSearchAgent } from './transfer-search/index.js';
 
 // ---------------------------------------------------------------------------
 // Shared types

--- a/packages/agents/lodging/src/transfer-search/index.ts
+++ b/packages/agents/lodging/src/transfer-search/index.ts
@@ -4,7 +4,7 @@
  * Thin typed wrapper around Hotelbeds Transfers search for route→fill
  * orchestration.
  */
-import type { Agent, AgentInput, AgentOutput } from '@otaip/core';
+import type { Agent, AgentHealthStatus, AgentInput, AgentOutput } from '@otaip/core';
 import { AgentNotInitializedError, AgentInputValidationError } from '@otaip/core';
 import type { TransferSearchAgentInput, TransferSearchAgentOutput } from './types.js';
 
@@ -77,7 +77,17 @@ export class TransferSearchAgent
     return { data: { offers } };
   }
 
-  async healthCheck() {
-    return { status: 'healthy' as const, agentId: this.id };
+  async health(): Promise<AgentHealthStatus> {
+    if (!this.initialized) {
+      return { status: 'unhealthy', details: 'Not initialized. Call initialize() first.' };
+    }
+    if (!this.adapter) {
+      return { status: 'degraded', details: 'No adapter injected.' };
+    }
+    return { status: 'healthy' };
+  }
+
+  destroy(): void {
+    this.initialized = false;
   }
 }

--- a/packages/agents/lodging/src/transfer-search/index.ts
+++ b/packages/agents/lodging/src/transfer-search/index.ts
@@ -1,7 +1,8 @@
 /**
  * Agent 20.9 — Transfer Search
  *
- * Thin typed wrapper around Hotelbeds Transfers search for Tarmac route→fill.
+ * Thin typed wrapper around Hotelbeds Transfers search for route→fill
+ * orchestration.
  */
 import type { Agent, AgentInput, AgentOutput } from '@otaip/core';
 import { AgentNotInitializedError, AgentInputValidationError } from '@otaip/core';

--- a/packages/agents/lodging/src/transfer-search/index.ts
+++ b/packages/agents/lodging/src/transfer-search/index.ts
@@ -1,0 +1,82 @@
+/**
+ * Agent 20.9 — Transfer Search
+ *
+ * Thin typed wrapper around Hotelbeds Transfers search for Tarmac route→fill.
+ */
+import type { Agent, AgentInput, AgentOutput } from '@otaip/core';
+import { AgentNotInitializedError, AgentInputValidationError } from '@otaip/core';
+import type { TransferSearchAgentInput, TransferSearchAgentOutput } from './types.js';
+
+export type {
+  TransferSearchAgentInput,
+  TransferSearchAgentOutput,
+  TransferSearchAgentOffer,
+} from './types.js';
+
+export interface TransferSearchAdapter {
+  searchTransfers(req: Record<string, unknown>): Promise<
+    Array<{
+      rateKey?: string;
+      transferType?: string;
+      vehicle?: { name?: string };
+      price?: { totalAmount?: string; currencyId?: string };
+    }>
+  >;
+}
+
+export class TransferSearchAgent
+  implements Agent<TransferSearchAgentInput, TransferSearchAgentOutput>
+{
+  readonly id = '20.9';
+  readonly name = 'Transfer Search';
+  readonly version = '0.1.0';
+
+  private initialized = false;
+  constructor(private readonly adapter?: TransferSearchAdapter) {}
+
+  async initialize(): Promise<void> {
+    this.initialized = true;
+  }
+
+  async execute(
+    input: AgentInput<TransferSearchAgentInput>,
+  ): Promise<AgentOutput<TransferSearchAgentOutput>> {
+    if (!this.initialized) throw new AgentNotInitializedError(this.id);
+    const d = input.data;
+    if (!d.originCode || !d.destinationCode || !d.outboundDate) {
+      throw new AgentInputValidationError(
+        this.id,
+        'originCode/destinationCode/outboundDate',
+        'Required.',
+      );
+    }
+    if (!this.adapter) {
+      return {
+        data: { offers: [] },
+        metadata: { note: 'No adapter injected — envelope validated only.' },
+      };
+    }
+    const raw = await this.adapter.searchTransfers({
+      language: 'en',
+      fromType: d.originType,
+      fromCode: d.originCode,
+      toType: d.destinationType,
+      toCode: d.destinationCode,
+      outbound: `${d.outboundDate}T${d.outboundTime ?? '12:00:00'}`,
+      adults: d.adults ?? 1,
+      children: d.children ?? 0,
+    });
+    const offers = raw.slice(0, 3).map((o, i) => ({
+      transferCode: String(o.rateKey ?? `xfer-${i}`),
+      transferType: String(o.transferType ?? 'PRIVATE'),
+      vehicleType: String(o.vehicle?.name ?? 'Car'),
+      price: String(o.price?.totalAmount ?? '0'),
+      currency: String(o.price?.currencyId ?? 'EUR'),
+    }));
+    return { data: { offers } };
+  }
+
+  async healthCheck() {
+    return { status: 'healthy' as const, agentId: this.id };
+  }
+}

--- a/packages/agents/lodging/src/transfer-search/types.ts
+++ b/packages/agents/lodging/src/transfer-search/types.ts
@@ -1,0 +1,24 @@
+/** Agent 20.9 — Transfer Search (Hotelbeds Transfers wrapper). */
+
+export interface TransferSearchAgentInput {
+  originType: 'A' | 'H' | 'G';
+  originCode: string;
+  destinationType: 'A' | 'H' | 'G';
+  destinationCode: string;
+  outboundDate: string;
+  outboundTime?: string;
+  adults?: number;
+  children?: number;
+}
+
+export interface TransferSearchAgentOffer {
+  transferCode: string;
+  transferType: string;
+  vehicleType: string;
+  price: string;
+  currency: string;
+}
+
+export interface TransferSearchAgentOutput {
+  offers: TransferSearchAgentOffer[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,14 @@ settings:
 overrides:
   hono: '>=4.12.25'
   ip-address: '>=10.1.1'
-  fast-uri: '>=3.1.2'
+  fast-uri: '>=3.1.3'
   vite: ^8.0.16
   esbuild: '>=0.28.1'
   qs: '>=6.15.2'
+  postcss: '>=8.5.18'
+  brace-expansion: '>=5.0.8'
+  find-my-way: '>=9.7.0'
+  '@fastify/static': '>=10.1.1'
 
 importers:
 
@@ -33,7 +37,7 @@ importers:
         version: 3.8.1
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -78,8 +82,8 @@ importers:
   examples/ligare:
     dependencies:
       '@fastify/static':
-        specifier: ^9.1.1
-        version: 9.1.1
+        specifier: '>=10.1.1'
+        version: 10.1.2
       '@otaip/adapter-duffel':
         specifier: workspace:*
         version: link:../../packages/adapters/duffel
@@ -98,7 +102,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -115,8 +119,8 @@ importers:
         specifier: ^10.3.0
         version: 10.3.0
       '@fastify/static':
-        specifier: ^9.1.1
-        version: 9.1.1
+        specifier: '>=10.1.1'
+        version: 10.1.2
       '@otaip/adapter-duffel':
         specifier: workspace:*
         version: link:../../packages/adapters/duffel
@@ -144,7 +148,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.21.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -172,10 +176,10 @@ importers:
         version: 6.0.3(vite@8.1.0(@types/node@25.5.0)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.5.0(postcss@8.5.14)
+        version: 10.5.0(postcss@8.5.23)
       postcss:
-        specifier: ^8.5.10
-        version: 8.5.14
+        specifier: '>=8.5.18'
+        version: 8.5.23
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.19(tsx@4.21.0)
@@ -675,8 +679,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@9.1.1':
-    resolution: {integrity: sha512-LHxFea3qdwe0Pbbkh/yux7/k6nFNLGTNcbLKVYgmRDB6LdDE/8TFSO7qWZ0IzM/nF6iwR8W03oFlwe4v79R1Ow==}
+  '@fastify/static@10.1.2':
+    resolution: {integrity: sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==}
 
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
@@ -1326,7 +1330,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.18'
 
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
@@ -1351,9 +1355,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1422,6 +1426,10 @@ packages:
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-disposition@2.0.1:
+    resolution: {integrity: sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==}
     engines: {node: '>=18'}
 
   content-type@1.0.5:
@@ -1637,11 +1645,14 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify-plugin@6.0.0:
+    resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
 
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
@@ -1670,8 +1681,8 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  find-my-way@9.5.0:
-    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-up@5.0.0:
@@ -2014,8 +2025,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2136,20 +2147,20 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: '>=8.5.18'
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: '>=8.5.18'
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.18'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -2166,7 +2177,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: '>=8.5.18'
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -2175,12 +2186,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2496,7 +2503,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.18'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -2807,7 +2814,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.2
+      fast-uri: 4.1.1
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -2850,12 +2857,13 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@9.1.1':
+  '@fastify/static@10.1.2':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
+      '@fastify/error': 4.2.0
       '@fastify/send': 4.1.0
-      content-disposition: 1.0.1
-      fastify-plugin: 5.1.0
+      content-disposition: 2.0.1
+      fastify-plugin: 6.0.0
       fastq: 1.20.1
       glob: 13.0.6
 
@@ -3339,7 +3347,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3360,13 +3368,13 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.5.0(postcss@8.5.14):
+  autoprefixer@10.5.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001792
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.14
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
   avvio@9.2.0:
@@ -3397,7 +3405,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3463,6 +3471,8 @@ snapshots:
   consola@3.4.2: {}
 
   content-disposition@1.0.1: {}
+
+  content-disposition@2.0.1: {}
 
   content-type@1.0.5: {}
 
@@ -3705,7 +3715,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.2
+      fast-uri: 4.1.1
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -3715,9 +3725,11 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.2: {}
+  fast-uri@4.1.1: {}
 
   fastify-plugin@5.1.0: {}
+
+  fastify-plugin@6.0.0: {}
 
   fastify@5.8.5:
     dependencies:
@@ -3728,7 +3740,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.2.0
       fast-json-stringify: 6.3.0
-      find-my-way: 9.5.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -3764,7 +3776,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way@9.5.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
@@ -4034,7 +4046,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 
@@ -4053,7 +4065,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -4153,37 +4165,29 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-import@15.1.0(postcss@8.5.14):
+  postcss-import@15.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.5.14):
+  postcss-js@4.1.0(postcss@8.5.23):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.14
+      postcss: 8.5.23
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.14
+      postcss: 8.5.23
       tsx: 4.21.0
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.21.0):
+  postcss-nested@6.2.0(postcss@8.5.23):
     dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 1.21.7
-      postcss: 8.5.15
-      tsx: 4.21.0
-
-  postcss-nested@6.2.0(postcss@8.5.14):
-    dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -4193,15 +4197,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.14:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4518,11 +4516,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.14
-      postcss-import: 15.1.0(postcss@8.5.14)
-      postcss-js: 4.1.0(postcss@8.5.14)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)
-      postcss-nested: 6.2.0(postcss@8.5.14)
+      postcss: 8.5.23
+      postcss-import: 15.1.0(postcss@8.5.23)
+      postcss-js: 4.1.0(postcss@8.5.23)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.21.0)
+      postcss-nested: 6.2.0(postcss@8.5.23)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -4586,7 +4584,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -4597,7 +4595,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -4606,7 +4604,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.23
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -4657,7 +4655,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rolldown: 1.1.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
OTAIP side of the Aviare SMOKE/CSB full-product fix.

- Enrich `BookResponse` from live Duffel orders (ticket numbers, segments/fare basis, base/tax, conditions) + `getOrder`
- Add lodging agents **20.8 ActivitySearch** and **20.9 TransferSearch**
- Adapter unit tests: 34 passed

Pairs with Aviare + Tarmac `cursor/resolve-smoke-bugs-d193`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d6a6a2-efb6-4c09-b5b7-4a96ea85d193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d6a6a2-efb6-4c09-b5b7-4a96ea85d193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

