### PR TITLE
chore(release): v0.7.4 — Duffel enrichment + activity/transfer agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 > **Versioning policy:** Pre-v1.0, every release is a patch bump (`0.6.0 → 0.6.1 → 0.6.2 → …`). See [VERSIONING.md](VERSIONING.md) for the full policy and an explanation of the early-history version jumps (0.3.4 → 0.5.0 → 0.5.1 → 0.6.0) that predate this rule. v0.6.4 → v0.7.0 is the one post-policy exception — see VERSIONING.md.
 
+## 0.7.4 — Duffel order enrichment + activity/transfer agents
+
+Workspace-wide patch bump `0.7.3 → 0.7.4` so npm picks up [#123](https://github.com/TelivityAI/otaip/pull/123).
+
+### `@otaip/adapter-duffel`
+
+- Enrich `BookResponse` from the live Duffel order already returned by `book()`: optional `ticketNumbers`, `segments` (fare basis), `baseAmount` / `taxAmount`, `recordLocator`, `passengerNames`, `refundable` / `changeable`, timestamps.
+- Add `getOrder(orderId)` → `GET /air/orders/{id}` mapped through the same helper.
+- Existing five fields unchanged; new fields optional. Unit tests cover the order mapper.
+
+### `@otaip/agents-lodging`
+
+- Agent **20.8** `ActivitySearchAgent` — typed Hotelbeds Activities search wrapper.
+- Agent **20.9** `TransferSearchAgent` — typed Hotelbeds Transfers search wrapper.
+- `agents.manifest.json` regenerated (77 agents).
+
+### CI / hygiene
+
+- `pnpm` overrides for high `pnpm audit` findings (`postcss`, `brace-expansion`, `fast-uri`, `find-my-way`, `@fastify/static`).
+- Public-repo comment guard: no internal product-name refs in lodging agent docs.
+
 ## 0.7.2 — Duffel Cars + auto-publish workflow + post-#93 release fix
 
 Patch bump. Three pieces of substantive work in this window:

--- a/examples/platform-ui/package.json
+++ b/examples/platform-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/platform-ui",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otaip",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Open Travel AI Platform — domain-specific AI agent orchestration for the travel industry",
   "homepage": "https://telivity.app",

--- a/packages/adapters/duffel/package.json
+++ b/packages/adapters/duffel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-duffel",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP distribution adapter for Duffel NDC API — Flights and Cars (mock + live implementations)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapters/hotelbeds/package.json
+++ b/packages/adapters/hotelbeds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/adapter-hotelbeds",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP distribution adapter for the Hotelbeds APItude APIs — Hotels, Activities, and Transfers",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-platform/package.json
+++ b/packages/agents-platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-platform",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 9 agents — orchestration, knowledge, monitoring, audit, plugins",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents-tmc/package.json
+++ b/packages/agents-tmc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-tmc",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 8 agents — TMC & agency operations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/booking/package.json
+++ b/packages/agents/booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-booking",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 3 agents — GDS/NDC routing, PNR building, validation, queue management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/exchange/package.json
+++ b/packages/agents/exchange/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-exchange",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 5 agents — change management, exchange/reissue, involuntary rebook",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/lodging/package.json
+++ b/packages/agents/lodging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-lodging",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/agents/pricing/package.json
+++ b/packages/agents/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-pricing",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 2 agents — fare rules, fare construction, and tax calculation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reconciliation/package.json
+++ b/packages/agents/reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reconciliation",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 7 agents — BSP and ARC reconciliation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/reference/package.json
+++ b/packages/agents/reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-reference",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 0 agents — reference data resolvers (airport codes, airline codes, fare basis, etc.)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/search/package.json
+++ b/packages/agents/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-search",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 1 agents — search, schedule, connection, and fare shopping",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/settlement/package.json
+++ b/packages/agents/settlement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-settlement",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 6 agents — refund processing, ADM prevention",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/ticketing/package.json
+++ b/packages/agents/ticketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/agents-ticketing",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Stage 4 agents — ticket issuance, EMD, void, itinerary delivery, document verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/cli",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP command-line interface — search, price, book, validate, and inspect agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/connect",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP Connect — universal supplier adapter framework for travel booking APIs",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/core",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP core runtime — base agent interfaces and shared types",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@otaip/integration",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "OTAIP integration seam — run contracted agents through the six gates against a live distribution adapter, with a durable, readable execution trace",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Workspace-wide version bump `0.7.3 → 0.7.4` so the Release → npm Publish pipeline ships [#123](https://github.com/TelivityAI/otaip/pull/123) to the registry.

### Includes (already on main via #123)
- `@otaip/adapter-duffel`: enriched `BookResponse` + `getOrder`
- `@otaip/agents-lodging`: agents 20.8 / 20.9
- Changelog section for 0.7.4

### After merge
`release.yml` on `main` should create GitHub release `v0.7.4`, which triggers `publish.yml` to npm (needs `RELEASE_PAT` / `NPM_TOKEN` secrets as before).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d6a6a2-efb6-4c09-b5b7-4a96ea85d193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d6a6a2-efb6-4c09-b5b7-4a96ea85d193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

