### PR TITLE
fix: enforce money-path DoD by default (not optional kit)

### DIFF
--- a/docs/engineering/PRODUCTION_DOD.md
+++ b/docs/engineering/PRODUCTION_DOD.md
@@ -2,20 +2,22 @@
 
 Binary scorecard for open-core money-path readiness. Catalog growth (more agents/adapters) does not move this bar.
 
+**PASS = default-enforced on the normal money-path API.** A class that exists but is optional or bypassable is FAIL / PARTIAL — see [PRODUCTION_DOD_SCORECARD.md](./PRODUCTION_DOD_SCORECARD.md).
+
 **Current score: see [PRODUCTION_DOD_SCORECARD.md](./PRODUCTION_DOD_SCORECARD.md).**
 
 ## Criteria (all must PASS)
 
 | # | Criterion | PASS only if |
 |---|---|---|
-| 1 | Mutations safe | Book/ticket/cancel not blindly retried after ambiguous failure; `OUTCOME_UNKNOWN` → reconcile via `getBookingStatus` / `getOrder`; fault-injection tests |
-| 2 | Money state survives crash | Pay→confirm + order durable; same idempotency key → one supplier effect; replay returns prior result |
-| 3 | Persistence can do #2 | CAS / command uniqueness / OCC APIs; reference durable impl; live mode refuses irreversible ops on in-memory/mock |
-| 4 | Supplier backpressure real | `RateLimiter` + circuit breaker on live adapter HTTP path; 429 handling |
+| 1 | Mutations safe | Book/ticket/cancel not blindly retried after ambiguous failure on the **default** adapter/Duffel path; `OUTCOME_UNKNOWN` → reconcile via `getBookingStatus` / `getOrder`; fault-injection tests |
+| 2 | Money state survives crash | Pay→confirm + order durable with CAS/OCC (not plain overwrite); same idempotency key → one supplier effect; replay returns prior result |
+| 3 | Persistence can do #2 | CAS / command uniqueness / OCC APIs; reference durable impl; **live mode refuses** irreversible ops on in-memory/mock **by default** |
+| 4 | Supplier backpressure real | `RateLimiter` + circuit breaker **on by default** on live adapter HTTP path (including Duffel); 429 handling |
 | 5 | Live tickets not invented | Live mode blocks hash/mock serials; ticket identity from supplier response |
-| 6 | Irreversible LLM gate has teeth | Bound approval tokens; uncontracted mutations blocked |
-| 7 | Reversal works | Cancel/void/refund via same ledger/idempotency rules; sandbox tests |
-| 8 | Ops see/stop damage | Failure-by-stage + unknown-outcome age; mutation kill switch |
+| 6 | Irreversible LLM gate has teeth | Bound approval **before** side effects; HMAC + single-use in live mode; uncontracted mutations blocked |
+| 7 | Reversal works | Cancel via same ledger/idempotency rules; void/refund fail closed unless capability exists (no silent cancel alias); sandbox tests |
+| 8 | Ops see/stop damage | Failure-by-stage + unknown-outcome age on the mutation path; kill switch stops new mutations |
 
 ## Key modules
 

--- a/docs/engineering/PRODUCTION_DOD_SCORECARD.md
+++ b/docs/engineering/PRODUCTION_DOD_SCORECARD.md
@@ -1,16 +1,24 @@
 # Production DoD Scorecard
 
-Criteria text only. Update when drills land.
+**PASS means default-enforced on the normal money-path API — not “a class exists if you wire it.”**
 
-| # | Criterion | Status | Evidence |
-|---|---|---|---|
-| 1 | Mutations safe | PASS | `MutationExecutor` + `BaseAdapter` disableUnsafeAutoRetry; tests in `packages/connect/src/__tests__/mutation-executor.test.ts`, `base-adapter-resilience.test.ts` |
-| 2 | Money state survives crash | PASS | `DurablePaymentConfirmationStateMachine`, effect ledger replay, concurrent idempotency tests |
-| 3 | Persistence can do #2 | PASS | CAS APIs + `FileCompareAndSwapPersistenceAdapter` + `LiveSafetyMode` |
-| 4 | Supplier backpressure real | PASS | `RateLimiter` + `CircuitBreaker` on `BaseAdapter`; 429 in `fetchWithTimeout` |
-| 5 | Live tickets not invented | PASS | `issueTickets` liveMode guard + `supplier_ticket_numbers` |
-| 6 | Irreversible LLM gate has teeth | PASS | Bound approval default policy; `uncontracted_mutation` orchestrator reason |
-| 7 | Reversal works | PASS | `executeReversal` via `MutationExecutor` |
-| 8 | Ops see/stop damage | PASS | `MutationOpsCollector`, `listUnknown`, `MutationKillSwitch` |
+| Enforcement | Meaning |
+|---|---|
+| `default` | Normal call path cannot bypass the control |
+| `opt-in` | Control exists but callers can skip it |
+| `unwired` | Primitive only; not on live paths |
 
-**Score: 8 / 8 PASS** (library drills). Live supplier credentials remain deployer-owned and must not be committed.
+| # | Criterion | Status | Enforcement | Evidence |
+|---|---|---|---|---|
+| 1 | Mutations safe | PASS | default | `GuardedConnectAdapter` via `createAdapter()`; Duffel `book`/`bookCar`/`cancelCar` via `MoneyPathExecutor` + `fetchOnce` on unsafe POSTs; drills in `packages/adapters/duffel/src/__tests__/money-path.test.ts`, `packages/connect/src/__tests__/guarded-adapter.test.ts` |
+| 2 | Money state survives crash | PASS | default* | Effect ledger replay + concurrent idempotency; durable SM uses `compareAndSet` OCC (`DurablePaymentConfirmationStateMachine`); *live mode refuses ephemeral stores |
+| 3 | Persistence can do #2 | PASS | default | CAS APIs + `FileCompareAndSwapPersistenceAdapter`; `MoneyPathExecutor` / live mode refuse ephemeral/mock irreversible ops |
+| 4 | Supplier backpressure real | PASS | default | `BaseAdapter` rate limiter on by default + CB; Duffel per-credential RL+CB on HTTP path |
+| 5 | Live tickets not invented | PASS | default | `issueTickets` liveMode guard; example OTA Duffel path uses order documents only (no synthetic serials in live) |
+| 6 | Irreversible LLM gate has teeth | PASS | default | `action_class` **before** `execute` for mutations; live mode requires HMAC secret + single-use consume; shape-only banned in live (`approval-before-execute.test.ts`) |
+| 7 | Reversal works | PASS | default | `cancel` via executor; `void`/`refund` **fail closed** (`UnsupportedReversalError`) — no cancel alias; Duffel flight cancel refuses |
+| 8 | Ops see/stop damage | PASS | default | `MutationOpsCollector` + process kill switch wired into `MoneyPathExecutor`; env `OTAIP_MUTATION_KILL_SWITCH=1`; orchestrator uses same switch |
+
+**Score: 8 / 8 PASS** under **default-enforced** definition (library drills + fault injection).
+
+Still not a turnkey OTA/TMC: no real credentials in repo, Duffel flight cancel unsupported by design, Connect `BookingPipeline`/`PaymentHandoff` remain labeled stubs. Live supplier credentials remain deployer-owned.

--- a/examples/ota/src/__tests__/duffel-ota-adapter.test.ts
+++ b/examples/ota/src/__tests__/duffel-ota-adapter.test.ts
@@ -68,7 +68,14 @@ const DUFFEL_ORDER_RESPONSE = {
     booking_reference: 'PNR123',
     total_amount: '212.40',
     total_currency: 'GBP',
-    passengers: [{ id: 'pas_test_1' }],
+    passengers: [{ id: 'pas_test_1', given_name: 'Ada', family_name: 'Lovelace' }],
+    owner: { iata_code: 'BA' },
+    documents: [
+      {
+        type: 'electronic_ticket',
+        unique_identifier: '1252106312810',
+      },
+    ],
   },
 };
 
@@ -141,7 +148,8 @@ describe('DuffelOtaAdapter', () => {
       const result = await adapter.book(VALID_REQUEST);
 
       expect(result.bookingReference).toBe('PNR123');
-      expect(result.status).toBe('confirmed');
+      expect(result.status).toBe('ticketed');
+      expect(result.ticketNumbers).toEqual(['1252106312810']);
       expect(result.offerId).toBe('off_test_xyz');
       expect(result.totalAmount).toBe('212.40');
       expect(result.currency).toBe('GBP');
@@ -196,11 +204,11 @@ describe('DuffelOtaAdapter', () => {
       expect(fetched?.currency).toBe('USD');
     });
 
-    it('issueTickets generates one number per passenger and flips status', async () => {
+    it('issueTickets returns supplier ticket numbers from book documents', async () => {
       const booking = await bookOnce();
+      expect(booking.status).toBe('ticketed');
       const tickets = adapter.issueTickets(booking.bookingReference);
-      expect(tickets).toHaveLength(VALID_REQUEST.passengers.length);
-      expect(tickets![0]).toMatch(/^016\d{10}$/);
+      expect(tickets).toEqual(['1252106312810']);
 
       const fetched = await adapter.getBooking(booking.bookingReference);
       expect(fetched?.status).toBe('ticketed');
@@ -214,8 +222,28 @@ describe('DuffelOtaAdapter', () => {
       expect(second).toEqual(first);
     });
 
-    it('cancelBooking succeeds for confirmed booking', async () => {
-      const booking = await bookOnce();
+    it('cancelBooking succeeds for confirmed booking without tickets', async () => {
+      queueFetchResponses([
+        { status: 200, body: DUFFEL_OFFER_RESPONSE },
+        {
+          status: 200,
+          body: {
+            data: {
+              id: 'ord_no_tix',
+              booking_reference: 'NOTIX1',
+              total_amount: '10.00',
+              total_currency: 'GBP',
+              passengers: [{ id: 'pas_1' }],
+            },
+          },
+        },
+      ]);
+      const booking = await adapter.book({
+        ...VALID_REQUEST,
+        offerId: 'off_no_tix',
+        idempotencyKey: 'cancel-confirmed',
+      });
+      expect(booking.status).toBe('confirmed');
       const result = await adapter.cancelBooking(booking.bookingReference);
       expect(result.success).toBe(true);
       const fetched = await adapter.getBooking(booking.bookingReference);
@@ -224,7 +252,7 @@ describe('DuffelOtaAdapter', () => {
 
     it('cancelBooking refuses to cancel a ticketed booking', async () => {
       const booking = await bookOnce();
-      adapter.issueTickets(booking.bookingReference);
+      expect(booking.status).toBe('ticketed');
       const result = await adapter.cancelBooking(booking.bookingReference);
       expect(result.success).toBe(false);
       expect(result.message).toContain('ticketed');

--- a/examples/ota/src/duffel-ota-adapter.ts
+++ b/examples/ota/src/duffel-ota-adapter.ts
@@ -1,20 +1,18 @@
 /**
  * Duffel OTA Adapter — bridges the live DuffelAdapter into the reference OTA.
  *
- * Search / price / book are real Duffel API calls. The post-book lifecycle
- * (payment, ticketing, get/cancel) stays in-process: the demo flow that
- * Duffel's sandbox proves out is search→price→book; payment + ticketing in
- * the OTA app are mock by design (Stripe + e-ticketing are out of scope for
- * the reference implementation).
+ * Search / price / book go through Duffel's money-path executor (idempotent,
+ * no blind retry). Ticket numbers come from Duffel order documents — live
+ * mode refuses synthetic serials (DoD 5).
  */
 
 import type {
-  DistributionAdapter,
   PriceRequest,
   PriceResponse,
   SearchRequest,
   SearchResponse,
 } from '@otaip/core';
+import { isLiveModeFromEnv, MoneyPathError } from '@otaip/core';
 import { DuffelAdapter } from '@otaip/adapter-duffel';
 import type {
   BookingLifecycle,
@@ -51,15 +49,6 @@ interface BookingRecord {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function generateTicketNumber(): string {
-  const prefix = '016';
-  let digits = '';
-  for (let i = 0; i < 10; i++) {
-    digits += Math.floor(Math.random() * 10).toString();
-  }
-  return `${prefix}${digits}`;
-}
 
 function mapGender(gender: PassengerDetail['gender']): 'm' | 'f' {
   return gender === 'male' ? 'm' : 'f';
@@ -105,10 +94,13 @@ export class DuffelOtaAdapter implements OtaAdapter, BookingLifecycle {
     const response = await this.duffel.book({
       offer_id: request.offerId,
       passengers: duffelPassengers,
+      idempotencyKey:
+        request.idempotencyKey ?? `ota-book:${request.offerId}:${request.contactEmail}`,
     });
 
     const reference = response.booking_reference;
     const now = new Date().toISOString();
+    const supplierTickets = response.ticketNumbers?.map((t) => t.number);
 
     const record: BookingRecord = {
       bookingReference: reference,
@@ -116,11 +108,14 @@ export class DuffelOtaAdapter implements OtaAdapter, BookingLifecycle {
       passengers: request.passengers,
       contactEmail: request.contactEmail,
       contactPhone: request.contactPhone,
-      status: 'confirmed',
+      status: supplierTickets && supplierTickets.length > 0 ? 'ticketed' : 'confirmed',
       totalAmount: response.total_amount,
       currency: response.total_currency,
       createdAt: now,
       duffelOrderId: response.order_id,
+      ...(supplierTickets && supplierTickets.length > 0
+        ? { ticketNumbers: supplierTickets, ticketedAt: now }
+        : {}),
     };
 
     this.bookings.set(reference, record);
@@ -147,15 +142,22 @@ export class DuffelOtaAdapter implements OtaAdapter, BookingLifecycle {
     const record = this.bookings.get(reference);
     if (!record) return null;
 
-    if (record.status === 'ticketed' && record.ticketNumbers) {
+    if (record.ticketNumbers && record.ticketNumbers.length > 0) {
+      record.status = 'ticketed';
+      record.ticketedAt = record.ticketedAt ?? new Date().toISOString();
       return record.ticketNumbers;
     }
 
-    const ticketNumbers = record.passengers.map(() => generateTicketNumber());
-    record.ticketNumbers = ticketNumbers;
-    record.status = 'ticketed';
-    record.ticketedAt = new Date().toISOString();
-    return ticketNumbers;
+    // Try refresh from Duffel getOrder (documents may populate after instant issue).
+    // Sync API — refresh is async; callers should use getOrder path. Fail closed in live.
+    if (isLiveModeFromEnv()) {
+      throw new MoneyPathError(
+        'Live mode refuses synthetic ticket numbers — wait for Duffel order documents / getOrder',
+      );
+    }
+
+    // Demo / non-live only: no supplier documents yet.
+    return null;
   }
 
   async getBooking(reference: string): Promise<BookingResult | null> {

--- a/examples/ota/src/duffel-ota-adapter.ts
+++ b/examples/ota/src/duffel-ota-adapter.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  DistributionAdapter,
   PriceRequest,
   PriceResponse,
   SearchRequest,

--- a/examples/ota/src/services/booking-service.ts
+++ b/examples/ota/src/services/booking-service.ts
@@ -70,6 +70,7 @@ export class BookingService {
       passengers,
       contactEmail,
       contactPhone,
+      idempotencyKey: `ota:${offerId}:${contactEmail}`,
     });
 
     // Update the booking with the actual price from the offer. Adapters that

--- a/examples/ota/src/types.ts
+++ b/examples/ota/src/types.ts
@@ -29,6 +29,8 @@ export interface BookingRequest {
   passengers: PassengerDetail[];
   contactEmail: string;
   contactPhone: string;
+  /** Required for live Duffel money path — one supplier order per key. */
+  idempotencyKey?: string;
 }
 
 export type BookingStatus = 'confirmed' | 'pending' | 'ticketed' | 'cancelled';

--- a/packages/adapters/duffel/src/__tests__/money-path.test.ts
+++ b/packages/adapters/duffel/src/__tests__/money-path.test.ts
@@ -1,0 +1,130 @@
+/**
+ * DoD1: Duffel book must not blind-retry on 5xx; money path ledger enforces once.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { DuffelAdapter } from '../duffel-adapter.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const PASSENGERS = [
+  {
+    title: 'mr' as const,
+    given_name: 'Test',
+    family_name: 'User',
+    born_on: '1990-01-01',
+    email: 't@example.com',
+    phone_number: '+15555550100',
+    gender: 'm' as const,
+    type: 'adult' as const,
+  },
+];
+
+describe('Duffel money-path book', () => {
+  it('POST /air/orders is attempted exactly once on 503', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/air/offers/')) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              id: 'off_1',
+              total_amount: '10.00',
+              total_currency: 'GBP',
+              passengers: [{ id: 'pas_1', type: 'adult' }],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes('/air/orders')) {
+        return new Response(JSON.stringify({ errors: [{ message: 'unavailable' }] }), {
+          status: 503,
+          statusText: 'Service Unavailable',
+        });
+      }
+      return new Response('{}', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const adapter = new DuffelAdapter({
+      apiKey: 'duffel_test_key',
+      liveMode: false,
+    });
+
+    await expect(
+      adapter.book({
+        offer_id: 'off_1',
+        passengers: PASSENGERS,
+        idempotencyKey: 'book-once-503',
+      }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+
+    const orderPosts = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes('/air/orders'),
+    );
+    expect(orderPosts.length).toBe(1);
+  });
+
+  it('replay same idempotency key does not POST again after unknown', async () => {
+    let orderPosts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/air/offers/')) {
+          return new Response(
+            JSON.stringify({
+              data: {
+                id: 'off_1',
+                total_amount: '10.00',
+                total_currency: 'GBP',
+                passengers: [{ id: 'pas_1', type: 'adult' }],
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes('/air/orders')) {
+          orderPosts += 1;
+          return new Response('', { status: 503, statusText: 'Service Unavailable' });
+        }
+        return new Response('{}', { status: 404 });
+      }),
+    );
+
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', liveMode: false });
+    await expect(
+      adapter.book({
+        offer_id: 'off_1',
+        passengers: PASSENGERS,
+        idempotencyKey: 'book-replay',
+      }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+
+    await expect(
+      adapter.book({
+        offer_id: 'off_1',
+        passengers: PASSENGERS,
+        idempotencyKey: 'book-replay',
+      }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+
+    expect(orderPosts).toBe(1);
+  });
+
+  it('requires idempotencyKey in live mode', async () => {
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', liveMode: true });
+    await expect(
+      adapter.book({ offer_id: 'off_1', passengers: PASSENGERS }),
+    ).rejects.toThrow(/idempotencyKey/);
+  });
+
+  it('flight cancel fails closed', async () => {
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', liveMode: false });
+    await expect(adapter.cancelFlightBooking('ord_1')).rejects.toThrow(/not supported/);
+  });
+});

--- a/packages/adapters/duffel/src/cars-types.ts
+++ b/packages/adapters/duffel/src/cars-types.ts
@@ -187,6 +187,8 @@ export interface CarBookRequest {
   inboundFlightNumber?: string;
   metadata?: Record<string, string>;
   signal?: AbortSignal;
+  /** Required in live mode — same key → one supplier car booking. */
+  idempotencyKey?: string;
 }
 
 export interface CarBookResponse {

--- a/packages/adapters/duffel/src/duffel-adapter.ts
+++ b/packages/adapters/duffel/src/duffel-adapter.ts
@@ -19,8 +19,19 @@ import type {
   PriceRequest,
   PriceResponse,
   PriceBreakdown,
+  MoneyPathExecutorConfig,
+  StoreDurability,
 } from '@otaip/core';
-import { fetchWithRetry } from '@otaip/core';
+import {
+  fetchWithRetry,
+  fetchOnce,
+  MoneyPathExecutor,
+  RateLimiter,
+  CircuitBreaker,
+  CircuitOpenError,
+  isLiveModeFromEnv,
+  MoneyPathError,
+} from '@otaip/core';
 import Decimal from 'decimal.js';
 
 import type {
@@ -273,6 +284,18 @@ export interface BookRequest {
     gender: 'm' | 'f';
     type: 'adult' | 'child' | 'infant_without_seat';
   }>;
+  /**
+   * Required in live mode. Same key → at most one POST /air/orders (DoD 1/2).
+   */
+  idempotencyKey?: string;
+}
+
+/** Paths that create/cancel money-path side effects — never auto-retried. */
+function isUnsafeDuffelPath(method: string, path: string): boolean {
+  if (method !== 'POST' && method !== 'DELETE' && method !== 'PATCH') return false;
+  if (path === '/air/orders' || path.startsWith('/air/orders/')) return true;
+  if (path === '/cars/bookings' || path.includes('/cars/bookings/')) return true;
+  return false;
 }
 
 export interface BookTicketNumber {
@@ -435,20 +458,63 @@ export function mapOrderToBookResponse(order: DuffelOrder): BookResponse {
   return response;
 }
 
+export interface DuffelAdapterOptions {
+  readonly apiKey?: string;
+  readonly baseUrl?: string;
+  readonly moneyPath?: MoneyPathExecutorConfig;
+  /** Store durability of the money-path ledger. Default ephemeral unless set. */
+  readonly storeDurability?: StoreDurability;
+  readonly liveMode?: boolean;
+}
+
 export class DuffelAdapter implements DistributionAdapter {
   readonly name = 'duffel';
   private readonly apiKey: string;
   private readonly baseUrl: string;
+  private readonly rateLimiter: RateLimiter;
+  private readonly circuitBreaker: CircuitBreaker;
+  private readonly moneyPath: MoneyPathExecutor;
+  private readonly liveMode: boolean;
 
-  constructor(apiKey?: string, baseUrl?: string) {
-    const resolvedKey = apiKey ?? process.env['DUFFEL_API_KEY'] ?? '';
+  constructor(apiKeyOrOptions?: string | DuffelAdapterOptions, baseUrl?: string) {
+    const options: DuffelAdapterOptions =
+      typeof apiKeyOrOptions === 'string' || apiKeyOrOptions === undefined
+        ? { apiKey: apiKeyOrOptions, baseUrl }
+        : apiKeyOrOptions;
+
+    const resolvedKey = options.apiKey ?? process.env['DUFFEL_API_KEY'] ?? '';
     if (!resolvedKey || resolvedKey.trim().length === 0) {
       throw new Error(
         'DuffelAdapter requires a valid API key. Pass it to the constructor or set DUFFEL_API_KEY env var.',
       );
     }
     this.apiKey = resolvedKey;
-    this.baseUrl = baseUrl ?? DUFFEL_BASE_URL;
+    this.baseUrl = options.baseUrl ?? DUFFEL_BASE_URL;
+    this.liveMode = options.liveMode ?? isLiveModeFromEnv();
+    this.rateLimiter = new RateLimiter({ maxRequests: 50, windowMs: 1_000 });
+    this.circuitBreaker = new CircuitBreaker({
+      name: 'duffel',
+      failureThreshold: 5,
+      resetMs: 30_000,
+    });
+    this.moneyPath = new MoneyPathExecutor({
+      liveMode: this.liveMode,
+      storeDurability: options.storeDurability ?? options.moneyPath?.storeDurability ?? 'ephemeral',
+      reconcileHint: 'getOrder',
+      ...options.moneyPath,
+    });
+  }
+
+  get moneyPathExecutor(): MoneyPathExecutor {
+    return this.moneyPath;
+  }
+
+  getCircuitBreakerStatus(): ReturnType<CircuitBreaker['getStatus']> {
+    return this.circuitBreaker.getStatus();
+  }
+
+  resetCircuitBreaker(): void {
+    this.circuitBreaker.reset();
   }
 
   async search(request: SearchRequest): Promise<SearchResponse> {
@@ -524,7 +590,28 @@ export class DuffelAdapter implements DistributionAdapter {
   }
 
   async book(request: BookRequest): Promise<BookResponse> {
-    // Fetch the offer to get Duffel passenger IDs and total for payment
+    const key = request.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'DuffelAdapter.book requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `duffel-book:${request.offer_id}`;
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'book',
+      idempotencyKey,
+      request: {
+        offer_id: request.offer_id,
+        passengerCount: request.passengers.length,
+      },
+      supplierId: 'duffel',
+      fn: () => this.bookOnce(request),
+    });
+  }
+
+  /** Single-attempt order create — used only inside MoneyPathExecutor. */
+  private async bookOnce(request: BookRequest): Promise<BookResponse> {
     const offerResponse = (await this.request(
       'GET',
       `/air/offers/${request.offer_id}?return_available_services=false`,
@@ -534,7 +621,6 @@ export class DuffelAdapter implements DistributionAdapter {
       throw new Error('Could not fetch offer details for booking');
     }
 
-    // Map Duffel passenger IDs to the provided passenger details
     const duffelPassengers: Array<{ id?: string; type?: string }> = offer.passengers ?? [];
     const passengers = request.passengers.map((pax, i) => ({
       ...pax,
@@ -644,30 +730,47 @@ export class DuffelAdapter implements DistributionAdapter {
   }
 
   async bookCar(request: CarBookRequest): Promise<CarBookResponse> {
-    const body: DuffelCarsBookingRequest = {
-      data: {
-        quote_id: request.quoteId,
-        driver: {
-          given_name: request.driver.givenName,
-          family_name: request.driver.familyName,
-          email: request.driver.email,
-          phone_number: request.driver.phoneNumber,
-          ...(request.driver.dateOfBirth ? { date_of_birth: request.driver.dateOfBirth } : {}),
-        },
-        ...(request.payment ? { payment: request.payment } : {}),
-        ...(request.metadata ? { metadata: request.metadata } : {}),
-        ...(request.inboundFlightNumber
-          ? { inbound_flight_number: request.inboundFlightNumber }
-          : {}),
+    const key = request.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'DuffelAdapter.bookCar requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `duffel-car-book:${request.quoteId}`;
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'bookCar',
+      idempotencyKey,
+      request: { quoteId: request.quoteId },
+      supplierId: 'duffel',
+      fn: async () => {
+        const body: DuffelCarsBookingRequest = {
+          data: {
+            quote_id: request.quoteId,
+            driver: {
+              given_name: request.driver.givenName,
+              family_name: request.driver.familyName,
+              email: request.driver.email,
+              phone_number: request.driver.phoneNumber,
+              ...(request.driver.dateOfBirth
+                ? { date_of_birth: request.driver.dateOfBirth }
+                : {}),
+            },
+            ...(request.payment ? { payment: request.payment } : {}),
+            ...(request.metadata ? { metadata: request.metadata } : {}),
+            ...(request.inboundFlightNumber
+              ? { inbound_flight_number: request.inboundFlightNumber }
+              : {}),
+          },
+        };
+        const response = (await this.request(
+          'POST',
+          '/cars/bookings',
+          body as unknown as Record<string, unknown>,
+          request.signal ? { signal: request.signal } : {},
+        )) as DuffelCarsBookingResponse;
+        return mapCarBookingResponse(response);
       },
-    };
-    const response = (await this.request(
-      'POST',
-      '/cars/bookings',
-      body as unknown as Record<string, unknown>,
-      request.signal ? { signal: request.signal } : {},
-    )) as DuffelCarsBookingResponse;
-    return mapCarBookingResponse(response);
+    });
   }
 
   async getCarBooking(bookingId: string, signal?: AbortSignal): Promise<CarBookResponse> {
@@ -684,13 +787,31 @@ export class DuffelAdapter implements DistributionAdapter {
     bookingId: string,
     signal?: AbortSignal,
   ): Promise<CarCancelResponse> {
-    const response = (await this.request(
-      'POST',
-      `/cars/bookings/${encodeURIComponent(bookingId)}/actions/cancel`,
-      undefined,
-      signal ? { signal } : {},
-    )) as DuffelCarsCancelResponse;
-    return mapCarCancelResponse(response);
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'cancelCarBooking',
+      idempotencyKey: `duffel-car-cancel:${bookingId}`,
+      request: { bookingId },
+      supplierId: 'duffel',
+      fn: async () => {
+        const response = (await this.request(
+          'POST',
+          `/cars/bookings/${encodeURIComponent(bookingId)}/actions/cancel`,
+          undefined,
+          signal ? { signal } : {},
+        )) as DuffelCarsCancelResponse;
+        return mapCarCancelResponse(response);
+      },
+    });
+  }
+
+  /**
+   * Flight cancel is not available on the Duffel public order API used here.
+   * Do not invent cancel behavior — fail closed (DoD 7).
+   */
+  async cancelFlightBooking(_orderId: string): Promise<never> {
+    throw new MoneyPathError(
+      'Duffel flight cancel is not supported on this adapter — refuse rather than alias',
+    );
   }
 
   private async request(
@@ -702,6 +823,17 @@ export class DuffelAdapter implements DistributionAdapter {
     if (options.signal?.aborted) {
       throw new Error('Duffel API request aborted before dispatch');
     }
+
+    try {
+      this.circuitBreaker.assertClosed();
+    } catch (err) {
+      if (err instanceof CircuitOpenError) {
+        throw new Error(`Duffel API circuit open: ${err.message}`);
+      }
+      throw err;
+    }
+    await this.rateLimiter.acquire();
+
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
@@ -712,14 +844,20 @@ export class DuffelAdapter implements DistributionAdapter {
       headers['Content-Type'] = 'application/json';
     }
 
+    const init: RequestInit = {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    };
+
+    const unsafe = isUnsafeDuffelPath(method, path);
     let response: Response;
     try {
-      response = await fetchWithRetry(url, {
-        method,
-        headers,
-        body: body ? JSON.stringify(body) : undefined,
-      });
+      response = unsafe
+        ? await fetchOnce(url, init)
+        : await fetchWithRetry(url, init);
     } catch (err: unknown) {
+      this.circuitBreaker.recordFailure();
       const message = err instanceof Error ? err.message : 'Unknown network error';
       throw new Error(`Duffel API network error: ${message}`);
     }
@@ -733,6 +871,10 @@ export class DuffelAdapter implements DistributionAdapter {
         // ignore parse errors
       }
 
+      if (response.status === 429 || response.status >= 500) {
+        this.circuitBreaker.recordFailure();
+      }
+
       if (response.status === 429) {
         throw new Error(`Duffel API rate limited (429). ${errorDetail}`.trim());
       }
@@ -742,6 +884,7 @@ export class DuffelAdapter implements DistributionAdapter {
       );
     }
 
+    this.circuitBreaker.recordSuccess();
     return response.json();
   }
 }

--- a/packages/adapters/duffel/src/index.ts
+++ b/packages/adapters/duffel/src/index.ts
@@ -10,6 +10,7 @@ export type {
   BookResponse,
   BookSegment,
   BookTicketNumber,
+  DuffelAdapterOptions,
   DuffelOrder,
 } from './duffel-adapter.js';
 export { DuffelOrderBridge } from './order-bridge.js';

--- a/packages/agents/booking/src/order-management/durable-state-machine.ts
+++ b/packages/agents/booking/src/order-management/durable-state-machine.ts
@@ -1,10 +1,11 @@
 /**
  * Durable wrapper around PaymentConfirmationStateMachine.
- * Persists managed-order snapshots via CompareAndSwapPersistenceAdapter.
+ * Persists managed-order snapshots via CompareAndSwapPersistenceAdapter
+ * using compareAndSet (OCC) — never plain overwrite (DoD 2/3).
  */
 
 import type { CompareAndSwapPersistenceAdapter } from '@otaip/core';
-import { InMemoryPersistenceAdapter } from '@otaip/core';
+import { InMemoryPersistenceAdapter, MoneyPathError } from '@otaip/core';
 import type { ConfirmationRequest, OrderState, OrderStateAuditEntry } from './order-state.js';
 import {
   PaymentConfirmationStateMachine,
@@ -13,6 +14,7 @@ import {
 } from './state-machine.js';
 
 const KEY_PREFIX = 'payconfirm:';
+const MAX_CAS_RETRIES = 8;
 
 interface PersistedManagedOrder {
   order_id: string;
@@ -24,15 +26,19 @@ interface PersistedManagedOrder {
   payment_capture_ref: string | null;
   refund_id: string | null;
   audit_trail: OrderStateAuditEntry[];
+  /** Monotonic version for OCC. */
+  version: number;
 }
 
 /**
- * Drop-in durable facade: loads/saves after each mutation.
+ * Drop-in durable facade: loads/saves after each mutation via CAS.
  * Same public transition API as PaymentConfirmationStateMachine.
  */
 export class DurablePaymentConfirmationStateMachine {
   private readonly inner: PaymentConfirmationStateMachine;
   private readonly persistence: CompareAndSwapPersistenceAdapter;
+  /** Last known persisted version per order (for CAS expected value). */
+  private readonly versions = new Map<string, number>();
 
   constructor(options?: {
     audit?: AuditPort;
@@ -54,9 +60,7 @@ export class DurablePaymentConfirmationStateMachine {
     if (this.inner.hasOrder(orderId)) return;
     const snap = await this.persistence.get<PersistedManagedOrder>(this.key(orderId));
     if (!snap) return;
-    // Re-initialize and replay state by direct initialize + capturing payment path
-    // via restoring through a private rebuild: initialize then apply stored state
-    // using a restore helper on the inner machine.
+    this.versions.set(orderId, snap.version ?? 0);
     this.inner.restoreFromSnapshot({
       order_id: snap.order_id,
       passenger_ref: snap.passenger_ref,
@@ -73,18 +77,49 @@ export class DurablePaymentConfirmationStateMachine {
   private async persist(orderId: string): Promise<void> {
     const snap = this.inner.exportSnapshot(orderId);
     if (!snap) return;
-    const record: PersistedManagedOrder = {
-      order_id: snap.order_id,
-      passenger_ref: snap.passenger_ref,
-      state: snap.state,
-      idempotency_keys: [...snap.idempotency_keys],
-      refund_initiated: snap.refund_initiated,
-      confirmation_request: snap.confirmation_request,
-      payment_capture_ref: snap.payment_capture_ref,
-      refund_id: snap.refund_id,
-      audit_trail: snap.audit_trail,
-    };
-    await this.persistence.set(this.key(orderId), record);
+    const key = this.key(orderId);
+
+    for (let attempt = 0; attempt < MAX_CAS_RETRIES; attempt++) {
+      const current = await this.persistence.get<PersistedManagedOrder>(key);
+      const known = this.versions.get(orderId);
+      // OCC: expected value is what we last hydrated/wrote. If another writer
+      // advanced the store, compareAndSet fails and we refuse to overwrite.
+      const expected =
+        current === null
+          ? undefined
+          : known !== undefined && current.version !== known
+            ? current // conflict detected via version skew — CAS will fail if we pass wrong expected
+            : current;
+
+      if (current && known !== undefined && current.version !== known) {
+        throw new MoneyPathError(
+          `DurablePaymentConfirmationStateMachine concurrent modification for order ${orderId}`,
+        );
+      }
+
+      const nextVersion = (current?.version ?? 0) + 1;
+      const record: PersistedManagedOrder = {
+        order_id: snap.order_id,
+        passenger_ref: snap.passenger_ref,
+        state: snap.state,
+        idempotency_keys: [...snap.idempotency_keys],
+        refund_initiated: snap.refund_initiated,
+        confirmation_request: snap.confirmation_request,
+        payment_capture_ref: snap.payment_capture_ref,
+        refund_id: snap.refund_id,
+        audit_trail: snap.audit_trail,
+        version: nextVersion,
+      };
+
+      const ok = await this.persistence.compareAndSet(key, expected, record);
+      if (ok) {
+        this.versions.set(orderId, nextVersion);
+        return;
+      }
+    }
+    throw new MoneyPathError(
+      `DurablePaymentConfirmationStateMachine CAS failed for order ${orderId} after ${MAX_CAS_RETRIES} attempts`,
+    );
   }
 
   async initializeOrder(orderId: string, passengerRef: string): Promise<OrderState> {

--- a/packages/connect/src/__tests__/guarded-adapter.test.ts
+++ b/packages/connect/src/__tests__/guarded-adapter.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { GuardedConnectAdapter, guardAdapter } from '../guarded-adapter.js';
+import { createAdapter, registerSupplier } from '../suppliers/index.js';
+import type { ConnectAdapter, CreateBookingInput, BookingResult } from '../types.js';
+import { ConnectError } from '../base-adapter.js';
+
+function mkAdapter(createFn: ConnectAdapter['createBooking']): ConnectAdapter {
+  return {
+    supplierId: 'test',
+    supplierName: 'Test',
+    searchFlights: async () => [],
+    priceItinerary: async () => ({
+      offerId: 'o',
+      supplier: 'test',
+      totalPrice: { amount: '1', currency: 'USD' },
+      fares: [],
+      fareRules: { refundable: false, changeable: false },
+      priceChanged: false,
+      available: true,
+    }),
+    createBooking: createFn,
+    getBookingStatus: async () => ({
+      bookingId: 'B1',
+      supplier: 'test',
+      status: 'confirmed',
+      segments: [],
+      passengers: [],
+      totalPrice: { amount: '1', currency: 'USD' },
+    }),
+    cancelBooking: async () => ({ success: true, message: 'ok' }),
+    healthCheck: async () => ({ healthy: true, latencyMs: 1 }),
+  };
+}
+
+const bookingInput: CreateBookingInput = {
+  offerId: 'off_1',
+  passengers: [
+    {
+      type: 'adult',
+      gender: 'M',
+      firstName: 'A',
+      lastName: 'B',
+      dateOfBirth: '1990-01-01',
+    },
+  ],
+  contact: { email: 'a@b.com', phone: '+1' },
+  idempotencyKey: 'idem-1',
+};
+
+const bookingResult: BookingResult = {
+  bookingId: 'B1',
+  supplier: 'test',
+  status: 'confirmed',
+  segments: [],
+  passengers: bookingInput.passengers,
+  totalPrice: { amount: '10', currency: 'USD' },
+};
+
+describe('GuardedConnectAdapter', () => {
+  it('requires idempotencyKey', async () => {
+    const guarded = new GuardedConnectAdapter({
+      adapter: mkAdapter(async () => bookingResult),
+      liveMode: false,
+    });
+    await expect(
+      guarded.createBooking({ ...bookingInput, idempotencyKey: undefined }),
+    ).rejects.toThrow(/idempotencyKey/);
+  });
+
+  it('does not re-invoke supplier on same idempotency key', async () => {
+    let calls = 0;
+    const guarded = new GuardedConnectAdapter({
+      adapter: mkAdapter(async () => {
+        calls += 1;
+        return bookingResult;
+      }),
+      liveMode: false,
+    });
+    await guarded.createBooking(bookingInput);
+    await guarded.createBooking(bookingInput);
+    expect(calls).toBe(1);
+  });
+
+  it('throws OutcomeUnknownError on ambiguous 503 without retrying', async () => {
+    let calls = 0;
+    const guarded = new GuardedConnectAdapter({
+      adapter: mkAdapter(async () => {
+        calls += 1;
+        throw new ConnectError('createBooking failed: 503', 'test', 'createBooking', true);
+      }),
+      liveMode: false,
+    });
+    await expect(guarded.createBooking(bookingInput)).rejects.toBeInstanceOf(
+      OutcomeUnknownError,
+    );
+    expect(calls).toBe(1);
+  });
+});
+
+describe('createAdapter default guard', () => {
+  it('wraps with GuardedConnectAdapter by default; unguarded opt-out', () => {
+    registerSupplier('guard-test-supplier', () => mkAdapter(async () => bookingResult));
+    const raw = createAdapter('guard-test-supplier', {}, { unguarded: true });
+    expect(raw).not.toBeInstanceOf(GuardedConnectAdapter);
+    const guarded = createAdapter('guard-test-supplier', {}, { liveMode: false });
+    expect(guarded).toBeInstanceOf(GuardedConnectAdapter);
+    expect(guardAdapter(raw, { liveMode: false })).toBeInstanceOf(GuardedConnectAdapter);
+  });
+});

--- a/packages/connect/src/__tests__/mutation-executor.test.ts
+++ b/packages/connect/src/__tests__/mutation-executor.test.ts
@@ -19,7 +19,7 @@ describe('operation classification', () => {
 describe('MutationExecutor', () => {
   it('does not auto-retry; marks unknown on ambiguous failure', async () => {
     const ledger = new InMemoryEffectLedger();
-    const exec = new MutationExecutor({ ledger });
+    const exec = new MutationExecutor({ ledger, liveMode: false });
     let calls = 0;
     const outcome = await exec.execute({
       operation: 'createBooking',
@@ -39,7 +39,7 @@ describe('MutationExecutor', () => {
 
   it('replays succeeded effect without re-invoking fn', async () => {
     const ledger = new InMemoryEffectLedger();
-    const exec = new MutationExecutor({ ledger });
+    const exec = new MutationExecutor({ ledger, liveMode: false });
     let calls = 0;
     const first = await exec.execute({
       operation: 'createBooking',
@@ -72,7 +72,7 @@ describe('MutationExecutor', () => {
 
   it('100 concurrent executes produce one supplier call', async () => {
     const ledger = new InMemoryEffectLedger();
-    const exec = new MutationExecutor({ ledger });
+    const exec = new MutationExecutor({ ledger, liveMode: false });
     let calls = 0;
     const results = await Promise.all(
       Array.from({ length: 100 }, () =>
@@ -96,7 +96,7 @@ describe('MutationExecutor', () => {
   it('respects kill switch', async () => {
     const killSwitch = new MutationKillSwitch();
     killSwitch.engage('test');
-    const exec = new MutationExecutor({ killSwitch });
+    const exec = new MutationExecutor({ killSwitch, liveMode: false });
     await expect(
       exec.execute({
         operation: 'createBooking',
@@ -109,7 +109,7 @@ describe('MutationExecutor', () => {
   });
 
   it('reconciles via getBookingStatus', async () => {
-    const exec = new MutationExecutor();
+    const exec = new MutationExecutor({ liveMode: false });
     const status: BookingStatusResult = {
       bookingId: 'B1',
       supplier: 'test',
@@ -141,5 +141,26 @@ describe('executeReversal', () => {
     });
     expect(outcome.kind).toBe('succeeded');
     expect(adapter.cancelBooking).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed for void/refund without aliasing cancel', async () => {
+    const adapter = {
+      supplierId: 'test',
+      cancelBooking: vi.fn(async () => ({ success: true, message: 'ok' })),
+    } as unknown as ConnectAdapter;
+    const voidOut = await executeReversal(adapter, {
+      kind: 'void',
+      bookingId: 'B1',
+      idempotencyKey: 'void-1',
+    });
+    expect(voidOut.kind).toBe('failed');
+    expect(adapter.cancelBooking).not.toHaveBeenCalled();
+    const refundOut = await executeReversal(adapter, {
+      kind: 'refund',
+      bookingId: 'B1',
+      idempotencyKey: 'refund-1',
+    });
+    expect(refundOut.kind).toBe('failed');
+    expect(adapter.cancelBooking).not.toHaveBeenCalled();
   });
 });

--- a/packages/connect/src/base-adapter.ts
+++ b/packages/connect/src/base-adapter.ts
@@ -39,13 +39,23 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
   maxDelayMs: 10_000,
 };
 
+/** Default rate limit — always on unless explicitly disabled. */
+const DEFAULT_RATE_LIMITER: RateLimiterConfig = {
+  maxRequests: 100,
+  windowMs: 1_000,
+};
+
 export interface BaseAdapterResilienceConfig {
-  readonly rateLimiter?: RateLimiterConfig;
+  /**
+   * Rate limiter config. Defaults to generous per-adapter limits.
+   * Pass `false` only for tightly controlled unit tests.
+   */
+  readonly rateLimiter?: RateLimiterConfig | false;
   readonly circuitBreaker?: Partial<CircuitBreakerConfig>;
   /**
    * When true (default), unsafe ops (book/ticket/cancel) are never
    * auto-retried by withRetry after failure — callers must use
-   * MutationExecutor + reconcile.
+   * MutationExecutor / GuardedConnectAdapter + reconcile.
    */
   readonly disableUnsafeAutoRetry?: boolean;
 }
@@ -62,9 +72,13 @@ export abstract class BaseAdapter {
     resilience?: BaseAdapterResilienceConfig,
   ) {
     this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
-    this.rateLimiter = resilience?.rateLimiter
-      ? new RateLimiter(resilience.rateLimiter)
-      : null;
+    if (resilience?.rateLimiter === false) {
+      this.rateLimiter = null;
+    } else {
+      this.rateLimiter = new RateLimiter(
+        resilience?.rateLimiter ?? DEFAULT_RATE_LIMITER,
+      );
+    }
     this.circuitBreaker = new CircuitBreaker({
       name: undefined,
       failureThreshold: 5,
@@ -126,14 +140,16 @@ export abstract class BaseAdapter {
       }
 
       if (lastError instanceof ConnectError) {
+        // Preserve retryable from the inner error so OUTCOME_UNKNOWN classification works.
         throw lastError;
       }
 
+      const ambiguous = this.isTransportFailure(lastError);
       throw new ConnectError(
         `${operation} failed after ${maxRetries + 1} attempts`,
         this.supplierId,
         operation,
-        false,
+        ambiguous,
         lastError,
       );
     }

--- a/packages/connect/src/guarded-adapter.ts
+++ b/packages/connect/src/guarded-adapter.ts
@@ -1,0 +1,160 @@
+/**
+ * GuardedConnectAdapter — default money-path enforcement for ConnectAdapter.
+ *
+ * createBooking / requestTicketing / cancelBooking always go through
+ * MutationExecutor (ledger + kill switch + live safety). Callers cannot
+ * bypass by invoking the raw supplier methods when using createAdapter().
+ */
+
+import {
+  MoneyPathError,
+  OutcomeUnknownError,
+  type MoneyPathExecutorConfig,
+} from '@otaip/core';
+import type {
+  BookingResult,
+  BookingStatusResult,
+  ConnectAdapter,
+  CreateBookingInput,
+  PassengerCount,
+  PricedItinerary,
+  SearchFlightsInput,
+  FlightOffer,
+} from './types.js';
+import { MutationExecutor } from './mutation-executor.js';
+import { ConnectError } from './base-adapter.js';
+
+export interface GuardedConnectAdapterOptions extends MoneyPathExecutorConfig {
+  /** Underlying supplier adapter (unguarded). */
+  readonly adapter: ConnectAdapter;
+}
+
+function unwrapOrThrow<T>(
+  outcome: Awaited<ReturnType<MutationExecutor['execute']>>,
+): T {
+  if (outcome.kind === 'succeeded') return outcome.value as T;
+  if (outcome.kind === 'unknown') {
+    throw new OutcomeUnknownError(
+      'Mutation outcome unknown — reconcile via getBookingStatus before retry',
+      {
+        idempotencyKey: outcome.idempotencyKey,
+        reconcileHint: outcome.reconcileHint,
+        cause: outcome.error,
+      },
+    );
+  }
+  if (outcome.error instanceof Error) throw outcome.error;
+  throw new MoneyPathError(String(outcome.error));
+}
+
+/**
+ * Wraps a ConnectAdapter so money mutations are ledger-backed and non-retrying.
+ */
+export class GuardedConnectAdapter implements ConnectAdapter {
+  readonly supplierId: string;
+  readonly supplierName: string;
+  private readonly inner: ConnectAdapter;
+  private readonly executor: MutationExecutor;
+
+  constructor(options: GuardedConnectAdapterOptions) {
+    this.inner = options.adapter;
+    this.supplierId = options.adapter.supplierId;
+    this.supplierName = options.adapter.supplierName;
+    const { adapter: _a, ...execConfig } = options;
+    this.executor = new MutationExecutor(execConfig);
+  }
+
+  get mutationExecutor(): MutationExecutor {
+    return this.executor;
+  }
+
+  get unguarded(): ConnectAdapter {
+    return this.inner;
+  }
+
+  async searchFlights(input: SearchFlightsInput): Promise<FlightOffer[]> {
+    return this.inner.searchFlights(input);
+  }
+
+  async priceItinerary(
+    offerId: string,
+    passengers: PassengerCount,
+  ): Promise<PricedItinerary> {
+    return this.inner.priceItinerary(offerId, passengers);
+  }
+
+  async createBooking(input: CreateBookingInput): Promise<BookingResult> {
+    const key = input.idempotencyKey?.trim();
+    if (!key) {
+      throw new MoneyPathError(
+        'createBooking requires idempotencyKey on GuardedConnectAdapter (DoD 1/2)',
+      );
+    }
+    const outcome = await this.executor.execute({
+      operation: 'createBooking',
+      idempotencyKey: key,
+      request: input,
+      supplierId: this.supplierId,
+      fn: () => this.inner.createBooking(input),
+    });
+    return unwrapOrThrow<BookingResult>(outcome);
+  }
+
+  async getBookingStatus(bookingId: string): Promise<BookingStatusResult> {
+    return this.inner.getBookingStatus(bookingId);
+  }
+
+  async requestTicketing(bookingId: string): Promise<BookingStatusResult> {
+    if (!this.inner.requestTicketing) {
+      throw new ConnectError(
+        'requestTicketing not supported',
+        this.supplierId,
+        'requestTicketing',
+        false,
+      );
+    }
+    const ticketing = this.inner.requestTicketing.bind(this.inner);
+    const outcome = await this.executor.execute({
+      operation: 'requestTicketing',
+      idempotencyKey: `ticket:${bookingId}`,
+      request: { bookingId },
+      supplierId: this.supplierId,
+      fn: () => ticketing(bookingId),
+    });
+    return unwrapOrThrow<BookingStatusResult>(outcome);
+  }
+
+  async cancelBooking(
+    bookingId: string,
+  ): Promise<{ success: boolean; message: string }> {
+    if (!this.inner.cancelBooking) {
+      throw new ConnectError(
+        'cancelBooking not supported',
+        this.supplierId,
+        'cancelBooking',
+        false,
+      );
+    }
+    const cancel = this.inner.cancelBooking.bind(this.inner);
+    const outcome = await this.executor.execute({
+      operation: 'cancelBooking',
+      idempotencyKey: `cancel:${bookingId}`,
+      request: { bookingId },
+      supplierId: this.supplierId,
+      fn: () => cancel(bookingId),
+    });
+    return unwrapOrThrow<{ success: boolean; message: string }>(outcome);
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; latencyMs: number }> {
+    return this.inner.healthCheck();
+  }
+}
+
+/** Wrap an adapter with money-path enforcement. */
+export function guardAdapter(
+  adapter: ConnectAdapter,
+  config?: Omit<GuardedConnectAdapterOptions, 'adapter'>,
+): GuardedConnectAdapter {
+  return new GuardedConnectAdapter({ adapter, ...config });
+}

--- a/packages/connect/src/guarded-adapter.ts
+++ b/packages/connect/src/guarded-adapter.ts
@@ -57,10 +57,10 @@ export class GuardedConnectAdapter implements ConnectAdapter {
   private readonly executor: MutationExecutor;
 
   constructor(options: GuardedConnectAdapterOptions) {
-    this.inner = options.adapter;
-    this.supplierId = options.adapter.supplierId;
-    this.supplierName = options.adapter.supplierName;
-    const { adapter: _a, ...execConfig } = options;
+    const { adapter, ...execConfig } = options;
+    this.inner = adapter;
+    this.supplierId = adapter.supplierId;
+    this.supplierName = adapter.supplierName;
     this.executor = new MutationExecutor(execConfig);
   }
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -37,15 +37,23 @@ export {
 export type { AdapterOperationClass, AdapterOperationName } from './operation-class.js';
 export { MutationExecutor } from './mutation-executor.js';
 export type { MutationExecutorConfig, MutationOutcome } from './mutation-executor.js';
-export { executeReversal } from './reversal-saga.js';
-export type { ReversalKind, ReversalRequest, ReversalResult } from './reversal-saga.js';
+export { GuardedConnectAdapter, guardAdapter } from './guarded-adapter.js';
+export type { GuardedConnectAdapterOptions } from './guarded-adapter.js';
+export { executeReversal, UnsupportedReversalError } from './reversal-saga.js';
+export type {
+  ReversalKind,
+  ReversalRequest,
+  ReversalResult,
+  ReversalCapabilities,
+} from './reversal-saga.js';
 
 // Config utilities
 export { validateConfig, baseAdapterConfigSchema } from './config.js';
 export type { BaseAdapterConfig } from './config.js';
 
-// Supplier registry
+// Supplier registry (createAdapter returns GuardedConnectAdapter by default)
 export { registerSupplier, createAdapter, listSuppliers } from './suppliers/index.js';
+export type { CreateAdapterOptions } from './suppliers/index.js';
 
 // TripPro adapter
 export { TripProAdapter } from './suppliers/trippro/index.js';

--- a/packages/connect/src/mutation-executor.ts
+++ b/packages/connect/src/mutation-executor.ts
@@ -1,97 +1,50 @@
 /**
- * Mutation executor — ledger-backed unsafe adapter operations with
- * OUTCOME_UNKNOWN + reconcile-first semantics (DoD 1 / 2).
+ * MutationExecutor — Connect-shaped facade over core MoneyPathExecutor
+ * (DoD 1 / 2 / 8). Prefer GuardedConnectAdapter so callers cannot bypass this.
  */
 
-import { createHash, randomUUID } from 'node:crypto';
 import {
-  InMemoryEffectLedger,
-  MutationKillSwitch,
-  assertIrreversibleAllowed,
+  MoneyPathExecutor,
+  type MoneyPathExecutorConfig,
+  type MoneyPathOutcome,
   type EffectLedger,
+  type MutationKillSwitch,
   type LiveSafetyModeConfig,
-  type MutationEffectType,
 } from '@otaip/core';
 import type { BookingStatusResult, ConnectAdapter } from './types.js';
 import { ConnectError } from './base-adapter.js';
 import { isUnsafeAdapterOperation } from './operation-class.js';
 
-export type MutationOutcome<T> =
-  | { readonly kind: 'succeeded'; readonly value: T; readonly replayed: boolean }
-  | { readonly kind: 'failed'; readonly error: unknown; readonly replayed: boolean }
-  | {
-      readonly kind: 'unknown';
-      readonly error: unknown;
-      readonly idempotencyKey: string;
-      readonly reconcileHint: 'getBookingStatus';
-    };
+export type MutationOutcome<T> = MoneyPathOutcome<T>;
 
-export interface MutationExecutorConfig {
-  readonly ledger?: EffectLedger;
-  readonly killSwitch?: MutationKillSwitch;
-  readonly safety?: LiveSafetyModeConfig;
-  readonly idFactory?: () => string;
-}
-
-function requestHash(input: unknown): string {
-  return createHash('sha256').update(JSON.stringify(input)).digest('hex');
-}
-
-function mapEffectType(operation: string): MutationEffectType {
-  if (operation.startsWith('createBooking')) return 'book';
-  if (operation.startsWith('requestTicketing')) return 'ticket';
-  if (operation.startsWith('cancelBooking')) return 'cancel';
-  if (operation.includes('void')) return 'void';
-  if (operation.includes('refund')) return 'refund';
-  if (operation.includes('pay')) return 'pay';
-  return 'book';
-}
-
-function isAmbiguousError(error: unknown): boolean {
-  if (error instanceof ConnectError) {
-    return error.retryable;
-  }
-  if (error instanceof Error) {
-    const msg = error.message.toLowerCase();
-    return (
-      msg.includes('fetch failed') ||
-      msg.includes('econnreset') ||
-      msg.includes('econnrefused') ||
-      msg.includes('network') ||
-      msg.includes('aborted') ||
-      msg.includes('timeout') ||
-      /\b5\d\d\b/.test(msg)
-    );
-  }
-  return false;
-}
+export type MutationExecutorConfig = MoneyPathExecutorConfig;
 
 export class MutationExecutor {
-  private readonly ledger: EffectLedger;
-  private readonly killSwitch: MutationKillSwitch;
-  private readonly safety: LiveSafetyModeConfig | undefined;
-  private readonly idFactory: () => string;
-  /** Single-process coalescing for concurrent identical idempotency keys. */
-  private readonly inFlight = new Map<string, Promise<MutationOutcome<unknown>>>();
+  private readonly inner: MoneyPathExecutor;
 
   constructor(config?: MutationExecutorConfig) {
-    this.ledger = config?.ledger ?? new InMemoryEffectLedger();
-    this.killSwitch = config?.killSwitch ?? new MutationKillSwitch();
-    this.safety = config?.safety;
-    this.idFactory = config?.idFactory ?? ((): string => randomUUID());
+    this.inner = new MoneyPathExecutor(config);
   }
 
   get effectLedger(): EffectLedger {
-    return this.ledger;
+    return this.inner.effectLedger;
   }
 
   get mutationKillSwitch(): MutationKillSwitch {
-    return this.killSwitch;
+    return this.inner.mutationKillSwitch;
+  }
+
+  get safetyConfig(): LiveSafetyModeConfig {
+    return this.inner.safetyConfig;
+  }
+
+  get moneyPath(): MoneyPathExecutor {
+    return this.inner;
   }
 
   /**
    * Execute an unsafe adapter mutation exactly once per idempotency key.
-   * On ambiguous failure, records OUTCOME_UNKNOWN and does not auto-retry.
+   * Safe ops pass through without ledger.
    */
   async execute<T>(params: {
     operation: string;
@@ -108,100 +61,7 @@ export class MutationExecutor {
       }
     }
 
-    const existing = this.inFlight.get(params.idempotencyKey);
-    if (existing) {
-      return existing as Promise<MutationOutcome<T>>;
-    }
-
-    const run = this.executeUnsafe<T>(params).finally(() => {
-      this.inFlight.delete(params.idempotencyKey);
-    });
-    this.inFlight.set(params.idempotencyKey, run as Promise<MutationOutcome<unknown>>);
-    return run;
-  }
-
-  private async executeUnsafe<T>(params: {
-    operation: string;
-    idempotencyKey: string;
-    request: unknown;
-    supplierId: string;
-    fn: () => Promise<T>;
-  }): Promise<MutationOutcome<T>> {
-    this.killSwitch.assertMutationsAllowed();
-    if (this.safety) {
-      assertIrreversibleAllowed(this.safety);
-    }
-
-    const hash = requestHash(params.request);
-    const begun = await this.ledger.begin<T>({
-      effectId: this.idFactory(),
-      effectType: mapEffectType(params.operation),
-      idempotencyKey: params.idempotencyKey,
-      requestHash: hash,
-      supplierId: params.supplierId,
-    });
-
-    if (begun.kind === 'conflict') {
-      return {
-        kind: 'failed',
-        error: new ConnectError(
-          begun.reason,
-          params.supplierId,
-          params.operation,
-          false,
-        ),
-        replayed: false,
-      };
-    }
-
-    if (begun.kind === 'replay') {
-      if (begun.record.outcome === 'succeeded' && begun.record.response !== undefined) {
-        return { kind: 'succeeded', value: begun.record.response, replayed: true };
-      }
-      if (begun.record.outcome === 'failed') {
-        return {
-          kind: 'failed',
-          error: new ConnectError(
-            'Replayed failed mutation',
-            params.supplierId,
-            params.operation,
-            false,
-          ),
-          replayed: true,
-        };
-      }
-      if (begun.record.outcome === 'unknown' || begun.record.outcome === 'pending') {
-        return {
-          kind: 'unknown',
-          error: new ConnectError(
-            'Prior mutation outcome unknown — reconcile before retry',
-            params.supplierId,
-            params.operation,
-            false,
-          ),
-          idempotencyKey: params.idempotencyKey,
-          reconcileHint: 'getBookingStatus',
-        };
-      }
-    }
-
-    try {
-      const value = await params.fn();
-      await this.ledger.resolve(params.idempotencyKey, 'succeeded', value);
-      return { kind: 'succeeded', value, replayed: false };
-    } catch (error) {
-      if (isAmbiguousError(error)) {
-        await this.ledger.resolve(params.idempotencyKey, 'unknown');
-        return {
-          kind: 'unknown',
-          error,
-          idempotencyKey: params.idempotencyKey,
-          reconcileHint: 'getBookingStatus',
-        };
-      }
-      await this.ledger.resolve(params.idempotencyKey, 'failed');
-      return { kind: 'failed', error, replayed: false };
-    }
+    return this.inner.executeUnsafe(params);
   }
 
   /**
@@ -215,10 +75,22 @@ export class MutationExecutor {
   ): Promise<BookingStatusResult> {
     const status = await adapter.getBookingStatus(bookingId);
     if (status.status === 'ticketed' || status.status === 'confirmed' || status.pnr) {
-      await this.ledger.resolve(idempotencyKey, 'succeeded', status as unknown, status.bookingId);
+      await this.inner.effectLedger.resolve(
+        idempotencyKey,
+        'succeeded',
+        status as unknown,
+        status.bookingId,
+      );
     } else if (status.status === 'cancelled' || status.status === 'failed') {
-      await this.ledger.resolve(idempotencyKey, 'failed', status as unknown, status.bookingId);
+      await this.inner.effectLedger.resolve(
+        idempotencyKey,
+        'failed',
+        status as unknown,
+        status.bookingId,
+      );
     }
     return status;
   }
 }
+
+export { ConnectError };

--- a/packages/connect/src/reversal-saga.ts
+++ b/packages/connect/src/reversal-saga.ts
@@ -1,12 +1,21 @@
 /**
- * Reversal saga — cancel/void/refund through the same MutationExecutor
- * ledger/idempotency rules as book (DoD 7).
+ * Reversal saga — cancel through MutationExecutor ledger rules (DoD 7).
+ *
+ * void/refund fail closed unless the adapter declares the capability.
+ * They must NOT silently alias to cancelBooking.
  */
 
 import type { ConnectAdapter } from './types.js';
 import { MutationExecutor, type MutationOutcome } from './mutation-executor.js';
+import { MoneyPathError } from '@otaip/core';
 
 export type ReversalKind = 'cancel' | 'void' | 'refund';
+
+export interface ReversalCapabilities {
+  readonly cancel?: boolean;
+  readonly void?: boolean;
+  readonly refund?: boolean;
+}
 
 export interface ReversalRequest {
   readonly kind: ReversalKind;
@@ -23,24 +32,76 @@ export interface ReversalResult {
   readonly kind: ReversalKind;
 }
 
+export class UnsupportedReversalError extends MoneyPathError {
+  readonly kind: ReversalKind;
+
+  constructor(kind: ReversalKind, message: string) {
+    super(message);
+    this.name = 'UnsupportedReversalError';
+    this.kind = kind;
+  }
+}
+
 /**
  * Execute a reversal using ledger-backed MutationExecutor.
  * Does not auto-retry after ambiguous failure.
+ *
+ * - cancel: requires adapter.cancelBooking
+ * - void / refund: require explicit capability flag — otherwise fail closed
  */
 export async function executeReversal(
   adapter: ConnectAdapter,
   request: ReversalRequest,
-  executor: MutationExecutor = new MutationExecutor(),
+  executor: MutationExecutor = new MutationExecutor({ liveMode: false }),
+  capabilities: ReversalCapabilities = { cancel: true },
 ): Promise<MutationOutcome<ReversalResult>> {
-  const operation =
-    request.kind === 'cancel'
-      ? 'cancelBooking'
-      : request.kind === 'void'
-        ? 'cancelBooking'
-        : 'cancelBooking';
+  if (request.kind === 'void' && !capabilities.void) {
+    return {
+      kind: 'failed',
+      error: new UnsupportedReversalError(
+        'void',
+        'void is not supported on this adapter — do not alias to cancelBooking',
+      ),
+      replayed: false,
+    };
+  }
+  if (request.kind === 'refund' && !capabilities.refund) {
+    return {
+      kind: 'failed',
+      error: new UnsupportedReversalError(
+        'refund',
+        'refund is not supported on this adapter — do not alias to cancelBooking',
+      ),
+      replayed: false,
+    };
+  }
+  if (request.kind !== 'cancel' && request.kind !== 'void' && request.kind !== 'refund') {
+    return {
+      kind: 'failed',
+      error: new UnsupportedReversalError(
+        request.kind,
+        `Unknown reversal kind: ${String(request.kind)}`,
+      ),
+      replayed: false,
+    };
+  }
+
+  // Only cancel is implemented via cancelBooking today.
+  // void/refund with capability=true still need supplier-specific APIs —
+  // until those exist, capability must stay false (fail closed above).
+  if (request.kind !== 'cancel') {
+    return {
+      kind: 'failed',
+      error: new UnsupportedReversalError(
+        request.kind,
+        `${request.kind} capability declared but no supplier API wired — refusing to alias cancel`,
+      ),
+      replayed: false,
+    };
+  }
 
   return executor.execute({
-    operation,
+    operation: 'cancelBooking',
     idempotencyKey: request.idempotencyKey,
     request,
     supplierId: adapter.supplierId,

--- a/packages/connect/src/suppliers/index.ts
+++ b/packages/connect/src/suppliers/index.ts
@@ -1,5 +1,8 @@
 /**
  * Supplier registry — factory pattern for creating ConnectAdapter instances.
+ *
+ * By default, returned adapters are wrapped in GuardedConnectAdapter so
+ * book/ticket/cancel cannot bypass the money-path executor.
  */
 
 import type { ConnectAdapter } from '../types.js';
@@ -7,6 +10,8 @@ import { AmadeusAdapter } from './amadeus/index.js';
 import { NavitaireAdapter } from './navitaire/index.js';
 import { SabreAdapter } from './sabre/index.js';
 import { TripProAdapter } from './trippro/index.js';
+import { guardAdapter, type GuardedConnectAdapter } from '../guarded-adapter.js';
+import type { MoneyPathExecutorConfig } from '@otaip/core';
 
 const SUPPLIER_FACTORIES: Record<string, (config: unknown) => ConnectAdapter> = {};
 
@@ -14,14 +19,29 @@ export function registerSupplier(id: string, factory: (config: unknown) => Conne
   SUPPLIER_FACTORIES[id] = factory;
 }
 
-export function createAdapter(supplierId: string, config: unknown): ConnectAdapter {
+export interface CreateAdapterOptions extends MoneyPathExecutorConfig {
+  /**
+   * When true, return the raw supplier adapter without GuardedConnectAdapter.
+   * Only for unit tests of raw HTTP/mapping — never for live money paths.
+   */
+  readonly unguarded?: boolean;
+}
+
+export function createAdapter(
+  supplierId: string,
+  config: unknown,
+  options?: CreateAdapterOptions,
+): ConnectAdapter | GuardedConnectAdapter {
   const factory = SUPPLIER_FACTORIES[supplierId];
   if (!factory) {
     throw new Error(
       `Unknown supplier: ${supplierId}. Available: ${Object.keys(SUPPLIER_FACTORIES).join(', ')}`,
     );
   }
-  return factory(config);
+  const raw = factory(config);
+  if (options?.unguarded) return raw;
+  const { unguarded: _u, ...execConfig } = options ?? {};
+  return guardAdapter(raw, execConfig);
 }
 
 export function listSuppliers(): string[] {

--- a/packages/connect/src/suppliers/index.ts
+++ b/packages/connect/src/suppliers/index.ts
@@ -40,7 +40,8 @@ export function createAdapter(
   }
   const raw = factory(config);
   if (options?.unguarded) return raw;
-  const { unguarded: _u, ...execConfig } = options ?? {};
+  const execConfig: Omit<CreateAdapterOptions, 'unguarded'> = { ...(options ?? {}) };
+  delete (execConfig as { unguarded?: boolean }).unguarded;
   return guardAdapter(raw, execConfig);
 }
 

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -34,6 +34,11 @@ export interface CreateBookingInput {
   offerId: string;
   passengers: PassengerDetail[];
   contact: ContactInfo;
+  /**
+   * Required on GuardedConnectAdapter (default createAdapter path).
+   * Same key → at most one supplier side effect (DoD 2).
+   */
+  idempotencyKey?: string;
 }
 
 export interface PassengerDetail {

--- a/packages/core/src/http/__tests__/fetch-once.test.ts
+++ b/packages/core/src/http/__tests__/fetch-once.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchOnce } from '../fetch-once.js';
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(impl: typeof fetch): void {
+  globalThis.fetch = impl as typeof fetch;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('fetchOnce', () => {
+  it('returns response without retrying 5xx', async () => {
+    const fn = vi.fn().mockResolvedValue(new Response('', { status: 503 }));
+    mockFetch(fn);
+
+    const res = await fetchOnce('https://example.test/book');
+    expect(res.status).toBe(503);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry network errors', async () => {
+    const fn = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+    mockFetch(fn);
+
+    await expect(fetchOnce('https://example.test/book')).rejects.toThrow(/fetch failed/);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/http/fetch-once.ts
+++ b/packages/core/src/http/fetch-once.ts
@@ -1,0 +1,32 @@
+/**
+ * Single-attempt fetch with AbortController timeout.
+ *
+ * Use for unsafe money-path mutations (book/ticket/cancel). Never retries —
+ * ambiguous 5xx/network outcomes must go to OUTCOME_UNKNOWN → reconcile.
+ */
+
+export interface FetchOnceOptions {
+  /** Timeout in milliseconds. Default: 30_000. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Fetch exactly once with timeout. Returns the Response (including 5xx/429)
+ * so callers can classify ambiguity. Throws on network/abort only.
+ */
+export async function fetchOnce(
+  input: string | URL,
+  init: RequestInit = {},
+  options: FetchOnceOptions = {},
+): Promise<Response> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/core/src/http/index.ts
+++ b/packages/core/src/http/index.ts
@@ -1,2 +1,4 @@
 export { fetchWithRetry } from './fetch-with-retry.js';
 export type { FetchWithRetryOptions } from './fetch-with-retry.js';
+export { fetchOnce } from './fetch-once.js';
+export type { FetchOnceOptions } from './fetch-once.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,7 +48,8 @@ export type {
 export type { RetryConfig, IsRetryable } from './retry/index.js';
 export { DEFAULT_RETRY_CONFIG, withRetry, computeDelay } from './retry/index.js';
 
-export { fetchWithRetry } from './http/index.js';
+export { fetchWithRetry, fetchOnce } from './http/index.js';
+export type { FetchOnceOptions } from './http/index.js';
 export type { FetchWithRetryOptions } from './http/index.js';
 
 export type { DomainInputRequired } from './domain/index.js';
@@ -154,6 +155,19 @@ export {
   assertIrreversibleAllowed,
   isLiveModeFromEnv,
 } from './safety/index.js';
+
+export type {
+  MoneyPathExecutorConfig,
+  MoneyPathOutcome,
+  MoneyPathOutcomeKind,
+} from './money-path/index.js';
+export {
+  MoneyPathExecutor,
+  MoneyPathError,
+  OutcomeUnknownError,
+  getProcessMutationKillSwitch,
+  isAmbiguousMutationError,
+} from './money-path/index.js';
 
 export type { CircuitBreakerConfig, CircuitBreakerStatus, CircuitState } from './circuit-breaker/index.js';
 export { CircuitBreaker, CircuitOpenError } from './circuit-breaker/index.js';

--- a/packages/core/src/money-path/__tests__/money-path-executor.test.ts
+++ b/packages/core/src/money-path/__tests__/money-path-executor.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryEffectLedger } from '../../effect-ledger/in-memory-effect-ledger.js';
+import { FileCompareAndSwapPersistenceAdapter } from '../../persistence/file-cas-adapter.js';
+import { MutationKillSwitch } from '../../safety/mutation-kill-switch.js';
+import { LiveSafetyError } from '../../safety/live-safety-mode.js';
+import { MoneyPathExecutor } from '../money-path-executor.js';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('MoneyPathExecutor', () => {
+  it('marks ambiguous 503 as unknown and does not re-invoke on replay', async () => {
+    const ledger = new InMemoryEffectLedger();
+    const exec = new MoneyPathExecutor({ ledger, liveMode: false });
+    let calls = 0;
+    const first = await exec.executeUnsafe({
+      operation: 'book',
+      idempotencyKey: 'k1',
+      request: { offer: 'o1' },
+      supplierId: 'duffel',
+      fn: async () => {
+        calls += 1;
+        throw new Error('Duffel API error 503: unavailable');
+      },
+    });
+    expect(first.kind).toBe('unknown');
+    const second = await exec.executeUnsafe({
+      operation: 'book',
+      idempotencyKey: 'k1',
+      request: { offer: 'o1' },
+      supplierId: 'duffel',
+      fn: async () => {
+        calls += 1;
+        return { id: 'should-not' };
+      },
+    });
+    expect(second.kind).toBe('unknown');
+    expect(calls).toBe(1);
+  });
+
+  it('refuses live mode with ephemeral stores by default', async () => {
+    const exec = new MoneyPathExecutor({ liveMode: true });
+    await expect(
+      exec.executeUnsafe({
+        operation: 'book',
+        idempotencyKey: 'live-1',
+        request: {},
+        supplierId: 'x',
+        fn: async () => ({ ok: true }),
+      }),
+    ).rejects.toBeInstanceOf(LiveSafetyError);
+  });
+
+  it('allows live mode with durable file-backed ledger', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'otaip-mp-'));
+    const persistence = new FileCompareAndSwapPersistenceAdapter(join(dir, 'ledger.json'));
+    const ledger = new InMemoryEffectLedger({ persistence });
+    const exec = new MoneyPathExecutor({
+      ledger,
+      storeDurability: 'durable',
+      liveMode: true,
+    });
+    const outcome = await exec.executeUnsafe({
+      operation: 'book',
+      idempotencyKey: 'live-ok',
+      request: { a: 1 },
+      supplierId: 'x',
+      fn: async () => ({ bookingId: 'B1' }),
+    });
+    expect(outcome.kind).toBe('succeeded');
+  });
+
+  it('respects kill switch', async () => {
+    const kill = new MutationKillSwitch();
+    kill.engage('test');
+    const exec = new MoneyPathExecutor({ killSwitch: kill, liveMode: false });
+    await expect(
+      exec.executeUnsafe({
+        operation: 'book',
+        idempotencyKey: 'k',
+        request: {},
+        supplierId: 'x',
+        fn: async () => ({ ok: true }),
+      }),
+    ).rejects.toThrow(/kill switch/i);
+  });
+
+  it('records ops audits on mutation', async () => {
+    const exec = new MoneyPathExecutor({ liveMode: false });
+    await exec.executeUnsafe({
+      operation: 'book',
+      idempotencyKey: 'ops-1',
+      request: { x: 1 },
+      supplierId: 'x',
+      fn: async () => ({ ok: true }),
+    });
+    expect(exec.opsCollector.listAudits().length).toBe(1);
+  });
+});

--- a/packages/core/src/money-path/ambiguity.ts
+++ b/packages/core/src/money-path/ambiguity.ts
@@ -1,0 +1,49 @@
+/**
+ * Classify whether a thrown error means the supplier effect may have applied.
+ */
+
+function messageLooksAmbiguous(msg: string): boolean {
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes('fetch failed') ||
+    lower.includes('econnreset') ||
+    lower.includes('econnrefused') ||
+    lower.includes('network') ||
+    lower.includes('aborted') ||
+    lower.includes('timeout') ||
+    lower.includes('429') ||
+    /\b5\d\d\b/.test(lower)
+  );
+}
+
+function walkCauses(error: unknown, depth = 0): unknown[] {
+  if (error === null || error === undefined || depth > 6) return [];
+  const out: unknown[] = [error];
+  if (typeof error === 'object' && error !== null && 'cause' in error) {
+    out.push(...walkCauses((error as { cause: unknown }).cause, depth + 1));
+  }
+  return out;
+}
+
+/**
+ * True when the caller must not re-issue the mutation — reconcile first.
+ */
+export function isAmbiguousMutationError(error: unknown): boolean {
+  for (const node of walkCauses(error)) {
+    if (
+      typeof node === 'object' &&
+      node !== null &&
+      'retryable' in node &&
+      (node as { retryable: unknown }).retryable === true
+    ) {
+      return true;
+    }
+    if (node instanceof Error && messageLooksAmbiguous(node.message)) {
+      return true;
+    }
+    if (typeof node === 'string' && messageLooksAmbiguous(node)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/core/src/money-path/index.ts
+++ b/packages/core/src/money-path/index.ts
@@ -1,0 +1,11 @@
+export {
+  MoneyPathExecutor,
+  getProcessMutationKillSwitch,
+} from './money-path-executor.js';
+export type { MoneyPathExecutorConfig } from './money-path-executor.js';
+export {
+  MoneyPathError,
+  OutcomeUnknownError,
+} from './types.js';
+export type { MoneyPathOutcome, MoneyPathOutcomeKind } from './types.js';
+export { isAmbiguousMutationError } from './ambiguity.js';

--- a/packages/core/src/money-path/money-path-executor.ts
+++ b/packages/core/src/money-path/money-path-executor.ts
@@ -1,0 +1,278 @@
+/**
+ * MoneyPathExecutor — default-enforced ledger + kill switch + live safety + ops
+ * for irreversible supplier mutations (DoD 1/2/3/8).
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import { InMemoryEffectLedger } from '../effect-ledger/in-memory-effect-ledger.js';
+import type { EffectLedger } from '../effect-ledger/types.js';
+import type { MutationEffectType } from '../command-store/types.js';
+import { MutationOpsCollector } from '../ops/mutation-ops.js';
+import {
+  assertIrreversibleAllowed,
+  isLiveModeFromEnv,
+  type LiveSafetyModeConfig,
+  type StoreDurability,
+} from '../safety/live-safety-mode.js';
+import {
+  MutationKillSwitch,
+  MutationKillSwitchError,
+} from '../safety/mutation-kill-switch.js';
+import { isAmbiguousMutationError } from './ambiguity.js';
+import {
+  MoneyPathError,
+  OutcomeUnknownError,
+  type MoneyPathOutcome,
+} from './types.js';
+
+export interface MoneyPathExecutorConfig {
+  readonly ledger?: EffectLedger;
+  readonly killSwitch?: MutationKillSwitch;
+  readonly ops?: MutationOpsCollector;
+  /**
+   * Store durability of the injected ledger/persistence.
+   * Defaults to `ephemeral` when ledger is the default in-memory impl.
+   */
+  readonly storeDurability?: StoreDurability;
+  /** When true, mock adapters / synthetic ticketing are in use. */
+  readonly mockAdapters?: boolean;
+  /**
+   * Override live detection. Default: `isLiveModeFromEnv()`.
+   * Live + ephemeral/mock → refuse irreversible ops (not opt-in).
+   */
+  readonly liveMode?: boolean;
+  readonly idFactory?: () => string;
+  /** Override reconcile hint label for unknown outcomes. */
+  readonly reconcileHint?: 'getBookingStatus' | 'getOrder';
+}
+
+function requestHash(input: unknown): string {
+  return createHash('sha256').update(JSON.stringify(input)).digest('hex');
+}
+
+function mapEffectType(operation: string): MutationEffectType {
+  if (operation.includes('ticket')) return 'ticket';
+  if (operation.includes('void')) return 'void';
+  if (operation.includes('refund')) return 'refund';
+  if (operation.includes('cancel')) return 'cancel';
+  if (operation.includes('pay')) return 'pay';
+  if (operation.includes('book') || operation.includes('Booking') || operation.includes('order')) {
+    return 'book';
+  }
+  return 'book';
+}
+
+/** Shared process kill switch — env engage at import time. */
+const processKillSwitch = new MutationKillSwitch();
+if ((process.env['OTAIP_MUTATION_KILL_SWITCH'] ?? '').trim() === '1') {
+  processKillSwitch.engage('OTAIP_MUTATION_KILL_SWITCH=1');
+}
+
+export function getProcessMutationKillSwitch(): MutationKillSwitch {
+  return processKillSwitch;
+}
+
+export class MoneyPathExecutor {
+  private readonly ledger: EffectLedger;
+  private readonly killSwitch: MutationKillSwitch;
+  private readonly ops: MutationOpsCollector;
+  private readonly storeDurability: StoreDurability;
+  private readonly mockAdapters: boolean;
+  private readonly liveMode: boolean;
+  private readonly idFactory: () => string;
+  private readonly reconcileHint: 'getBookingStatus' | 'getOrder';
+  private readonly inFlight = new Map<string, Promise<MoneyPathOutcome<unknown>>>();
+
+  constructor(config?: MoneyPathExecutorConfig) {
+    const usingDefaultLedger = config?.ledger === undefined;
+    this.ledger = config?.ledger ?? new InMemoryEffectLedger();
+    this.killSwitch = config?.killSwitch ?? processKillSwitch;
+    this.ops = config?.ops ?? new MutationOpsCollector();
+    this.storeDurability =
+      config?.storeDurability ?? (usingDefaultLedger ? 'ephemeral' : 'durable');
+    this.mockAdapters = config?.mockAdapters ?? false;
+    this.liveMode = config?.liveMode ?? isLiveModeFromEnv();
+    this.idFactory = config?.idFactory ?? ((): string => randomUUID());
+    this.reconcileHint = config?.reconcileHint ?? 'getBookingStatus';
+  }
+
+  get effectLedger(): EffectLedger {
+    return this.ledger;
+  }
+
+  get mutationKillSwitch(): MutationKillSwitch {
+    return this.killSwitch;
+  }
+
+  get opsCollector(): MutationOpsCollector {
+    return this.ops;
+  }
+
+  get safetyConfig(): LiveSafetyModeConfig {
+    return {
+      liveMode: this.liveMode,
+      storeDurability: this.storeDurability,
+      mockAdapters: this.mockAdapters,
+    };
+  }
+
+  /**
+   * Execute an unsafe mutation exactly once per idempotency key.
+   * On ambiguous failure, records OUTCOME_UNKNOWN and does not auto-retry.
+   */
+  async executeUnsafe<T>(params: {
+    operation: string;
+    idempotencyKey: string;
+    request: unknown;
+    supplierId: string;
+    agentId?: string;
+    sessionId?: string;
+    fn: () => Promise<T>;
+  }): Promise<MoneyPathOutcome<T>> {
+    if (!params.idempotencyKey || params.idempotencyKey.trim().length === 0) {
+      throw new MoneyPathError(
+        `Money-path operation '${params.operation}' requires a non-empty idempotencyKey`,
+      );
+    }
+
+    const existing = this.inFlight.get(params.idempotencyKey);
+    if (existing) {
+      return existing as Promise<MoneyPathOutcome<T>>;
+    }
+
+    const run = this.runUnsafe<T>(params).finally(() => {
+      this.inFlight.delete(params.idempotencyKey);
+    });
+    this.inFlight.set(params.idempotencyKey, run as Promise<MoneyPathOutcome<unknown>>);
+    return run;
+  }
+
+  /**
+   * Same as executeUnsafe but throws OutcomeUnknownError / original error
+   * instead of returning a discriminated union (handy for adapter wrappers).
+   */
+  async executeUnsafeOrThrow<T>(params: {
+    operation: string;
+    idempotencyKey: string;
+    request: unknown;
+    supplierId: string;
+    agentId?: string;
+    sessionId?: string;
+    fn: () => Promise<T>;
+  }): Promise<T> {
+    const outcome = await this.executeUnsafe(params);
+    if (outcome.kind === 'succeeded') return outcome.value;
+    if (outcome.kind === 'unknown') {
+      throw new OutcomeUnknownError(
+        'Prior mutation outcome unknown — reconcile before retry',
+        {
+          idempotencyKey: outcome.idempotencyKey,
+          reconcileHint: outcome.reconcileHint,
+          cause: outcome.error,
+        },
+      );
+    }
+    throw outcome.error instanceof Error
+      ? outcome.error
+      : new MoneyPathError(String(outcome.error));
+  }
+
+  private async runUnsafe<T>(params: {
+    operation: string;
+    idempotencyKey: string;
+    request: unknown;
+    supplierId: string;
+    agentId?: string;
+    sessionId?: string;
+    fn: () => Promise<T>;
+  }): Promise<MoneyPathOutcome<T>> {
+    this.killSwitch.assertMutationsAllowed();
+    assertIrreversibleAllowed(this.safetyConfig);
+
+    const hash = requestHash(params.request);
+    const effectType = mapEffectType(params.operation);
+
+    this.ops.recordIrreversible({
+      actionId: this.idFactory(),
+      effectType,
+      payloadHash: hash,
+      ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
+      ...(params.sessionId !== undefined ? { sessionId: params.sessionId } : {}),
+    });
+
+    const begun = await this.ledger.begin<T>({
+      effectId: this.idFactory(),
+      effectType,
+      idempotencyKey: params.idempotencyKey,
+      requestHash: hash,
+      supplierId: params.supplierId,
+    });
+
+    if (begun.kind === 'conflict') {
+      this.ops.recordFailure({
+        stage: effectType === 'cancel' ? 'cancel' : effectType === 'ticket' ? 'ticket' : 'book',
+        code: 'IDEMPOTENCY_CONFLICT',
+        supplierId: params.supplierId,
+      });
+      return {
+        kind: 'failed',
+        error: new MoneyPathError(begun.reason),
+        replayed: false,
+      };
+    }
+
+    if (begun.kind === 'replay') {
+      if (begun.record.outcome === 'succeeded' && begun.record.response !== undefined) {
+        return { kind: 'succeeded', value: begun.record.response, replayed: true };
+      }
+      if (begun.record.outcome === 'failed') {
+        return {
+          kind: 'failed',
+          error: new MoneyPathError('Replayed failed mutation'),
+          replayed: true,
+        };
+      }
+      if (begun.record.outcome === 'unknown' || begun.record.outcome === 'pending') {
+        return {
+          kind: 'unknown',
+          error: new MoneyPathError(
+            'Prior mutation outcome unknown — reconcile before retry',
+          ),
+          idempotencyKey: params.idempotencyKey,
+          reconcileHint: this.reconcileHint,
+        };
+      }
+    }
+
+    try {
+      const value = await params.fn();
+      await this.ledger.resolve(params.idempotencyKey, 'succeeded', value);
+      return { kind: 'succeeded', value, replayed: false };
+    } catch (error) {
+      if (error instanceof MutationKillSwitchError) {
+        throw error;
+      }
+      if (isAmbiguousMutationError(error)) {
+        await this.ledger.resolve(params.idempotencyKey, 'unknown');
+        this.ops.recordFailure({
+          stage: effectType === 'cancel' ? 'cancel' : effectType === 'ticket' ? 'ticket' : 'book',
+          code: 'OUTCOME_UNKNOWN',
+          supplierId: params.supplierId,
+        });
+        return {
+          kind: 'unknown',
+          error,
+          idempotencyKey: params.idempotencyKey,
+          reconcileHint: this.reconcileHint,
+        };
+      }
+      await this.ledger.resolve(params.idempotencyKey, 'failed');
+      this.ops.recordFailure({
+        stage: effectType === 'cancel' ? 'cancel' : effectType === 'ticket' ? 'ticket' : 'book',
+        code: 'MUTATION_FAILED',
+        supplierId: params.supplierId,
+      });
+      return { kind: 'failed', error, replayed: false };
+    }
+  }
+}

--- a/packages/core/src/money-path/types.ts
+++ b/packages/core/src/money-path/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Money-path mutation outcomes shared by Connect + Duffel.
+ */
+
+export type MoneyPathOutcomeKind = 'succeeded' | 'failed' | 'unknown';
+
+export type MoneyPathOutcome<T> =
+  | { readonly kind: 'succeeded'; readonly value: T; readonly replayed: boolean }
+  | { readonly kind: 'failed'; readonly error: unknown; readonly replayed: boolean }
+  | {
+      readonly kind: 'unknown';
+      readonly error: unknown;
+      readonly idempotencyKey: string;
+      readonly reconcileHint: 'getBookingStatus' | 'getOrder';
+    };
+
+export class OutcomeUnknownError extends Error {
+  readonly idempotencyKey: string;
+  readonly reconcileHint: 'getBookingStatus' | 'getOrder';
+  override readonly cause?: unknown;
+
+  constructor(
+    message: string,
+    opts: {
+      idempotencyKey: string;
+      reconcileHint: 'getBookingStatus' | 'getOrder';
+      cause?: unknown;
+    },
+  ) {
+    super(message);
+    this.name = 'OutcomeUnknownError';
+    this.idempotencyKey = opts.idempotencyKey;
+    this.reconcileHint = opts.reconcileHint;
+    if (opts.cause !== undefined) this.cause = opts.cause;
+  }
+}
+
+export class MoneyPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MoneyPathError';
+  }
+}

--- a/packages/core/src/pipeline-validator/__tests__/approval-before-execute.test.ts
+++ b/packages/core/src/pipeline-validator/__tests__/approval-before-execute.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { PipelineOrchestrator } from '../orchestrator.js';
+import type { Agent } from '../../types/agent.js';
+import type { AgentContract, ReferenceDataProvider } from '../types.js';
+import {
+  InMemoryBoundApprovalTokenStore,
+  issueBoundApprovalToken,
+} from '../../approval/bound-approval.js';
+
+const emptyReference: ReferenceDataProvider = {
+  async resolveAirport() {
+    return null;
+  },
+  async resolveAirline() {
+    return null;
+  },
+  async decodeFareBasis() {
+    return null;
+  },
+};
+
+describe('approval before execute (DoD 6)', () => {
+  it('does not call execute when approval fails', async () => {
+    const execute = vi.fn(async () => ({ data: {}, confidence: 1 }));
+    const contract: AgentContract = {
+      agentId: 'irrev',
+      inputSchema: z.object({ approvalToken: z.string().optional() }).passthrough(),
+      outputSchema: z.object({}).passthrough(),
+      actionType: 'mutation_irreversible',
+      confidenceThreshold: 0.95,
+      intentRelevance: ['test'],
+      outputContract: [],
+      async validate() {
+        return { ok: true, warnings: [] };
+      },
+    };
+    const agent = {
+      id: 'irrev',
+      name: 'irrev',
+      version: '1',
+      async initialize() {},
+      async health() {
+        return { status: 'healthy' as const };
+      },
+      execute,
+    } satisfies Agent;
+
+    const orch = new PipelineOrchestrator({
+      reference: emptyReference,
+      contracts: new Map([['irrev', contract]]),
+      agents: new Map([['irrev', agent]]),
+      liveMode: false,
+    });
+    const session = orch.createSession({
+      type: 'test',
+      origin: 'JFK',
+      destination: 'LHR',
+      outboundDate: '2026-05-01',
+      passengerCount: 1,
+    });
+
+    const result = await orch.runAgent(session, 'irrev', {});
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('action_class_blocked');
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('live mode consumes single-use HMAC token before execute', async () => {
+    const execute = vi.fn(async () => ({ data: { ok: true }, confidence: 1 }));
+    const store = new InMemoryBoundApprovalTokenStore();
+    const secret = 'live-secret';
+    const contract: AgentContract = {
+      agentId: 'irrev',
+      inputSchema: z.object({ x: z.number(), approvalToken: z.string().optional() }),
+      outputSchema: z.object({ ok: z.boolean() }),
+      actionType: 'mutation_irreversible',
+      confidenceThreshold: 0.95,
+      intentRelevance: ['test'],
+      outputContract: [],
+      async validate() {
+        return { ok: true, warnings: [] };
+      },
+    };
+    const agent = {
+      id: 'irrev',
+      name: 'irrev',
+      version: '1',
+      async initialize() {},
+      async health() {
+        return { status: 'healthy' as const };
+      },
+      execute,
+    } satisfies Agent;
+
+    const orch = new PipelineOrchestrator({
+      reference: emptyReference,
+      contracts: new Map([['irrev', contract]]),
+      agents: new Map([['irrev', agent]]),
+      liveMode: true,
+      approvalSecret: secret,
+      approvalTokenStore: store,
+    });
+    const session = orch.createSession({
+      type: 'test',
+      origin: 'JFK',
+      destination: 'LHR',
+      outboundDate: '2026-05-01',
+      passengerCount: 1,
+    });
+
+    const input = { x: 1 };
+    const token = issueBoundApprovalToken({
+      sessionId: session.sessionId,
+      agentId: 'irrev',
+      input,
+      secret,
+    });
+
+    const ok = await orch.runAgent(session, 'irrev', { ...input, approvalToken: token });
+    expect(ok.ok).toBe(true);
+    expect(execute).toHaveBeenCalledOnce();
+
+    // Replay same token must fail and not execute again
+    execute.mockClear();
+    const replay = await orch.runAgent(session, 'irrev', {
+      ...input,
+      approvalToken: token,
+    });
+    expect(replay.ok).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('live mode without approval secret refuses irreversible', async () => {
+    const execute = vi.fn(async () => ({ data: {}, confidence: 1 }));
+    const contract: AgentContract = {
+      agentId: 'irrev',
+      inputSchema: z.object({}).passthrough(),
+      outputSchema: z.object({}).passthrough(),
+      actionType: 'mutation_irreversible',
+      confidenceThreshold: 0.95,
+      intentRelevance: ['test'],
+      outputContract: [],
+      async validate() {
+        return { ok: true, warnings: [] };
+      },
+    };
+    const agent = {
+      id: 'irrev',
+      name: 'irrev',
+      version: '1',
+      async initialize() {},
+      async health() {
+        return { status: 'healthy' as const };
+      },
+      execute,
+    } satisfies Agent;
+
+    const orch = new PipelineOrchestrator({
+      reference: emptyReference,
+      contracts: new Map([['irrev', contract]]),
+      agents: new Map([['irrev', agent]]),
+      liveMode: true,
+      approvalSecret: '',
+    });
+    const session = orch.createSession({
+      type: 'test',
+      origin: 'JFK',
+      destination: 'LHR',
+      outboundDate: '2026-05-01',
+      passengerCount: 1,
+    });
+    const result = await orch.runAgent(session, 'irrev', {});
+    expect(result.ok).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/pipeline-validator/__tests__/orchestrator.test.ts
+++ b/packages/core/src/pipeline-validator/__tests__/orchestrator.test.ts
@@ -70,7 +70,8 @@ describe('PipelineOrchestrator', () => {
       expect(result.output.data).toEqual({ out: 'HI' });
       expect(session.history).toHaveLength(1);
       expect(session.contractState.get('echo')).toEqual({ out: 'HI' });
-      // All six logical gates fire at least once.
+      // Query path: input gates + execute + output gates.
+      // action_class runs pre-execute for mutations only (DoD 6).
       const gates = result.invocation.gateResults.map((g) => g.gate);
       expect(gates).toContain('intent_lock');
       expect(gates).toContain('schema_in');
@@ -78,7 +79,7 @@ describe('PipelineOrchestrator', () => {
       expect(gates).toContain('cross_agent');
       expect(gates).toContain('schema_out');
       expect(gates).toContain('confidence');
-      expect(gates).toContain('action_class');
+      expect(gates).not.toContain('action_class');
     }
   });
 

--- a/packages/core/src/pipeline-validator/orchestrator.ts
+++ b/packages/core/src/pipeline-validator/orchestrator.ts
@@ -41,6 +41,7 @@ import type {
   PipelineSession,
   ReferenceDataProvider,
   SemanticIssue,
+  SemanticValidationResult,
 } from './types.js';
 
 export interface PipelineOrchestratorConfig {
@@ -316,20 +317,20 @@ export class PipelineOrchestrator {
       : (this.config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY);
 
     const consumeApproval = useBoundCrypto
-      ? async (rawInput: unknown) => {
+      ? async (rawInput: unknown): Promise<SemanticValidationResult> => {
           const token =
             rawInput && typeof rawInput === 'object'
               ? (rawInput as Record<string, unknown>)['approvalToken']
               : undefined;
           if (typeof token !== 'string') {
             return {
-              ok: false as const,
+              ok: false,
               issues: [
                 {
                   code: 'APPROVAL_TOKEN_INVALID',
                   path: ['approvalToken'],
                   message: 'Approval token is missing or empty',
-                  severity: 'error' as const,
+                  severity: 'error',
                 },
               ],
             };

--- a/packages/core/src/pipeline-validator/orchestrator.ts
+++ b/packages/core/src/pipeline-validator/orchestrator.ts
@@ -20,8 +20,19 @@ import {
   makeInvocation,
   runGates,
 } from './validator.js';
-import type { ApprovalPolicy } from './action-classifier.js';
+import {
+  DEFAULT_APPROVAL_POLICY,
+  type ApprovalPolicy,
+} from './action-classifier.js';
 import type { MutationKillSwitch } from '../safety/mutation-kill-switch.js';
+import { getProcessMutationKillSwitch } from '../money-path/money-path-executor.js';
+import { isLiveModeFromEnv } from '../safety/live-safety-mode.js';
+import {
+  InMemoryBoundApprovalTokenStore,
+  consumeBoundApprovalToken,
+  createBoundApprovalPolicy,
+  type BoundApprovalTokenStore,
+} from '../approval/bound-approval.js';
 import type {
   AgentContract,
   AgentInvocation,
@@ -44,6 +55,11 @@ export interface PipelineOrchestratorConfig {
   readonly retryBudget?: number;
   /** Set of agent ids that should be treated as reference-data agents. */
   readonly referenceAgentIds?: ReadonlySet<string>;
+  /**
+   * Approval policy. In live mode (or when OTAIP_APPROVAL_SECRET is set),
+   * per-invocation HMAC + single-use policy overrides this for irreversible
+   * mutations.
+   */
   readonly approvalPolicy?: ApprovalPolicy;
   /**
    * When an agent id is known to be a mutation but has no contract, fail with
@@ -51,8 +67,15 @@ export interface PipelineOrchestratorConfig {
    * for ids in this set as uncontracted mutations.
    */
   readonly mutationAgentIds?: ReadonlySet<string>;
-  /** Optional kill switch — blocks irreversible/mutation runs when engaged. */
+  /**
+   * Kill switch — defaults to process-global switch (env OTAIP_MUTATION_KILL_SWITCH=1).
+   */
   readonly killSwitch?: MutationKillSwitch;
+  /** HMAC secret for bound approvals. Defaults to OTAIP_APPROVAL_SECRET. */
+  readonly approvalSecret?: string;
+  readonly approvalTokenStore?: BoundApprovalTokenStore;
+  /** Override live detection. Default: isLiveModeFromEnv(). */
+  readonly liveMode?: boolean;
   /** Clock injection for tests. */
   readonly now?: () => Date;
   /** Deterministic id source for sessions/invocations (tests). */
@@ -166,7 +189,22 @@ export class PipelineOrchestrator {
       reference: config.reference,
       contracts: config.contracts,
       agents: config.agents,
+      killSwitch: config.killSwitch ?? getProcessMutationKillSwitch(),
+      approvalTokenStore:
+        config.approvalTokenStore ?? new InMemoryBoundApprovalTokenStore(),
+      liveMode: config.liveMode ?? isLiveModeFromEnv(),
+      approvalSecret:
+        config.approvalSecret ?? process.env['OTAIP_APPROVAL_SECRET'],
     };
+  }
+
+  private get liveMode(): boolean {
+    return this.config.liveMode ?? false;
+  }
+
+  private get approvalSecret(): string | undefined {
+    const s = this.config.approvalSecret;
+    return s && s.trim().length > 0 ? s : undefined;
   }
 
   /** Open a new session with the given locked intent. */
@@ -205,12 +243,13 @@ export class PipelineOrchestrator {
     const agent = this.config.agents.get(agentId);
     const startedAt = this.now();
 
-    if (this.config.killSwitch?.isEngaged) {
+    const killSwitch = this.config.killSwitch ?? getProcessMutationKillSwitch();
+    if (killSwitch.isEngaged) {
       return this.recordFailure(session, agentId, startedAt, input, 'kill_switch', [
         {
           code: 'MUTATION_KILL_SWITCH',
           path: [],
-          message: `Mutation kill switch engaged: ${this.config.killSwitch.engagedReason ?? 'unspecified'}`,
+          message: `Mutation kill switch engaged: ${killSwitch.engagedReason ?? 'unspecified'}`,
           severity: 'error',
         },
       ]);
@@ -243,6 +282,66 @@ export class PipelineOrchestrator {
       ]);
     }
 
+    // Live mode refuses irreversible mutations without an HMAC approval secret.
+    if (
+      this.liveMode &&
+      contract.actionType === 'mutation_irreversible' &&
+      !this.approvalSecret
+    ) {
+      return this.recordFailure(session, agentId, startedAt, input, 'action_class_blocked', [
+        {
+          code: 'APPROVAL_SECRET_REQUIRED',
+          path: ['approvalToken'],
+          message:
+            'Live mode requires OTAIP_APPROVAL_SECRET (or approvalSecret) for mutation_irreversible agents',
+          severity: 'error',
+        },
+      ]);
+    }
+
+    const secret = this.approvalSecret;
+    const useBoundCrypto =
+      (this.liveMode || secret !== undefined) &&
+      contract.actionType === 'mutation_irreversible' &&
+      secret !== undefined;
+
+    const approvalPolicy: ApprovalPolicy = useBoundCrypto
+      ? createBoundApprovalPolicy({
+          secret,
+          store: this.config.approvalTokenStore ?? new InMemoryBoundApprovalTokenStore(),
+          sessionId: session.sessionId,
+          agentId,
+          expectedInput: input,
+        })
+      : (this.config.approvalPolicy ?? DEFAULT_APPROVAL_POLICY);
+
+    const consumeApproval = useBoundCrypto
+      ? async (rawInput: unknown) => {
+          const token =
+            rawInput && typeof rawInput === 'object'
+              ? (rawInput as Record<string, unknown>)['approvalToken']
+              : undefined;
+          if (typeof token !== 'string') {
+            return {
+              ok: false as const,
+              issues: [
+                {
+                  code: 'APPROVAL_TOKEN_INVALID',
+                  path: ['approvalToken'],
+                  message: 'Approval token is missing or empty',
+                  severity: 'error' as const,
+                },
+              ],
+            };
+          }
+          return consumeBoundApprovalToken(
+            token,
+            secret,
+            this.config.approvalTokenStore ?? new InMemoryBoundApprovalTokenStore(),
+          );
+        }
+      : undefined;
+
     const retryBudget = this.config.retryBudget ?? 3;
     let attempt = 0;
     let lastResult: GateRunResult | undefined;
@@ -251,7 +350,8 @@ export class PipelineOrchestrator {
       const result = await runGates(contract, agent as Agent, input, session, {
         now: startedAt,
         reference: this.config.reference,
-        approvalPolicy: this.config.approvalPolicy,
+        approvalPolicy,
+        ...(consumeApproval !== undefined ? { consumeApproval } : {}),
         isReferenceAgent:
           this.config.referenceAgentIds?.has(agentId) ?? false,
       });

--- a/packages/core/src/pipeline-validator/validator.ts
+++ b/packages/core/src/pipeline-validator/validator.ts
@@ -11,14 +11,12 @@
  *   2. schema_in         — Zod safeParse on input
  *   3. semantic_in       — contract.validate(input, ctx)
  *   4. cross_agent       — input fields consistent with session.contractState
+ *   5. action_class      — for mutations: approval + zero-warnings BEFORE side effects
  *   --- execute the agent ---
- *   5. schema_out        — Zod safeParse on output.data + optional validateOutput
- *   6. confidence        — output.confidence >= effective threshold
- *   7. action_class      — approval token + zero-warnings check
+ *   6. schema_out        — Zod safeParse on output.data + optional validateOutput
+ *   7. confidence        — output.confidence >= effective threshold
  *
- * Numbering inside this file follows the implementation order above;
- * the master plan counts six logical gates (schema, semantic, intent,
- * cross-agent, confidence, action).
+ * Queries skip pre-execute action_class (no approval / mutation warnings gate).
  */
 
 import type { z } from 'zod';
@@ -46,6 +44,13 @@ export interface RunGatesConfig {
   readonly approvalPolicy?: ApprovalPolicy;
   /** If true, the contract is marked as a reference-data agent for confidence floor purposes. */
   readonly isReferenceAgent?: boolean;
+  /**
+   * Optional single-use token consumption — invoked after sync approval policy
+   * passes and BEFORE agent.execute() for mutations.
+   */
+  readonly consumeApproval?: (
+    input: unknown,
+  ) => Promise<import('./types.js').SemanticValidationResult>;
 }
 
 export type GateRunResult =
@@ -148,6 +153,37 @@ export async function runGates<TIn extends z.ZodType, TOut extends z.ZodType>(
   }
   gateResults.push({ gate: 'cross_agent', passed: true, issues: crossAgent.warnings });
 
+  // Gate 5 (pre-execute for mutations): action_class — MUST run before side effects.
+  const isMutation =
+    contract.actionType === 'mutation_reversible' ||
+    contract.actionType === 'mutation_irreversible';
+  if (isMutation) {
+    const actionCheck = checkActionClassification(
+      contract.actionType,
+      input,
+      gateResults,
+      config.approvalPolicy,
+    );
+    if (!actionCheck.ok) {
+      gateResults.push({ gate: 'action_class', passed: false, issues: actionCheck.issues });
+      return fail('action_class_blocked', actionCheck.issues, gateResults);
+    }
+    gateResults.push({ gate: 'action_class', passed: true });
+  }
+
+  // Optional async consume hook (single-use tokens) — still before execute.
+  if (config.consumeApproval && isMutation) {
+    const consumeResult = await config.consumeApproval(input);
+    if (!consumeResult.ok) {
+      gateResults.push({
+        gate: 'action_class',
+        passed: false,
+        issues: consumeResult.issues,
+      });
+      return fail('action_class_blocked', consumeResult.issues, gateResults);
+    }
+  }
+
   // Execute
   let output: AgentOutput<z.output<TOut>>;
   try {
@@ -166,7 +202,7 @@ export async function runGates<TIn extends z.ZodType, TOut extends z.ZodType>(
     return fail('agent_error', issues, gateResults);
   }
 
-  // Gate 5: schema_out
+  // Gate 6: schema_out
   const outParse = contract.outputSchema.safeParse(output.data);
   if (!outParse.success) {
     const issues: SemanticIssue[] = outParse.error.issues.map((i) => ({
@@ -190,7 +226,7 @@ export async function runGates<TIn extends z.ZodType, TOut extends z.ZodType>(
     gateResults.push({ gate: 'schema_out', passed: true });
   }
 
-  // Gate 6: confidence
+  // Gate 7: confidence
   const conf = checkConfidence({
     outputConfidence: output.confidence,
     threshold: contract.confidenceThreshold,
@@ -202,19 +238,6 @@ export async function runGates<TIn extends z.ZodType, TOut extends z.ZodType>(
     return fail('low_confidence', conf.issues, gateResults);
   }
   gateResults.push({ gate: 'confidence', passed: true });
-
-  // Gate 7: action_class
-  const actionCheck = checkActionClassification(
-    contract.actionType,
-    input, // raw input (so approvalToken passthrough is visible)
-    gateResults,
-    config.approvalPolicy,
-  );
-  if (!actionCheck.ok) {
-    gateResults.push({ gate: 'action_class', passed: false, issues: actionCheck.issues });
-    return fail('action_class_blocked', actionCheck.issues, gateResults);
-  }
-  gateResults.push({ gate: 'action_class', passed: true });
 
   // Capture output contract into session state.
   captureOutputContract(contract.agentId, output.data, contract.outputContract, session);

--- a/packages/integration/src/__tests__/run-search.test.ts
+++ b/packages/integration/src/__tests__/run-search.test.ts
@@ -116,6 +116,7 @@ describe('runAvailabilitySearch (offline)', () => {
     expect(exec.agentId).toBe('1.1');
     expect(exec.success).toBe(true);
     const passedGates = new Set(exec.gateResults.filter((g) => g.passed).map((g) => g.gate));
+    // Query agents skip action_class (approval runs pre-execute for mutations only).
     for (const gate of [
       'intent_lock',
       'schema_in',
@@ -124,10 +125,10 @@ describe('runAvailabilitySearch (offline)', () => {
       'execute',
       'schema_out',
       'confidence',
-      'action_class',
     ]) {
       expect(passedGates.has(gate)).toBe(true);
     }
+    expect(passedGates.has('action_class')).toBe(false);
 
     expect(trace.adapterHealth).toHaveLength(1);
     expect(trace.adapterHealth[0]?.status).toBe('healthy');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR #125 shipped a safety kit that callers could bypass. Scorecard claimed 8/8 while Duffel `book()` still `fetchWithRetry`’d on 500s, `MutationExecutor` was unused, approval ran after `execute()`, and void/refund aliased to cancel.

**PASS now means default-enforced**, not “class exists if you wire it.”

## What changed

| DoD | Enforcement |
|---|---|
| 1 Mutations | `GuardedConnectAdapter` via `createAdapter()`; Duffel unsafe POSTs use `fetchOnce` + `MoneyPathExecutor` |
| 2–3 Durability | Live mode refuses ephemeral stores; durable pay-confirm uses `compareAndSet` OCC |
| 4 Backpressure | `BaseAdapter` rate limiter **on by default**; Duffel RL+CB on HTTP path |
| 5 Tickets | Example OTA Duffel path uses order documents; live refuses synthetic serials |
| 6 Approvals | `action_class` **before** `execute` for mutations; live HMAC + single-use consume |
| 7 Reversal | `cancel` via executor; `void`/`refund` fail closed — no cancel alias |
| 8 Ops | Kill switch + ops collector wired into `MoneyPathExecutor`; env `OTAIP_MUTATION_KILL_SWITCH=1` |

## Tests

- `packages/adapters/duffel/src/__tests__/money-path.test.ts` — 503 → one POST, replay no re-POST
- `packages/connect/src/__tests__/guarded-adapter.test.ts`
- `packages/core/src/money-path/__tests__/money-path-executor.test.ts`
- `packages/core/src/pipeline-validator/__tests__/approval-before-execute.test.ts`

CI green on this branch (lint + typecheck + full test suite).

## Not claimed

Still not a turnkey OTA/TMC. No live credentials in repo. Duffel flight cancel unsupported by design. Connect `BookingPipeline`/`PaymentHandoff` remain stubs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3359bdd7-0df8-450b-8493-63132da9a593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3359bdd7-0df8-450b-8493-63132da9a593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

