### PR TITLE
fix: honest production DoD 8/8 — default-enforced money-path safety

### DIFF
--- a/docs/engineering/PRODUCTION_DOD_SCORECARD.md
+++ b/docs/engineering/PRODUCTION_DOD_SCORECARD.md
@@ -8,17 +8,19 @@
 | `opt-in` | Control exists but callers can skip it |
 | `unwired` | Primitive only; not on live paths |
 
+Covered money-path surfaces: Connect `createAdapter` (including HAIP), Duffel, Hotelbeds, orchestrator live approvals.
+
 | # | Criterion | Status | Enforcement | Evidence |
 |---|---|---|---|---|
-| 1 | Mutations safe | PASS | default | `GuardedConnectAdapter` via `createAdapter()`; Duffel `book`/`bookCar`/`cancelCar` via `MoneyPathExecutor` + `fetchOnce` on unsafe POSTs; drills in `packages/adapters/duffel/src/__tests__/money-path.test.ts`, `packages/connect/src/__tests__/guarded-adapter.test.ts` |
-| 2 | Money state survives crash | PASS | default* | Effect ledger replay + concurrent idempotency; durable SM uses `compareAndSet` OCC (`DurablePaymentConfirmationStateMachine`); *live mode refuses ephemeral stores |
-| 3 | Persistence can do #2 | PASS | default | CAS APIs + `FileCompareAndSwapPersistenceAdapter`; `MoneyPathExecutor` / live mode refuse ephemeral/mock irreversible ops |
-| 4 | Supplier backpressure real | PASS | default | `BaseAdapter` rate limiter on by default + CB; Duffel per-credential RL+CB on HTTP path |
+| 1 | Mutations safe | PASS | default | `GuardedConnectAdapter` via `createAdapter()`; Duffel/Hotelbeds/HAIP mutations via `MoneyPathExecutor` + `fetchOnce` on unsafe Hotelbeds/Duffel paths; HAIP registered in `createAdapter`. Drills: `packages/adapters/duffel/src/__tests__/money-path.test.ts`, `packages/adapters/hotelbeds/src/__tests__/money-path.test.ts`, `packages/connect/src/suppliers/haip/__tests__/money-path.test.ts`, `packages/connect/src/__tests__/guarded-adapter.test.ts` — 503/timeout → one wire call; replay → zero additional; `OUTCOME_UNKNOWN` |
+| 2 | Money state survives crash | PASS | default | Effect ledger replay + concurrent idempotency; `listUnresolved` includes aged `pending` crash-left records (`money-path-executor.test.ts`). Live refuses ephemeral ledgers. |
+| 3 | Persistence can do #2 | PASS | default | Store-declared `durability` on `EffectLedger` / CAS adapters; `InMemory*=ephemeral`, `File*=durable`; `MoneyPathExecutor` reads ledger durability and rejects ephemeral→durable upgrade; `FileEffectLedger` live book drill in `money-path-executor.test.ts` |
+| 4 | Supplier backpressure real | PASS | default | `BaseAdapter` RL+CB on by default; Duffel/Hotelbeds RL+CB on `request()`; `RateLimiter` serializes concurrent waiters — `rate-limiter.test.ts` (10@limit1) |
 | 5 | Live tickets not invented | PASS | default | `issueTickets` liveMode guard; example OTA Duffel path uses order documents only (no synthetic serials in live) |
-| 6 | Irreversible LLM gate has teeth | PASS | default | `action_class` **before** `execute` for mutations; live mode requires HMAC secret + single-use consume; shape-only banned in live (`approval-before-execute.test.ts`) |
-| 7 | Reversal works | PASS | default | `cancel` via executor; `void`/`refund` **fail closed** (`UnsupportedReversalError`) — no cancel alias; Duffel flight cancel refuses |
-| 8 | Ops see/stop damage | PASS | default | `MutationOpsCollector` + process kill switch wired into `MoneyPathExecutor`; env `OTAIP_MUTATION_KILL_SWITCH=1`; orchestrator uses same switch |
+| 6 | Irreversible LLM gate has teeth | PASS | default | `action_class` before `execute` for mutations; tokens use `createHmac('sha256')` with `v1.` prefix (`bound-approval.test.ts`); `CasBoundApprovalTokenStore` durable single-use; live orchestrator refuses ephemeral token store; forged/legacy-hash-concat/replay-across-CAS-instances/expired/wrong-hash rejected (`approval-before-execute.test.ts`, `bound-approval.test.ts`) |
+| 7 | Reversal works | PASS | default | `executeReversal` requires shared `MutationExecutor` (no `liveMode:false` fresh-ledger default); `void`/`refund` fail closed; cancel idempotent across shared executor (`mutation-executor.test.ts`); Duffel flight cancel / Hotelbeds activity+transfer cancel refuse rather than invent |
+| 8 | Ops see/stop damage | PASS | default | Process-global `MutationOpsCollector` + kill switch on `MoneyPathExecutor`; `effectType`→`BookingFailureStage` 1:1 (refund→`refund`); env `OTAIP_MUTATION_KILL_SWITCH=1`; orchestrator uses same switch |
 
 **Score: 8 / 8 PASS** under **default-enforced** definition (library drills + fault injection).
 
-Still not a turnkey OTA/TMC: no real credentials in repo, Duffel flight cancel unsupported by design, Connect `BookingPipeline`/`PaymentHandoff` remain labeled stubs. Live supplier credentials remain deployer-owned.
+Still not a turnkey OTA/TMC: no real credentials in repo; Duffel flight cancel unsupported by design; Hotelbeds activity/transfer cancel fail closed pending DOMAIN_QUESTION; Connect `BookingPipeline`/`PaymentHandoff` remain labeled stubs. Live supplier credentials remain deployer-owned.

--- a/examples/ota/src/__tests__/duffel-ota-adapter.test.ts
+++ b/examples/ota/src/__tests__/duffel-ota-adapter.test.ts
@@ -88,7 +88,11 @@ describe('DuffelOtaAdapter', () => {
   let adapter: DuffelOtaAdapter;
 
   beforeEach(() => {
-    duffel = new DuffelAdapter('duffel_test_key');
+    duffel = new DuffelAdapter({
+      apiKey: 'duffel_test_key',
+      baseUrl: 'https://api.test.duffel.local',
+      liveMode: false,
+    });
     adapter = new DuffelOtaAdapter(duffel);
   });
 

--- a/packages/adapters/duffel/src/__tests__/cars.test.ts
+++ b/packages/adapters/duffel/src/__tests__/cars.test.ts
@@ -175,7 +175,7 @@ describe('DuffelAdapter.searchCars', () => {
     await adapter.searchCars(SEARCH_REQUEST);
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe('https://api.duffel.com/cars/search');
+    expect(calls[0]!.url).toBe('https://api.test.duffel.local/cars/search');
     expect(calls[0]!.init.method).toBe('POST');
     const body = JSON.parse(calls[0]!.init.body as string);
     expect(body).toEqual({
@@ -316,7 +316,7 @@ describe('DuffelAdapter.quoteCar', () => {
   it('posts /cars/quotes with rate_id wrapped in data', async () => {
     const { calls } = captureFetch([{ status: 200, body: QUOTE_RESPONSE }]);
     await adapter.quoteCar('rae_test_alpha');
-    expect(calls[0]!.url).toBe('https://api.duffel.com/cars/quotes');
+    expect(calls[0]!.url).toBe('https://api.test.duffel.local/cars/quotes');
     expect(calls[0]!.init.method).toBe('POST');
     expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
       data: { rate_id: 'rae_test_alpha' },
@@ -371,7 +371,7 @@ describe('DuffelAdapter.bookCar', () => {
       metadata: { trip: 'business' },
       inboundFlightNumber: 'BA123',
     });
-    expect(calls[0]!.url).toBe('https://api.duffel.com/cars/bookings');
+    expect(calls[0]!.url).toBe('https://api.test.duffel.local/cars/bookings');
     const body = JSON.parse(calls[0]!.init.body as string);
     expect(body).toEqual({
       data: {
@@ -436,7 +436,7 @@ describe('DuffelAdapter.getCarBooking', () => {
     const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
     const result = await adapter.getCarBooking('boo_test_001');
-    expect(calls[0]!.url).toBe('https://api.duffel.com/cars/bookings/boo_test_001');
+    expect(calls[0]!.url).toBe('https://api.test.duffel.local/cars/bookings/boo_test_001');
     expect(calls[0]!.init.method).toBe('GET');
     expect(result.bookingId).toBe('boo_test_001');
   });
@@ -455,7 +455,7 @@ describe('DuffelAdapter.cancelCarBooking', () => {
     const { calls } = captureFetch([{ status: 200, body: CANCEL_RESPONSE }]);
     const result = await adapter.cancelCarBooking('boo_test_001');
     expect(calls[0]!.url).toBe(
-      'https://api.duffel.com/cars/bookings/boo_test_001/actions/cancel',
+      'https://api.test.duffel.local/cars/bookings/boo_test_001/actions/cancel',
     );
     expect(calls[0]!.init.method).toBe('POST');
     expect(result.status).toBe('cancelled');

--- a/packages/adapters/duffel/src/__tests__/cars.test.ts
+++ b/packages/adapters/duffel/src/__tests__/cars.test.ts
@@ -166,7 +166,7 @@ afterEach(() => {
 describe('DuffelAdapter.searchCars', () => {
   let adapter: DuffelAdapter;
   beforeEach(() => {
-    adapter = new DuffelAdapter('duffel_test_key');
+    adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
   });
 
   it('hits POST /cars/search with the brief-shape body', async () => {
@@ -310,7 +310,7 @@ describe('DuffelAdapter.searchCars', () => {
 describe('DuffelAdapter.quoteCar', () => {
   let adapter: DuffelAdapter;
   beforeEach(() => {
-    adapter = new DuffelAdapter('duffel_test_key');
+    adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
   });
 
   it('posts /cars/quotes with rate_id wrapped in data', async () => {
@@ -353,7 +353,7 @@ describe('DuffelAdapter.quoteCar', () => {
 describe('DuffelAdapter.bookCar', () => {
   let adapter: DuffelAdapter;
   beforeEach(() => {
-    adapter = new DuffelAdapter('duffel_test_key');
+    adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
   });
 
   it('posts /cars/bookings with the brief-shape body', async () => {
@@ -433,7 +433,7 @@ describe('DuffelAdapter.bookCar', () => {
 
 describe('DuffelAdapter.getCarBooking', () => {
   it('GETs /cars/bookings/{id}', async () => {
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
     const result = await adapter.getCarBooking('boo_test_001');
     expect(calls[0]!.url).toBe('https://api.duffel.com/cars/bookings/boo_test_001');
@@ -442,7 +442,7 @@ describe('DuffelAdapter.getCarBooking', () => {
   });
 
   it('URL-encodes the booking id', async () => {
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     const { calls } = captureFetch([{ status: 200, body: BOOKING_RESPONSE }]);
     await adapter.getCarBooking('boo /weird');
     expect(calls[0]!.url).toContain('boo%20%2Fweird');
@@ -451,7 +451,7 @@ describe('DuffelAdapter.getCarBooking', () => {
 
 describe('DuffelAdapter.cancelCarBooking', () => {
   it('POSTs /cars/bookings/{id}/actions/cancel', async () => {
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     const { calls } = captureFetch([{ status: 200, body: CANCEL_RESPONSE }]);
     const result = await adapter.cancelCarBooking('boo_test_001');
     expect(calls[0]!.url).toBe(

--- a/packages/adapters/duffel/src/__tests__/duffel-adapter.test.ts
+++ b/packages/adapters/duffel/src/__tests__/duffel-adapter.test.ts
@@ -122,7 +122,7 @@ describe('DuffelAdapter constructor', () => {
   });
 
   it('creates adapter with valid key', () => {
-    const adapter = new DuffelAdapter('duffel_test_abc123');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_abc123', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     expect(adapter.name).toBe('duffel');
   });
 });
@@ -134,7 +134,7 @@ describe('DuffelAdapter constructor', () => {
 describe('DuffelAdapter search', () => {
   let adapter: DuffelAdapter;
   beforeEach(() => {
-    adapter = new DuffelAdapter('duffel_test_key');
+    adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
   });
 
   it('returns mapped offers from API response', async () => {
@@ -259,7 +259,7 @@ describe('DuffelAdapter search', () => {
 describe('DuffelAdapter price', () => {
   let adapter: DuffelAdapter;
   beforeEach(() => {
-    adapter = new DuffelAdapter('duffel_test_key');
+    adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
   });
 
   it('returns priced offer', async () => {
@@ -295,19 +295,19 @@ describe('DuffelAdapter price', () => {
 describe('DuffelAdapter isAvailable', () => {
   it('returns true when API responds 200', async () => {
     mockFetchResponse(200, { data: [] });
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     expect(await adapter.isAvailable()).toBe(true);
   });
 
   it('returns false on network failure', async () => {
     mockFetchNetworkError('ECONNREFUSED');
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     expect(await adapter.isAvailable()).toBe(false);
   });
 
   it('returns false on 401', async () => {
     mockFetchResponse(401, { errors: [{ message: 'Invalid token' }] });
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     expect(await adapter.isAvailable()).toBe(false);
   });
 });
@@ -319,7 +319,7 @@ describe('DuffelAdapter isAvailable', () => {
 describe('DuffelAdapter error handling', () => {
   let adapter: DuffelAdapter;
   beforeEach(() => {
-    adapter = new DuffelAdapter('duffel_test_key');
+    adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
   });
 
   it('throws on network failure with clear message', async () => {
@@ -512,7 +512,7 @@ describe('mapOrderToBookResponse', () => {
 describe('DuffelAdapter getOrder', () => {
   it('GETs /air/orders/{id} and returns enriched BookResponse', async () => {
     mockFetchResponse(200, { data: SAMPLE_ORDER });
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
 
     const result = await adapter.getOrder('ord_00009hthhsUZ8W4LxQgkjo');
 
@@ -529,7 +529,7 @@ describe('DuffelAdapter getOrder', () => {
 
   it('throws when order payload is missing', async () => {
     mockFetchResponse(200, { data: null });
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     await expect(adapter.getOrder('ord_missing')).rejects.toThrow('not found');
   });
 });
@@ -562,7 +562,7 @@ describe('DuffelAdapter book', () => {
         }),
     );
 
-    const adapter = new DuffelAdapter('duffel_test_key');
+    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', baseUrl: 'https://api.test.duffel.local', liveMode: false });
     const result = await adapter.book({
       offer_id: 'off_test_123',
       passengers: [

--- a/packages/adapters/duffel/src/__tests__/duffel-adapter.test.ts
+++ b/packages/adapters/duffel/src/__tests__/duffel-adapter.test.ts
@@ -522,7 +522,7 @@ describe('DuffelAdapter getOrder', () => {
 
     const fetchCall = vi.mocked(fetch).mock.calls[0]!;
     expect(fetchCall[0]).toBe(
-      'https://api.duffel.com/air/orders/ord_00009hthhsUZ8W4LxQgkjo',
+      'https://api.test.duffel.local/air/orders/ord_00009hthhsUZ8W4LxQgkjo',
     );
     expect((fetchCall[1] as RequestInit).method).toBe('GET');
   });

--- a/packages/adapters/duffel/src/__tests__/money-path.test.ts
+++ b/packages/adapters/duffel/src/__tests__/money-path.test.ts
@@ -51,6 +51,7 @@ describe('Duffel money-path book', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const adapter = new DuffelAdapter({
+      baseUrl: 'https://api.test.duffel.local',
       apiKey: 'duffel_test_key',
       liveMode: false,
     });
@@ -96,7 +97,9 @@ describe('Duffel money-path book', () => {
       }),
     );
 
-    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', liveMode: false });
+    const adapter = new DuffelAdapter({
+      baseUrl: 'https://api.test.duffel.local',
+ apiKey: 'duffel_test_key', liveMode: false });
     await expect(
       adapter.book({
         offer_id: 'off_1',
@@ -117,14 +120,18 @@ describe('Duffel money-path book', () => {
   });
 
   it('requires idempotencyKey in live mode', async () => {
-    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', liveMode: true });
+    const adapter = new DuffelAdapter({
+      baseUrl: 'https://api.test.duffel.local',
+ apiKey: 'duffel_test_key', liveMode: true });
     await expect(
       adapter.book({ offer_id: 'off_1', passengers: PASSENGERS }),
     ).rejects.toThrow(/idempotencyKey/);
   });
 
   it('flight cancel fails closed', async () => {
-    const adapter = new DuffelAdapter({ apiKey: 'duffel_test_key', liveMode: false });
+    const adapter = new DuffelAdapter({
+      baseUrl: 'https://api.test.duffel.local',
+ apiKey: 'duffel_test_key', liveMode: false });
     await expect(adapter.cancelFlightBooking('ord_1')).rejects.toThrow(/not supported/);
   });
 });

--- a/packages/adapters/duffel/src/duffel-adapter.ts
+++ b/packages/adapters/duffel/src/duffel-adapter.ts
@@ -490,7 +490,10 @@ export class DuffelAdapter implements DistributionAdapter {
     }
     this.apiKey = resolvedKey;
     this.baseUrl = options.baseUrl ?? DUFFEL_BASE_URL;
-    this.liveMode = options.liveMode ?? isLiveModeFromEnv();
+    // Production Duffel endpoint forces live — cannot override off.
+    const productionEndpoint =
+      this.baseUrl === DUFFEL_BASE_URL || this.baseUrl.startsWith(`${DUFFEL_BASE_URL}/`);
+    this.liveMode = productionEndpoint ? true : (options.liveMode ?? isLiveModeFromEnv());
     this.rateLimiter = new RateLimiter({ maxRequests: 50, windowMs: 1_000 });
     this.circuitBreaker = new CircuitBreaker({
       name: 'duffel',
@@ -498,10 +501,12 @@ export class DuffelAdapter implements DistributionAdapter {
       resetMs: 30_000,
     });
     this.moneyPath = new MoneyPathExecutor({
-      liveMode: this.liveMode,
-      storeDurability: options.storeDurability ?? options.moneyPath?.storeDurability ?? 'ephemeral',
       reconcileHint: 'getOrder',
       ...options.moneyPath,
+      liveMode: this.liveMode,
+      ...(options.storeDurability !== undefined
+        ? { storeDurability: options.storeDurability }
+        : {}),
     });
   }
 

--- a/packages/adapters/hotelbeds/src/__tests__/activities-adapter.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/activities-adapter.test.ts
@@ -358,39 +358,10 @@ describe('HotelbedsAdapter.cancelActivity', () => {
     adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
   });
 
-  it('sends DELETE /activities/booking/{ref}', async () => {
-    const { calls } = captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
-    await adapter.cancelActivity('HB-ACT-9001');
-    expect(calls[0]!.url).toBe(
-      'https://api.test.hotelbeds.com/activity-api/3.0/activities/booking/HB-ACT-9001',
+  it('fails closed — activity cancel HTTP contract undocumented (DOMAIN_QUESTION)', async () => {
+    await expect(adapter.cancelActivity('HB-ACT-9001')).rejects.toThrow(
+      /DOMAIN_QUESTION|not wired|undocumented/i,
     );
-    expect(calls[0]!.init.method).toBe('DELETE');
-  });
-
-  it('returns the cancellation reference', async () => {
-    captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
-    const result = await adapter.cancelActivity('HB-ACT-9001');
-    expect(result).toEqual({
-      status: 'CANCELLED',
-      cancellationReference: 'CXL-HB-ACT-9001',
-    });
-  });
-
-  it('falls back to booking reference when cancellationReference is missing', async () => {
-    captureFetch([
-      {
-        status: 200,
-        body: { booking: { reference: 'HB-ACT-9001', status: 'CANCELLED' } },
-      },
-    ]);
-    const result = await adapter.cancelActivity('HB-ACT-9001');
-    expect(result.cancellationReference).toBe('HB-ACT-9001');
-  });
-
-  it('URL-encodes the booking reference', async () => {
-    const { calls } = captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
-    await adapter.cancelActivity('HB ACT/01');
-    expect(calls[0]!.url).toContain('HB%20ACT%2F01');
   });
 });
 

--- a/packages/adapters/hotelbeds/src/__tests__/activities-integration.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/activities-integration.test.ts
@@ -48,12 +48,11 @@ describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Activities — sandbox integration'
   });
 
   afterAll(async () => {
+    // Activity cancel is fail-closed pending DOMAIN_QUESTION — no adapter cleanup.
     if (bookingRef && !cancelled) {
-      try {
-        await adapter.cancelActivity(bookingRef);
-      } catch (err) {
-        console.warn(`[activities-integration] cleanup cancel failed for ${bookingRef}:`, err);
-      }
+      console.warn(
+        `[activities-integration] left sandbox booking ${bookingRef} (cancel not wired)`,
+      );
     }
   });
 
@@ -89,14 +88,9 @@ describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Activities — sandbox integration'
     bookingRef = result.bookingReference;
   });
 
-  it('cancelActivity returns a cancellation reference', async () => {
-    if (!bookingRef) {
-      console.warn('Skipping cancel: no booking reference from book step');
-      return;
-    }
-    const result = await adapter.cancelActivity(bookingRef);
-    expect(result.status).toBe('CANCELLED');
-    expect(result.cancellationReference.length).toBeGreaterThan(0);
-    cancelled = true;
+  it('cancelActivity fails closed until DOMAIN_QUESTION resolved', async () => {
+    await expect(adapter.cancelActivity(bookingRef ?? 'NOREF')).rejects.toThrow(
+      /DOMAIN_QUESTION|not wired|undocumented/i,
+    );
   });
 });

--- a/packages/adapters/hotelbeds/src/__tests__/money-path.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/money-path.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Hotelbeds money-path: fetchOnce on book/hard-cancel; ledger once-only.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { HotelbedsAdapter } from '../hotelbeds-adapter.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const BOOK_BODY = {
+  holder: { name: 'Test', surname: 'User' },
+  rooms: [
+    {
+      rateKey: 'rk-1',
+      paxes: [{ roomId: 1, type: 'AD' as const, name: 'Test', surname: 'User' }],
+    },
+  ],
+  clientReference: 'AVR-1',
+};
+
+describe('Hotelbeds money-path book', () => {
+  it('POST /bookings attempted exactly once on 503', async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ error: { message: 'unavailable' } }), {
+        status: 503,
+        statusText: 'Service Unavailable',
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const adapter = new HotelbedsAdapter({
+      apiKey: 'k',
+      secret: 's',
+      environment: 'test',
+      liveMode: false,
+    });
+
+    await expect(
+      adapter.book(BOOK_BODY, { idempotencyKey: 'hb-book-503' }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('replay same idempotency key does not POST again after unknown', async () => {
+    let posts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        posts += 1;
+        return new Response('', { status: 503, statusText: 'Service Unavailable' });
+      }),
+    );
+
+    const adapter = new HotelbedsAdapter({
+      apiKey: 'k',
+      secret: 's',
+      environment: 'test',
+      liveMode: false,
+    });
+
+    await expect(
+      adapter.book(BOOK_BODY, { idempotencyKey: 'hb-book-replay' }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(
+      adapter.book(BOOK_BODY, { idempotencyKey: 'hb-book-replay' }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+
+    expect(posts).toBe(1);
+  });
+
+  it('requires idempotencyKey in live mode', async () => {
+    const adapter = new HotelbedsAdapter({
+      apiKey: 'k',
+      secret: 's',
+      environment: 'test',
+      liveMode: true,
+    });
+    await expect(adapter.book(BOOK_BODY)).rejects.toThrow(/idempotencyKey/);
+  });
+
+  it('production environment forces live (cannot override off)', () => {
+    const adapter = new HotelbedsAdapter({
+      apiKey: 'k',
+      secret: 's',
+      environment: 'production',
+      liveMode: false,
+    });
+    expect(adapter.moneyPathExecutor.safetyConfig.liveMode).toBe(true);
+  });
+
+  it('hard cancel CANCELLATION is once-only on 503', async () => {
+    let deletes = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        deletes += 1;
+        return new Response('', { status: 503, statusText: 'Service Unavailable' });
+      }),
+    );
+    const adapter = new HotelbedsAdapter({
+      apiKey: 'k',
+      secret: 's',
+      environment: 'test',
+      liveMode: false,
+    });
+    await expect(
+      adapter.cancelBooking('REF1', 'CANCELLATION', { idempotencyKey: 'hb-cxl' }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(
+      adapter.cancelBooking('REF1', 'CANCELLATION', { idempotencyKey: 'hb-cxl' }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(deletes).toBe(1);
+  });
+});

--- a/packages/adapters/hotelbeds/src/__tests__/transfers-adapter.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/transfers-adapter.test.ts
@@ -331,21 +331,9 @@ describe('HotelbedsAdapter.cancelTransfer', () => {
     adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
   });
 
-  it('sends DELETE /bookings/{ref}', async () => {
-    const { calls } = captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
-    await adapter.cancelTransfer('HB-TRF-3001');
-    expect(calls[0]!.url).toBe(
-      'https://api.test.hotelbeds.com/transfer-api/1.0/bookings/HB-TRF-3001',
+  it('fails closed — transfer cancel HTTP contract undocumented (DOMAIN_QUESTION)', async () => {
+    await expect(adapter.cancelTransfer('HB-TRF-3001')).rejects.toThrow(
+      /DOMAIN_QUESTION|not wired|undocumented/i,
     );
-    expect(calls[0]!.init.method).toBe('DELETE');
-  });
-
-  it('returns the cancellation reference', async () => {
-    captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
-    const result = await adapter.cancelTransfer('HB-TRF-3001');
-    expect(result).toEqual({
-      status: 'CANCELLED',
-      cancellationReference: 'CXL-HB-TRF-3001',
-    });
   });
 });

--- a/packages/adapters/hotelbeds/src/__tests__/transfers-integration.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/transfers-integration.test.ts
@@ -46,12 +46,11 @@ describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Transfers — sandbox integration',
   });
 
   afterAll(async () => {
+    // Transfer cancel is fail-closed pending DOMAIN_QUESTION — no adapter cleanup.
     if (bookingRef && !cancelled) {
-      try {
-        await adapter.cancelTransfer(bookingRef);
-      } catch (err) {
-        console.warn(`[transfers-integration] cleanup cancel failed for ${bookingRef}:`, err);
-      }
+      console.warn(
+        `[transfers-integration] left sandbox booking ${bookingRef} (cancel not wired)`,
+      );
     }
   });
 
@@ -89,14 +88,9 @@ describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Transfers — sandbox integration',
     bookingRef = result.bookingReference;
   });
 
-  it('cancelTransfer returns a cancellation reference', async () => {
-    if (!bookingRef) {
-      console.warn('Skipping cancel: no booking reference from book step');
-      return;
-    }
-    const result = await adapter.cancelTransfer(bookingRef);
-    expect(result.status).toBe('CANCELLED');
-    expect(result.cancellationReference.length).toBeGreaterThan(0);
-    cancelled = true;
+  it('cancelTransfer fails closed until DOMAIN_QUESTION resolved', async () => {
+    await expect(adapter.cancelTransfer(bookingRef ?? 'NOREF')).rejects.toThrow(
+      /DOMAIN_QUESTION|not wired|undocumented/i,
+    );
   });
 });

--- a/packages/adapters/hotelbeds/src/activities-types.ts
+++ b/packages/adapters/hotelbeds/src/activities-types.ts
@@ -76,6 +76,8 @@ export interface ActivityBookRequest {
   paxes: Array<{ age: number }>;
   holder: { name: string; surname: string };
   clientReference: string;
+  /** Required in live mode for money-path idempotency. */
+  idempotencyKey?: string;
   signal?: AbortSignal;
 }
 

--- a/packages/adapters/hotelbeds/src/hotelbeds-adapter.ts
+++ b/packages/adapters/hotelbeds/src/hotelbeds-adapter.ts
@@ -7,23 +7,20 @@
  *   - The full Hotels lifecycle (availability, checkrate, book, retrieve,
  *     cancel) as direct methods on this class.
  *
- * Endpoints used:
- *   POST   /hotel-api/1.0/availability
- *   POST   /hotel-api/1.0/checkrates
- *   POST   /hotel-api/1.0/bookings
- *   GET    /hotel-api/1.0/bookings/{ref}
- *   GET    /hotel-api/1.0/bookings
- *   DELETE /hotel-api/1.0/bookings/{ref}?cancellationFlag={SIMULATION|CANCELLATION}
- *   GET    /hotel-api/1.0/status                 (health)
- *
- * Retry policy is delegated to `fetchWithRetry`, which retries 5xx, 429,
- * and network errors. 4xx other than 429 is surfaced as an error.
- *
- * Hotelbeds test sandbox is rate-limited to 50 requests/day. The adapter
- * does NOT enforce that client-side; callers are expected to throttle.
+ * Unsafe mutations (book POST, hard-cancel DELETE) use fetchOnce + MoneyPathExecutor.
+ * Safe reads/search/checkrate/simulation cancel keep fetchWithRetry.
  */
 
-import { fetchWithRetry } from '@otaip/core';
+import {
+  CircuitBreaker,
+  CircuitOpenError,
+  fetchOnce,
+  fetchWithRetry,
+  isLiveModeFromEnv,
+  MoneyPathError,
+  MoneyPathExecutor,
+  RateLimiter,
+} from '@otaip/core';
 import type { RawHotelResult } from '@otaip/agents-lodging';
 
 import { buildAuthHeaders, type HotelbedsCredentials } from './auth.js';
@@ -31,12 +28,10 @@ import { mapHotelToRawResult, summarizeBooking, type BookingSummary } from './fi
 import {
   mapActivityAvailability,
   mapActivityBookingResponse,
-  mapActivityCancellation,
 } from './activities-mapper.js';
 import {
   mapTransferAvailability,
   mapTransferBookingResponse,
-  mapTransferCancellation,
 } from './transfers-mapper.js';
 import type {
   HotelbedsAdapterConfig,
@@ -63,14 +58,12 @@ import type {
   HotelbedsActivitiesAvailabilityResponse,
   HotelbedsActivitiesBookingRequest,
   HotelbedsActivitiesBookingResponse,
-  HotelbedsActivitiesCancellationResponse,
 } from './activities-types.js';
 import type {
   HotelbedsTransfersAvailabilityRequest,
   HotelbedsTransfersAvailabilityResponse,
   HotelbedsTransfersBookingRequest,
   HotelbedsTransfersBookingResponse,
-  HotelbedsTransfersCancellationResponse,
   TransferBookRequest,
   TransferBookResponse,
   TransferCancelResponse,
@@ -93,13 +86,41 @@ interface RequestOptions {
   signal?: AbortSignal;
 }
 
-/**
- * The `HotelSourceAdapter` interface lives in `@otaip/agents-lodging`. We
- * re-state it locally to keep this package's dependency surface narrow and
- * avoid a circular import — the lodging package is allowed to depend on
- * adapters in future iterations.
- */
 export type { HotelSearchParams, HotelSourceAdapter } from './lodging-source-interface.js';
+
+export interface HotelbedsBookOptions {
+  /** Required in live mode — same key → at most one supplier book. */
+  idempotencyKey?: string;
+}
+
+function isUnsafeHotelbedsPath(method: string, path: string): boolean {
+  const upper = method.toUpperCase();
+  const pathOnly = path.split('?')[0] ?? path;
+
+  if (upper === 'POST') {
+    if (pathOnly === `${HOTELS_BASE_PATH}/bookings`) return true;
+    if (pathOnly === `${ACTIVITIES_BASE_PATH}/activities/booking`) return true;
+    if (pathOnly === `${TRANSFERS_BASE_PATH}/bookings`) return true;
+  }
+  if (upper === 'DELETE') {
+    // Hard hotel cancel only — SIMULATION may retry
+    if (
+      pathOnly.startsWith(`${HOTELS_BASE_PATH}/bookings/`) &&
+      path.includes('cancellationFlag=CANCELLATION')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveLiveMode(config: HotelbedsAdapterConfig, environment: HotelbedsEnvironment, baseUrl: string): boolean {
+  const productionUrl = HOTELBEDS_BASE_URLS.production;
+  const forcedLive =
+    environment === 'production' || baseUrl === productionUrl || baseUrl.startsWith(`${productionUrl}/`);
+  if (forcedLive) return true;
+  return config.liveMode ?? isLiveModeFromEnv();
+}
 
 export class HotelbedsAdapter implements HotelSourceAdapter {
   readonly adapterId = 'hotelbeds';
@@ -109,6 +130,10 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
   private readonly baseUrl: string;
   private readonly environment: HotelbedsEnvironment;
   private readonly timeoutMs: number | undefined;
+  private readonly rateLimiter: RateLimiter;
+  private readonly circuitBreaker: CircuitBreaker;
+  private readonly moneyPath: MoneyPathExecutor;
+  private readonly liveMode: boolean;
 
   constructor(config: HotelbedsAdapterConfig = {}) {
     const apiKey = config.apiKey ?? process.env['HOTELBEDS_API_KEY'] ?? '';
@@ -125,28 +150,43 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
       );
     }
 
-    const envFromArgsOrEnv = config.environment ?? (process.env['HOTELBEDS_ENV'] as HotelbedsEnvironment | undefined);
+    const envFromArgsOrEnv =
+      config.environment ?? (process.env['HOTELBEDS_ENV'] as HotelbedsEnvironment | undefined);
     this.environment = envFromArgsOrEnv === 'production' ? 'production' : 'test';
     this.baseUrl = config.baseUrl ?? HOTELBEDS_BASE_URLS[this.environment];
     this.credentials = { apiKey, secret };
     this.timeoutMs = config.timeoutMs;
+    this.liveMode = resolveLiveMode(config, this.environment, this.baseUrl);
+
+    this.rateLimiter = new RateLimiter({ maxRequests: 50, windowMs: 1_000 });
+    this.circuitBreaker = new CircuitBreaker({
+      name: 'hotelbeds',
+      failureThreshold: 5,
+      resetMs: 30_000,
+    });
+
+    this.moneyPath = new MoneyPathExecutor({
+      reconcileHint: 'getBookingStatus',
+      ...config.moneyPath,
+      liveMode: this.liveMode,
+      ...(config.storeDurability !== undefined
+        ? { storeDurability: config.storeDurability }
+        : {}),
+    });
+  }
+
+  get moneyPathExecutor(): MoneyPathExecutor {
+    return this.moneyPath;
+  }
+
+  getCircuitBreakerStatus(): ReturnType<CircuitBreaker['getStatus']> {
+    return this.circuitBreaker.getStatus();
   }
 
   // -------------------------------------------------------------------------
   // HotelSourceAdapter — search bridge
   // -------------------------------------------------------------------------
 
-  /**
-   * Adapts the search-aggregator's `HotelSearchParams` to a Hotelbeds
-   * availability request and maps the response back to `RawHotelResult[]`.
-   *
-   * Destination handling: Hotelbeds expects a destination *code* (its own
-   * 3-letter identifier). When the caller hands us anything else we pass
-   * it through verbatim — Hotelbeds returns an empty result set rather
-   * than a 4xx for unknown codes. Resolving free-text destinations to
-   * Hotelbeds destination codes is the search-aggregator's job, not the
-   * adapter's.
-   */
   async searchHotels(params: HotelSearchParams): Promise<RawHotelResult[]> {
     const start = Date.now();
     const occupancies = [
@@ -176,11 +216,6 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
     );
   }
 
-  /**
-   * Implementation of `HotelSourceAdapter.isAvailable`. Hits the Hotelbeds
-   * `/status` endpoint, which is small and cheap (counts toward the
-   * sandbox 50/day quota — call sparingly).
-   */
   async isAvailable(): Promise<boolean> {
     try {
       await this.request('GET', `${HOTELS_BASE_PATH}/status`);
@@ -210,12 +245,33 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
     )) as HotelbedsCheckRateResponse;
   }
 
-  async book(request: HotelbedsBookingRequest): Promise<HotelbedsBookingResponse> {
-    return (await this.request(
-      'POST',
-      `${HOTELS_BASE_PATH}/bookings`,
-      request,
-    )) as HotelbedsBookingResponse;
+  async book(
+    request: HotelbedsBookingRequest,
+    options?: HotelbedsBookOptions,
+  ): Promise<HotelbedsBookingResponse> {
+    const key = options?.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HotelbedsAdapter.book requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `hotelbeds-book:${request.clientReference ?? 'noref'}`;
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'book',
+      idempotencyKey,
+      request: {
+        clientReference: request.clientReference,
+        holder: request.holder,
+      },
+      supplierId: 'hotelbeds',
+      fn: () =>
+        this.request(
+          'POST',
+          `${HOTELS_BASE_PATH}/bookings`,
+          request,
+        ) as Promise<HotelbedsBookingResponse>,
+    });
   }
 
   async getBooking(reference: string): Promise<HotelbedsBookingResponse> {
@@ -245,26 +301,38 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
    *   1. Call with `flag = 'SIMULATION'` to preview the penalty.
    *   2. Call with `flag = 'CANCELLATION'` to actually cancel.
    *
-   * Callers (the hotel-modification agent) are responsible for the
-   * simulate-then-confirm flow.
+   * Hard cancel (CANCELLATION) goes through MoneyPathExecutor + fetchOnce.
    */
   async cancelBooking(
     reference: string,
     flag: HotelbedsCancellationFlag = 'SIMULATION',
+    options?: HotelbedsBookOptions,
   ): Promise<HotelbedsCancellationResponse> {
-    return (await this.request(
-      'DELETE',
-      `${HOTELS_BASE_PATH}/bookings/${encodeURIComponent(reference)}?cancellationFlag=${flag}`,
-    )) as HotelbedsCancellationResponse;
+    const path = `${HOTELS_BASE_PATH}/bookings/${encodeURIComponent(reference)}?cancellationFlag=${flag}`;
+
+    if (flag !== 'CANCELLATION') {
+      return (await this.request('DELETE', path)) as HotelbedsCancellationResponse;
+    }
+
+    const key = options?.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HotelbedsAdapter.cancelBooking (CANCELLATION) requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `hotelbeds-cancel:${reference}`;
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'cancelBooking',
+      idempotencyKey,
+      request: { reference, flag },
+      supplierId: 'hotelbeds',
+      fn: () => this.request('DELETE', path) as Promise<HotelbedsCancellationResponse>,
+    });
   }
 
   // -------------------------------------------------------------------------
   // Activities API — search / book / cancel
-  //
-  // Endpoints under /activity-api/3.0. Auth and retry policy are inherited
-  // from the shared `request()` helper. See
-  // `docs/knowledge-base/activities.md` for the authoritative domain input
-  // and outstanding DOMAIN_QUESTIONs.
   // -------------------------------------------------------------------------
 
   async searchActivities(request: ActivitySearchRequest): Promise<ActivityOffer[]> {
@@ -290,6 +358,14 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
   }
 
   async bookActivity(request: ActivityBookRequest): Promise<ActivityBookResponse> {
+    const key = request.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HotelbedsAdapter.bookActivity requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `hotelbeds-activity-book:${request.clientReference}`;
+
     const body: HotelbedsActivitiesBookingRequest = {
       activities: [
         {
@@ -302,36 +378,42 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
       holder: request.holder,
       clientReference: request.clientReference,
     };
-    const response = (await this.request(
-      'POST',
-      `${ACTIVITIES_BASE_PATH}/activities/booking`,
-      body,
-      request.signal ? { signal: request.signal } : {},
-    )) as HotelbedsActivitiesBookingResponse;
-    return mapActivityBookingResponse(response);
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'bookActivity',
+      idempotencyKey,
+      request: {
+        activityCode: request.activityCode,
+        modalityCode: request.modalityCode,
+        clientReference: request.clientReference,
+      },
+      supplierId: 'hotelbeds',
+      fn: async () => {
+        const response = (await this.request(
+          'POST',
+          `${ACTIVITIES_BASE_PATH}/activities/booking`,
+          body,
+          request.signal ? { signal: request.signal } : {},
+        )) as HotelbedsActivitiesBookingResponse;
+        return mapActivityBookingResponse(response);
+      },
+    });
   }
 
   /**
-   * Cancel an activity booking. The HTTP shape (DELETE vs POST,
-   * SIMULATION/CANCELLATION two-step) is not fully documented for
-   * Activities — see DQ-A1 in the KB. The adapter assumes
-   * `DELETE /activity-api/3.0/activities/booking/{ref}`. Update once
-   * verified against the live sandbox.
+   * Activity cancel HTTP contract is not fully documented.
+   * // TODO: DOMAIN_QUESTION: What is the authoritative Hotelbeds Activities
+   * // cancel HTTP shape (method, path, SIMULATION/CANCELLATION flags)?
+   * Fail closed — do not invent the wire call.
    */
-  async cancelActivity(bookingReference: string): Promise<ActivityCancelResponse> {
-    const response = (await this.request(
-      'DELETE',
-      `${ACTIVITIES_BASE_PATH}/activities/booking/${encodeURIComponent(bookingReference)}`,
-    )) as HotelbedsActivitiesCancellationResponse;
-    return mapActivityCancellation(response);
+  async cancelActivity(_bookingReference: string): Promise<ActivityCancelResponse> {
+    throw new MoneyPathError(
+      'Hotelbeds activity cancel is not wired — activity cancel HTTP contract undocumented (DOMAIN_QUESTION). Refusing rather than inventing.',
+    );
   }
 
   // -------------------------------------------------------------------------
   // Transfers API — search / book / cancel
-  //
-  // Endpoints under /transfer-api/1.0. See
-  // `docs/knowledge-base/transfers.md` for outstanding DOMAIN_QUESTIONs
-  // (location code formats, timezone semantics, vehicle taxonomy).
   // -------------------------------------------------------------------------
 
   async searchTransfers(request: TransferSearchRequest): Promise<TransferOffer[]> {
@@ -353,37 +435,57 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
   }
 
   async bookTransfer(request: TransferBookRequest): Promise<TransferBookResponse> {
+    const key = request.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HotelbedsAdapter.bookTransfer requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `hotelbeds-transfer-book:${request.clientReference}`;
+
     const body: HotelbedsTransfersBookingRequest = {
       transferCode: request.transferCode,
       holder: request.holder,
       passengers: request.passengers,
       clientReference: request.clientReference,
     };
-    const response = (await this.request(
-      'POST',
-      `${TRANSFERS_BASE_PATH}/bookings`,
-      body,
-      request.signal ? { signal: request.signal } : {},
-    )) as HotelbedsTransfersBookingResponse;
-    return mapTransferBookingResponse(response);
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'bookTransfer',
+      idempotencyKey,
+      request: {
+        transferCode: request.transferCode,
+        clientReference: request.clientReference,
+      },
+      supplierId: 'hotelbeds',
+      fn: async () => {
+        const response = (await this.request(
+          'POST',
+          `${TRANSFERS_BASE_PATH}/bookings`,
+          body,
+          request.signal ? { signal: request.signal } : {},
+        )) as HotelbedsTransfersBookingResponse;
+        return mapTransferBookingResponse(response);
+      },
+    });
   }
 
   /**
-   * Cancel a transfer booking. Same caveat as `cancelActivity` — DQ-T1.
+   * Transfer cancel HTTP contract is not fully documented.
+   * // TODO: DOMAIN_QUESTION: What is the authoritative Hotelbeds Transfers
+   * // cancel HTTP shape (method, path, flags)?
+   * Fail closed — do not invent the wire call.
    */
-  async cancelTransfer(bookingReference: string): Promise<TransferCancelResponse> {
-    const response = (await this.request(
-      'DELETE',
-      `${TRANSFERS_BASE_PATH}/bookings/${encodeURIComponent(bookingReference)}`,
-    )) as HotelbedsTransfersCancellationResponse;
-    return mapTransferCancellation(response);
+  async cancelTransfer(_bookingReference: string): Promise<TransferCancelResponse> {
+    throw new MoneyPathError(
+      'Hotelbeds transfer cancel is not wired — transfer cancel HTTP contract undocumented (DOMAIN_QUESTION). Refusing rather than inventing.',
+    );
   }
 
   // -------------------------------------------------------------------------
   // Convenience helpers — mapped output
   // -------------------------------------------------------------------------
 
-  /** Run availability + map every hotel to OTAIP `RawHotelResult`. */
   async availabilityRawResults(
     request: HotelbedsAvailabilityRequest,
   ): Promise<RawHotelResult[]> {
@@ -400,9 +502,11 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
     );
   }
 
-  /** Run book + return the OTAIP-friendly summary or null if Hotelbeds returned no booking. */
-  async bookSummary(request: HotelbedsBookingRequest): Promise<BookingSummary | null> {
-    const response = await this.book(request);
+  async bookSummary(
+    request: HotelbedsBookingRequest,
+    options?: HotelbedsBookOptions,
+  ): Promise<BookingSummary | null> {
+    const response = await this.book(request, options);
     if (!response.booking) return null;
     return summarizeBooking(response.booking);
   }
@@ -420,6 +524,17 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
     if (options.signal?.aborted) {
       throw new Error('Hotelbeds API request aborted before dispatch');
     }
+
+    try {
+      this.circuitBreaker.assertClosed();
+    } catch (err) {
+      if (err instanceof CircuitOpenError) {
+        throw new Error(`Hotelbeds API circuit open: ${err.message}`);
+      }
+      throw err;
+    }
+    await this.rateLimiter.acquire();
+
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = {
       ...buildAuthHeaders(this.credentials),
@@ -428,18 +543,21 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
       headers['Content-Type'] = 'application/json';
     }
 
+    const unsafe = isUnsafeHotelbedsPath(method, path);
+    const init: RequestInit = {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    };
+    const fetchOpts = this.timeoutMs !== undefined ? { timeoutMs: this.timeoutMs } : {};
+
     let response: Response;
     try {
-      response = await fetchWithRetry(
-        url,
-        {
-          method,
-          headers,
-          body: body ? JSON.stringify(body) : undefined,
-        },
-        this.timeoutMs !== undefined ? { timeoutMs: this.timeoutMs } : {},
-      );
+      response = unsafe
+        ? await fetchOnce(url, init, fetchOpts)
+        : await fetchWithRetry(url, init, fetchOpts);
     } catch (err: unknown) {
+      this.circuitBreaker.recordFailure();
       const message = err instanceof Error ? err.message : 'Unknown network error';
       throw new Error(`Hotelbeds API network error: ${message}`);
     }
@@ -453,6 +571,10 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
         // ignore parse errors — Hotelbeds occasionally returns text/html on 5xx
       }
 
+      if (response.status === 429 || response.status >= 500) {
+        this.circuitBreaker.recordFailure();
+      }
+
       if (response.status === 429) {
         throw new Error(`Hotelbeds API rate limited (429). ${detail}`.trim());
       }
@@ -461,6 +583,8 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
         `Hotelbeds API error ${response.status}: ${detail || response.statusText}`.trim(),
       );
     }
+
+    this.circuitBreaker.recordSuccess();
 
     // 204 No Content — uncommon but the spec allows it for some empty results.
     if (response.status === 204) return {};

--- a/packages/adapters/hotelbeds/src/transfers-types.ts
+++ b/packages/adapters/hotelbeds/src/transfers-types.ts
@@ -66,6 +66,8 @@ export interface TransferBookRequest {
   holder: { name: string; surname: string };
   passengers: Array<{ type: 'ADULT' | 'CHILD'; name: string; surname: string }>;
   clientReference: string;
+  /** Required in live mode for money-path idempotency. */
+  idempotencyKey?: string;
   signal?: AbortSignal;
 }
 

--- a/packages/adapters/hotelbeds/src/types.ts
+++ b/packages/adapters/hotelbeds/src/types.ts
@@ -13,6 +13,8 @@
  * inventing behavior.
  */
 
+import type { MoneyPathExecutorConfig, StoreDurability } from '@otaip/core';
+
 // ---------------------------------------------------------------------------
 // Adapter configuration
 // ---------------------------------------------------------------------------
@@ -25,8 +27,16 @@ export interface HotelbedsAdapterConfig {
   environment?: HotelbedsEnvironment;
   /** Override the resolved base URL (useful for local mocks). */
   baseUrl?: string;
-  /** Per-request timeout in ms (passed to fetchWithRetry). */
+  /** Per-request timeout in ms (passed to fetchWithRetry / fetchOnce). */
   timeoutMs?: number;
+  /** Money-path executor options (ledger, kill switch, ops). */
+  moneyPath?: MoneyPathExecutorConfig;
+  storeDurability?: StoreDurability;
+  /**
+   * Override live detection. Production environment / production base URL
+   * always forces live — cannot be overridden off.
+   */
+  liveMode?: boolean;
 }
 
 export const HOTELBEDS_BASE_URLS: Record<HotelbedsEnvironment, string> = {

--- a/packages/connect/src/__tests__/guarded-adapter.test.ts
+++ b/packages/connect/src/__tests__/guarded-adapter.test.ts
@@ -99,12 +99,19 @@ describe('GuardedConnectAdapter', () => {
 });
 
 describe('createAdapter default guard', () => {
-  it('wraps with GuardedConnectAdapter by default; unguarded opt-out', () => {
+  it('wraps with GuardedConnectAdapter by default; unguarded opt-out in non-live', () => {
     registerSupplier('guard-test-supplier', () => mkAdapter(async () => bookingResult));
-    const raw = createAdapter('guard-test-supplier', {}, { unguarded: true });
+    const raw = createAdapter('guard-test-supplier', {}, { unguarded: true, liveMode: false });
     expect(raw).not.toBeInstanceOf(GuardedConnectAdapter);
     const guarded = createAdapter('guard-test-supplier', {}, { liveMode: false });
     expect(guarded).toBeInstanceOf(GuardedConnectAdapter);
     expect(guardAdapter(raw, { liveMode: false })).toBeInstanceOf(GuardedConnectAdapter);
+  });
+
+  it('refuses unguarded opt-out in live mode', () => {
+    registerSupplier('guard-test-live', () => mkAdapter(async () => bookingResult));
+    expect(() =>
+      createAdapter('guard-test-live', {}, { unguarded: true, liveMode: true }),
+    ).toThrow(/unguarded|live mode/i);
   });
 });

--- a/packages/connect/src/__tests__/mutation-executor.test.ts
+++ b/packages/connect/src/__tests__/mutation-executor.test.ts
@@ -129,7 +129,7 @@ describe('MutationExecutor', () => {
 });
 
 describe('executeReversal', () => {
-  it('runs cancel through ledger', async () => {
+  it('refuses when shared executor is omitted', async () => {
     const adapter = {
       supplierId: 'test',
       cancelBooking: vi.fn(async () => ({ success: true, message: 'ok' })),
@@ -139,7 +139,39 @@ describe('executeReversal', () => {
       bookingId: 'B1',
       idempotencyKey: 'rev-1',
     });
+    expect(outcome.kind).toBe('failed');
+    expect(adapter.cancelBooking).not.toHaveBeenCalled();
+  });
+
+  it('runs cancel through shared executor ledger', async () => {
+    const adapter = {
+      supplierId: 'test',
+      cancelBooking: vi.fn(async () => ({ success: true, message: 'ok' })),
+    } as unknown as ConnectAdapter;
+    const executor = new MutationExecutor({ liveMode: false });
+    const outcome = await executeReversal(
+      adapter,
+      {
+        kind: 'cancel',
+        bookingId: 'B1',
+        idempotencyKey: 'rev-1',
+      },
+      executor,
+    );
     expect(outcome.kind).toBe('succeeded');
+    expect(adapter.cancelBooking).toHaveBeenCalledOnce();
+
+    // Idempotent across calls with same key
+    const replay = await executeReversal(
+      adapter,
+      {
+        kind: 'cancel',
+        bookingId: 'B1',
+        idempotencyKey: 'rev-1',
+      },
+      executor,
+    );
+    expect(replay.kind).toBe('succeeded');
     expect(adapter.cancelBooking).toHaveBeenCalledOnce();
   });
 
@@ -148,18 +180,27 @@ describe('executeReversal', () => {
       supplierId: 'test',
       cancelBooking: vi.fn(async () => ({ success: true, message: 'ok' })),
     } as unknown as ConnectAdapter;
-    const voidOut = await executeReversal(adapter, {
-      kind: 'void',
-      bookingId: 'B1',
-      idempotencyKey: 'void-1',
-    });
+    const executor = new MutationExecutor({ liveMode: false });
+    const voidOut = await executeReversal(
+      adapter,
+      {
+        kind: 'void',
+        bookingId: 'B1',
+        idempotencyKey: 'void-1',
+      },
+      executor,
+    );
     expect(voidOut.kind).toBe('failed');
     expect(adapter.cancelBooking).not.toHaveBeenCalled();
-    const refundOut = await executeReversal(adapter, {
-      kind: 'refund',
-      bookingId: 'B1',
-      idempotencyKey: 'refund-1',
-    });
+    const refundOut = await executeReversal(
+      adapter,
+      {
+        kind: 'refund',
+        bookingId: 'B1',
+        idempotencyKey: 'refund-1',
+      },
+      executor,
+    );
     expect(refundOut.kind).toBe('failed');
     expect(adapter.cancelBooking).not.toHaveBeenCalled();
   });

--- a/packages/connect/src/guarded-adapter.ts
+++ b/packages/connect/src/guarded-adapter.ts
@@ -68,10 +68,6 @@ export class GuardedConnectAdapter implements ConnectAdapter {
     return this.executor;
   }
 
-  get unguarded(): ConnectAdapter {
-    return this.inner;
-  }
-
   async searchFlights(input: SearchFlightsInput): Promise<FlightOffer[]> {
     return this.inner.searchFlights(input);
   }

--- a/packages/connect/src/reversal-saga.ts
+++ b/packages/connect/src/reversal-saga.ts
@@ -3,6 +3,9 @@
  *
  * void/refund fail closed unless the adapter declares the capability.
  * They must NOT silently alias to cancelBooking.
+ *
+ * Callers must pass a shared MutationExecutor (typically from GuardedConnectAdapter).
+ * There is no silent liveMode:false + fresh-ledger default.
  */
 
 import type { ConnectAdapter } from './types.js';
@@ -43,18 +46,30 @@ export class UnsupportedReversalError extends MoneyPathError {
 }
 
 /**
- * Execute a reversal using ledger-backed MutationExecutor.
+ * Execute a reversal using a caller-supplied ledger-backed MutationExecutor.
  * Does not auto-retry after ambiguous failure.
  *
  * - cancel: requires adapter.cancelBooking
  * - void / refund: require explicit capability flag — otherwise fail closed
+ * - executor: required — omit refuses (no weak liveMode:false fresh-ledger default)
  */
 export async function executeReversal(
   adapter: ConnectAdapter,
   request: ReversalRequest,
-  executor: MutationExecutor = new MutationExecutor({ liveMode: false }),
+  executor?: MutationExecutor,
   capabilities: ReversalCapabilities = { cancel: true },
 ): Promise<MutationOutcome<ReversalResult>> {
+  if (!executor) {
+    return {
+      kind: 'failed',
+      error: new MoneyPathError(
+        'executeReversal requires a shared MutationExecutor (e.g. from GuardedConnectAdapter). ' +
+          'Refusing silent liveMode:false + fresh-ledger default.',
+      ),
+      replayed: false,
+    };
+  }
+
   if (request.kind === 'void' && !capabilities.void) {
     return {
       kind: 'failed',

--- a/packages/connect/src/suppliers/haip/__tests__/money-path.test.ts
+++ b/packages/connect/src/suppliers/haip/__tests__/money-path.test.ts
@@ -1,0 +1,98 @@
+/**
+ * HAIP money-path: create/cancel once-only on ambiguous failure.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { createAdapter, GuardedConnectAdapter } from '../../../index.js';
+import { HaipAdapter } from '../index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const BOOK_PARAMS = {
+  propertyId: 'prop-1',
+  roomTypeId: 'rt-1',
+  rateId: 'rate-1',
+  checkIn: '2026-06-01',
+  checkOut: '2026-06-03',
+  rooms: 1,
+  guest: { firstName: 'Test', lastName: 'User' },
+  idempotencyKey: 'haip-book-1',
+};
+
+describe('HAIP money-path', () => {
+  it('createBooking wire call once on 503; replay zero additional', async () => {
+    let posts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/api/v1/connect/book')) {
+          posts += 1;
+          return new Response('unavailable', { status: 503, statusText: 'Service Unavailable' });
+        }
+        return new Response('{}', { status: 404 });
+      }),
+    );
+
+    const adapter = new HaipAdapter(
+      { baseUrl: 'http://haip.test.local', apiKey: '', timeoutMs: 1000, maxRetries: 0 },
+      { liveMode: false },
+    );
+
+    await expect(adapter.createBooking(BOOK_PARAMS)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.createBooking(BOOK_PARAMS)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(posts).toBe(1);
+  });
+
+  it('cancelBooking wire call once on timeout-shaped 503; replay zero', async () => {
+    let deletes = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes('/bookings/')) {
+          deletes += 1;
+          return new Response('timeout', { status: 503 });
+        }
+        return new Response('{}', { status: 404 });
+      }),
+    );
+
+    const adapter = new HaipAdapter(
+      { baseUrl: 'http://haip.test.local', apiKey: '' },
+      { liveMode: false },
+    );
+
+    await expect(
+      adapter.cancelBooking('CONF-1', { idempotencyKey: 'haip-cxl-1' }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(
+      adapter.cancelBooking('CONF-1', { idempotencyKey: 'haip-cxl-1' }),
+    ).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(deletes).toBe(1);
+  });
+
+  it('createAdapter registers haip as GuardedConnectAdapter', () => {
+    const adapter = createAdapter(
+      'haip',
+      { baseUrl: 'http://haip.test.local', apiKey: '' },
+      { liveMode: false },
+    );
+    expect(adapter).toBeInstanceOf(GuardedConnectAdapter);
+  });
+
+  it('requires idempotencyKey in live mode', async () => {
+    const adapter = new HaipAdapter(
+      { baseUrl: 'http://haip.test.local', apiKey: '' },
+      { liveMode: true },
+    );
+    await expect(
+      adapter.createBooking({
+        ...BOOK_PARAMS,
+        idempotencyKey: undefined,
+      }),
+    ).rejects.toThrow(/idempotencyKey/);
+  });
+});

--- a/packages/connect/src/suppliers/haip/connect-bridge.ts
+++ b/packages/connect/src/suppliers/haip/connect-bridge.ts
@@ -1,0 +1,98 @@
+/**
+ * ConnectAdapter bridge for HAIP lodging — enables createAdapter('haip')
+ * to return GuardedConnectAdapter. Flight search/price/book are unsupported;
+ * cancel/status/health delegate to HaipAdapter once-methods (Guarded owns ledger).
+ */
+
+import { MoneyPathError } from '@otaip/core';
+import { ConnectError } from '../../base-adapter.js';
+import type {
+  BookingResult,
+  BookingStatusResult,
+  ConnectAdapter,
+  CreateBookingInput,
+  FlightOffer,
+  PassengerCount,
+  PricedItinerary,
+  SearchFlightsInput,
+} from '../../types.js';
+import { HaipAdapter } from './index.js';
+
+export class HaipConnectBridge implements ConnectAdapter {
+  readonly supplierId = 'haip';
+  readonly supplierName = 'HAIP PMS';
+  private readonly haip: HaipAdapter;
+
+  constructor(config: unknown) {
+    this.haip = new HaipAdapter(config, { liveMode: false });
+  }
+
+  /** Underlying lodging adapter (money-path enforced on direct use). */
+  get lodgingAdapter(): HaipAdapter {
+    return this.haip;
+  }
+
+  async searchFlights(_input: SearchFlightsInput): Promise<FlightOffer[]> {
+    throw new ConnectError(
+      'HAIP does not support flight search',
+      this.supplierId,
+      'searchFlights',
+      false,
+    );
+  }
+
+  async priceItinerary(
+    _offerId: string,
+    _passengers: PassengerCount,
+  ): Promise<PricedItinerary> {
+    throw new ConnectError(
+      'HAIP does not support flight pricing',
+      this.supplierId,
+      'priceItinerary',
+      false,
+    );
+  }
+
+  async createBooking(_input: CreateBookingInput): Promise<BookingResult> {
+    throw new MoneyPathError(
+      'HAIP lodging bookings use HaipAdapter.createBooking with HaipBookingParams, not ConnectAdapter flight createBooking',
+    );
+  }
+
+  async getBookingStatus(bookingId: string): Promise<BookingStatusResult> {
+    const status = await this.haip.getBookingStatus(bookingId);
+    const mappedStatus: BookingStatusResult['status'] =
+      status.status === 'confirmed'
+        ? 'confirmed'
+        : status.status === 'cancelled'
+          ? 'cancelled'
+          : 'held';
+    return {
+      bookingId,
+      supplier: 'haip',
+      status: mappedStatus,
+      segments: [],
+      passengers: [],
+      totalPrice: {
+        amount: status.totalAmount,
+        currency: status.currency,
+      },
+      raw: status,
+    };
+  }
+
+  async cancelBooking(
+    bookingId: string,
+  ): Promise<{ success: boolean; message: string }> {
+    // Once-method: GuardedConnectAdapter / MutationExecutor owns the ledger.
+    const result = await this.haip.cancelBookingOnce(bookingId);
+    return {
+      success: result.status === 'cancelled',
+      message: result.message ?? 'cancelled',
+    };
+  }
+
+  async healthCheck(): Promise<{ healthy: boolean; latencyMs: number }> {
+    return this.haip.healthCheck();
+  }
+}

--- a/packages/connect/src/suppliers/haip/index.ts
+++ b/packages/connect/src/suppliers/haip/index.ts
@@ -4,14 +4,17 @@
  * A thin HTTP client that calls the HAIP Connect API at /api/v1/connect/*
  * and maps responses to OTAIP-compatible hotel types.
  *
- * - Stateless: each call is independent
- * - Auto-confirm: HAIP confirms bookings immediately (no polling)
- * - Three confirmation codes: PMS confirmation + external reference
- * - No auth in HAIP v1.0.0 — Bearer header included but empty
- *
- * Extends BaseAdapter for retry, timeout, and error wrapping utilities.
+ * Unsafe mutations (create/modify/cancel) go through MoneyPathExecutor.
+ * Extends BaseAdapter for timeout and error wrapping; unsafe ops skip auto-retry.
  */
 
+import {
+  isLiveModeFromEnv,
+  MoneyPathError,
+  MoneyPathExecutor,
+  type MoneyPathExecutorConfig,
+  type StoreDurability,
+} from '@otaip/core';
 import { BaseAdapter, ConnectError } from '../../base-adapter.js';
 import type { HaipConfig } from './config.js';
 import { validateHaipConfig } from './config.js';
@@ -75,6 +78,8 @@ export interface HaipBookingParams {
   };
   externalConfirmationCode?: string;
   specialRequests?: string;
+  /** Required in live mode — same key → at most one supplier book. */
+  idempotencyKey?: string;
 }
 
 export interface HaipModifyParams {
@@ -90,11 +95,19 @@ export interface HaipModifyParams {
     phone?: string;
   };
   specialRequests?: string;
+  /** Required in live mode for money-path idempotency. */
+  idempotencyKey?: string;
 }
 
-// ---------------------------------------------------------------------------
-// Re-export mapper output types for consumers
-// ---------------------------------------------------------------------------
+export interface HaipAdapterOptions {
+  readonly moneyPath?: MoneyPathExecutorConfig;
+  readonly storeDurability?: StoreDurability;
+  /**
+   * Override live detection. Production-looking base URLs force live —
+   * cannot be overridden off.
+   */
+  readonly liveMode?: boolean;
+}
 
 export type {
   HaipHotelResult,
@@ -105,9 +118,19 @@ export type {
   HaipRawRate,
 } from './mapper.js';
 
-// ---------------------------------------------------------------------------
-// Adapter implementation
-// ---------------------------------------------------------------------------
+function resolveHaipLiveMode(
+  config: HaipConfig,
+  options?: HaipAdapterOptions,
+): boolean {
+  const base = config.baseUrl.toLowerCase();
+  const forcedLive =
+    base.includes('://api.') ||
+    base.includes('.production.') ||
+    base.endsWith('.haip.io') ||
+    (process.env['HAIP_ENV'] ?? '').toLowerCase() === 'production';
+  if (forcedLive) return true;
+  return options?.liveMode ?? isLiveModeFromEnv();
+}
 
 export class HaipAdapter extends BaseAdapter {
   protected readonly supplierId = 'haip';
@@ -115,14 +138,29 @@ export class HaipAdapter extends BaseAdapter {
   readonly adapterName = 'HAIP PMS';
 
   private readonly config: HaipConfig;
+  private readonly moneyPath: MoneyPathExecutor;
+  private readonly liveMode: boolean;
 
-  constructor(config: unknown) {
+  constructor(config: unknown, options?: HaipAdapterOptions) {
     const validated = validateHaipConfig(config);
     super({
       maxRetries: validated.maxRetries,
       baseDelayMs: validated.baseDelayMs,
     });
     this.config = validated;
+    this.liveMode = resolveHaipLiveMode(validated, options);
+    this.moneyPath = new MoneyPathExecutor({
+      reconcileHint: 'getBookingStatus',
+      ...options?.moneyPath,
+      liveMode: this.liveMode,
+      ...(options?.storeDurability !== undefined
+        ? { storeDurability: options.storeDurability }
+        : {}),
+    });
+  }
+
+  get moneyPathExecutor(): MoneyPathExecutor {
+    return this.moneyPath;
   }
 
   // -----------------------------------------------------------------------
@@ -208,24 +246,48 @@ export class HaipAdapter extends BaseAdapter {
   // -----------------------------------------------------------------------
 
   async createBooking(params: HaipBookingParams): Promise<HaipBookingResult> {
-    return this.withRetry('createBooking', async () => {
-      const body: HaipBookRequest = {
+    const key = params.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HaipAdapter.createBooking requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey =
+      key ??
+      `haip-book:${params.externalConfirmationCode ?? `${params.propertyId}:${params.checkIn}`}`;
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'createBooking',
+      idempotencyKey,
+      request: {
         propertyId: params.propertyId,
         roomTypeId: params.roomTypeId,
         rateId: params.rateId,
         checkIn: params.checkIn,
         checkOut: params.checkOut,
         rooms: params.rooms,
-        guest: params.guest,
-        externalConfirmationCode: params.externalConfirmationCode,
-        specialRequests: params.specialRequests,
-      };
-
-      const response = await this.request<HaipBookResponse>('POST', '/api/v1/connect/book', body);
-
-      // HAIP auto-confirms agent bookings — status should be 'confirmed'
-      return mapBookingResponse(response, params.externalConfirmationCode);
+      },
+      supplierId: 'haip',
+      fn: () => this.createBookingOnce(params),
     });
+  }
+
+  /** Single-attempt book — used by MoneyPathExecutor and Connect bridge. */
+  async createBookingOnce(params: HaipBookingParams): Promise<HaipBookingResult> {
+    const body: HaipBookRequest = {
+      propertyId: params.propertyId,
+      roomTypeId: params.roomTypeId,
+      rateId: params.rateId,
+      checkIn: params.checkIn,
+      checkOut: params.checkOut,
+      rooms: params.rooms,
+      guest: params.guest,
+      externalConfirmationCode: params.externalConfirmationCode,
+      specialRequests: params.specialRequests,
+    };
+
+    const response = await this.request<HaipBookResponse>('POST', '/api/v1/connect/book', body);
+    return mapBookingResponse(response, params.externalConfirmationCode);
   }
 
   async getBookingStatus(confirmationNumber: string): Promise<HaipVerificationResult> {
@@ -243,36 +305,74 @@ export class HaipAdapter extends BaseAdapter {
     confirmationNumber: string,
     changes: HaipModifyParams,
   ): Promise<HaipModificationResult> {
-    return this.withRetry('modifyBooking', async () => {
-      const body: HaipModifyRequest = {
-        checkIn: changes.checkIn,
-        checkOut: changes.checkOut,
-        rooms: changes.rooms,
-        roomTypeId: changes.roomTypeId,
-        rateId: changes.rateId,
-        guest: changes.guest,
-        specialRequests: changes.specialRequests,
-      };
-
-      const response = await this.request<HaipModifyResponse>(
-        'PATCH',
-        `/api/v1/connect/bookings/${encodeURIComponent(confirmationNumber)}`,
-        body,
+    const key = changes.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HaipAdapter.modifyBooking requires idempotencyKey in live mode (DoD 1/2)',
       );
+    }
+    const idempotencyKey = key ?? `haip-modify:${confirmationNumber}`;
 
-      return mapModifyResponse(response);
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'modifyBooking',
+      idempotencyKey,
+      request: { confirmationNumber, changes },
+      supplierId: 'haip',
+      fn: () => this.modifyBookingOnce(confirmationNumber, changes),
     });
   }
 
-  async cancelBooking(confirmationNumber: string): Promise<HaipCancellationResult> {
-    return this.withRetry('cancelBooking', async () => {
-      const response = await this.request<HaipCancelResponse>(
-        'DELETE',
-        `/api/v1/connect/bookings/${encodeURIComponent(confirmationNumber)}`,
-      );
+  async modifyBookingOnce(
+    confirmationNumber: string,
+    changes: HaipModifyParams,
+  ): Promise<HaipModificationResult> {
+    const body: HaipModifyRequest = {
+      checkIn: changes.checkIn,
+      checkOut: changes.checkOut,
+      rooms: changes.rooms,
+      roomTypeId: changes.roomTypeId,
+      rateId: changes.rateId,
+      guest: changes.guest,
+      specialRequests: changes.specialRequests,
+    };
 
-      return mapCancelResponse(response);
+    const response = await this.request<HaipModifyResponse>(
+      'PATCH',
+      `/api/v1/connect/bookings/${encodeURIComponent(confirmationNumber)}`,
+      body,
+    );
+
+    return mapModifyResponse(response);
+  }
+
+  async cancelBooking(
+    confirmationNumber: string,
+    options?: { idempotencyKey?: string },
+  ): Promise<HaipCancellationResult> {
+    const key = options?.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HaipAdapter.cancelBooking requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `haip-cancel:${confirmationNumber}`;
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'cancelBooking',
+      idempotencyKey,
+      request: { confirmationNumber },
+      supplierId: 'haip',
+      fn: () => this.cancelBookingOnce(confirmationNumber),
     });
+  }
+
+  async cancelBookingOnce(confirmationNumber: string): Promise<HaipCancellationResult> {
+    const response = await this.request<HaipCancelResponse>(
+      'DELETE',
+      `/api/v1/connect/bookings/${encodeURIComponent(confirmationNumber)}`,
+    );
+
+    return mapCancelResponse(response);
   }
 
   // -----------------------------------------------------------------------
@@ -307,7 +407,6 @@ export class HaipAdapter extends BaseAdapter {
       Accept: 'application/json',
     };
 
-    // Auth header — empty for HAIP v1.0.0, ready for OAuth token later
     if (this.config.apiKey) {
       headers['Authorization'] = `Bearer ${this.config.apiKey}`;
     }
@@ -334,7 +433,6 @@ export class HaipAdapter extends BaseAdapter {
       );
     }
 
-    // DELETE may return 204 with no body
     if (response.status === 204) {
       return {} as T;
     }

--- a/packages/connect/src/suppliers/index.ts
+++ b/packages/connect/src/suppliers/index.ts
@@ -5,13 +5,14 @@
  * book/ticket/cancel cannot bypass the money-path executor.
  */
 
+import { isLiveModeFromEnv, LiveSafetyError, type MoneyPathExecutorConfig } from '@otaip/core';
 import type { ConnectAdapter } from '../types.js';
 import { AmadeusAdapter } from './amadeus/index.js';
 import { NavitaireAdapter } from './navitaire/index.js';
 import { SabreAdapter } from './sabre/index.js';
 import { TripProAdapter } from './trippro/index.js';
+import { HaipConnectBridge } from './haip/connect-bridge.js';
 import { guardAdapter, type GuardedConnectAdapter } from '../guarded-adapter.js';
-import type { MoneyPathExecutorConfig } from '@otaip/core';
 
 const SUPPLIER_FACTORIES: Record<string, (config: unknown) => ConnectAdapter> = {};
 
@@ -38,11 +39,17 @@ export function createAdapter(
       `Unknown supplier: ${supplierId}. Available: ${Object.keys(SUPPLIER_FACTORIES).join(', ')}`,
     );
   }
+  const liveMode = options?.liveMode ?? isLiveModeFromEnv();
+  if (options?.unguarded && liveMode) {
+    throw new LiveSafetyError(
+      'createAdapter({ unguarded: true }) is refused in live mode — money-path guard is mandatory',
+    );
+  }
   const raw = factory(config);
   if (options?.unguarded) return raw;
   const execConfig: Omit<CreateAdapterOptions, 'unguarded'> = { ...(options ?? {}) };
   delete (execConfig as { unguarded?: boolean }).unguarded;
-  return guardAdapter(raw, execConfig);
+  return guardAdapter(raw, { ...execConfig, liveMode });
 }
 
 export function listSuppliers(): string[] {
@@ -60,3 +67,6 @@ registerSupplier('navitaire', (config) => new NavitaireAdapter(config));
 
 // Auto-register Amadeus
 registerSupplier('amadeus', (config) => new AmadeusAdapter(config));
+
+// Auto-register HAIP (lodging Connect bridge → GuardedConnectAdapter by default)
+registerSupplier('haip', (config) => new HaipConnectBridge(config));

--- a/packages/core/src/approval/__tests__/bound-approval.test.ts
+++ b/packages/core/src/approval/__tests__/bound-approval.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect } from 'vitest';
+import { createHash, createHmac } from 'node:crypto';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FileCompareAndSwapPersistenceAdapter } from '../../persistence/file-cas-adapter.js';
 import {
+  CasBoundApprovalTokenStore,
   InMemoryBoundApprovalTokenStore,
   consumeBoundApprovalToken,
   createBoundApprovalPolicy,
   hashApprovalInput,
   issueBoundApprovalToken,
+  peekBoundApprovalClaims,
 } from '../bound-approval.js';
 
 const secret = 'unit-test-secret';
@@ -18,6 +25,7 @@ describe('bound approval tokens', () => {
       input,
       secret,
     });
+    expect(token.startsWith('v1.')).toBe(true);
     const policy = createBoundApprovalPolicy({
       secret,
       store: new InMemoryBoundApprovalTokenStore(),
@@ -27,6 +35,28 @@ describe('bound approval tokens', () => {
     });
     const result = policy.validateApprovalToken?.(token, 'mutation_irreversible');
     expect(result?.ok).toBe(true);
+  });
+
+  it('uses createHmac not hash-concat', () => {
+    const token = issueBoundApprovalToken({
+      sessionId: 's',
+      agentId: 'a',
+      input: { z: 1, a: 2 },
+      secret,
+      jtiFactory: () => 'fixed-jti',
+      now: () => 1_000_000,
+      ttlMs: 60_000,
+    });
+    const [, body, sig] = token.split('.');
+    expect(body).toBeTruthy();
+    const hmacSig = createHmac('sha256', secret).update(body!).digest('hex');
+    const concatSig = createHash('sha256').update(`${secret}:${body}`).digest('hex');
+    expect(sig).toBe(hmacSig);
+    expect(sig).not.toBe(concatSig);
+  });
+
+  it('canonical key order for input hash', () => {
+    expect(hashApprovalInput({ b: 1, a: 2 })).toBe(hashApprovalInput({ a: 2, b: 1 }));
   });
 
   it('rejects wrong input hash', () => {
@@ -62,6 +92,27 @@ describe('bound approval tokens', () => {
     expect(result?.ok).toBe(false);
   });
 
+  it('rejects length-extension-shaped legacy hash-concat token', () => {
+    const claims = {
+      sessionId: 's',
+      agentId: 'a',
+      inputHash: hashApprovalInput({}),
+      expiresAt: Date.now() + 60_000,
+      jti: 'legacy',
+    };
+    const body = Buffer.from(JSON.stringify(claims), 'utf8').toString('base64url');
+    const legacySig = createHash('sha256').update(`${secret}:${body}`).digest('hex');
+    const legacyToken = `${body}.${legacySig}`;
+    const policy = createBoundApprovalPolicy({
+      secret,
+      store: new InMemoryBoundApprovalTokenStore(),
+      sessionId: 's',
+      agentId: 'a',
+      expectedInput: {},
+    });
+    expect(policy.validateApprovalToken?.(legacyToken, 'mutation_irreversible')?.ok).toBe(false);
+  });
+
   it('rejects expired token', () => {
     let now = 1_000_000;
     const token = issueBoundApprovalToken({
@@ -88,23 +139,43 @@ describe('bound approval tokens', () => {
     }
   });
 
-  it('rejects replayed token on consume', async () => {
+  it('single-use consume rejects replay', async () => {
     const store = new InMemoryBoundApprovalTokenStore();
     const token = issueBoundApprovalToken({
       sessionId: 's',
       agentId: 'a',
       input: { x: 1 },
       secret,
-      jtiFactory: () => 'fixed-jti',
     });
     const first = await consumeBoundApprovalToken(token, secret, store);
-    const second = await consumeBoundApprovalToken(token, secret, store);
     expect(first.ok).toBe(true);
+    const second = await consumeBoundApprovalToken(token, secret, store);
     expect(second.ok).toBe(false);
-    if (!second.ok) expect(second.issues[0]?.code).toBe('APPROVAL_TOKEN_REPLAYED');
+    if (!second.ok) {
+      expect(second.issues[0]?.code).toBe('APPROVAL_TOKEN_REPLAYED');
+    }
   });
 
-  it('hashApprovalInput ignores approvalToken field', () => {
-    expect(hashApprovalInput({ a: 1, approvalToken: 'x' })).toBe(hashApprovalInput({ a: 1 }));
+  it('CasBoundApprovalTokenStore rejects replay across two store instances sharing file CAS', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'otaip-appr-'));
+    const persistence = new FileCompareAndSwapPersistenceAdapter(join(dir, 'jti.json'));
+    expect(persistence.durability).toBe('durable');
+    const storeA = new CasBoundApprovalTokenStore(persistence);
+    const storeB = new CasBoundApprovalTokenStore(persistence);
+    expect(storeA.durability).toBe('durable');
+
+    const token = issueBoundApprovalToken({
+      sessionId: 's',
+      agentId: 'a',
+      input: { n: 1 },
+      secret,
+    });
+    const claims = peekBoundApprovalClaims(token, secret);
+    expect(claims).not.toBeNull();
+
+    const first = await consumeBoundApprovalToken(token, secret, storeA);
+    expect(first.ok).toBe(true);
+    const second = await consumeBoundApprovalToken(token, secret, storeB);
+    expect(second.ok).toBe(false);
   });
 });

--- a/packages/core/src/approval/bound-approval.ts
+++ b/packages/core/src/approval/bound-approval.ts
@@ -2,16 +2,22 @@
  * Bound, single-use approval tokens for mutation_irreversible actions.
  *
  * Tokens bind to (sessionId, agentId, inputHash) and expire. Default policy
- * no longer accepts arbitrary non-empty strings.
+ * no longer accepts arbitrary non-empty strings. Signatures use createHmac.
  */
 
-import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { createHmac, createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import type {
   ActionType,
   SemanticIssue,
   SemanticValidationResult,
 } from '../pipeline-validator/types.js';
 import type { ApprovalPolicy } from '../pipeline-validator/action-classifier.js';
+import type { CompareAndSwapPersistenceAdapter } from '../persistence/types.js';
+import type { StoreDurability } from '../safety/live-safety-mode.js';
+import { canonicalJson } from '../util/canonical-json.js';
+
+/** Token format version — old concatenated-hash tokens are rejected. */
+const TOKEN_VERSION = 'v1';
 
 export interface BoundApprovalClaims {
   readonly sessionId: string;
@@ -24,6 +30,8 @@ export interface BoundApprovalClaims {
 }
 
 export interface BoundApprovalTokenStore {
+  /** Store-declared durability for live-mode refusal of ephemeral stores. */
+  readonly durability: StoreDurability;
   /** Returns false if the jti was already consumed. */
   consume(jti: string): Promise<boolean>;
   /** Optional: check without consuming. */
@@ -31,6 +39,7 @@ export interface BoundApprovalTokenStore {
 }
 
 export class InMemoryBoundApprovalTokenStore implements BoundApprovalTokenStore {
+  readonly durability = 'ephemeral' as const;
   private readonly consumed = new Set<string>();
 
   async consume(jti: string): Promise<boolean> {
@@ -44,21 +53,49 @@ export class InMemoryBoundApprovalTokenStore implements BoundApprovalTokenStore 
   }
 }
 
+/**
+ * CAS-backed single-use jti tombstones — durable when the persistence
+ * adapter is durable (e.g. FileCompareAndSwapPersistenceAdapter).
+ */
+export class CasBoundApprovalTokenStore implements BoundApprovalTokenStore {
+  readonly durability: StoreDurability;
+  private readonly persistence: CompareAndSwapPersistenceAdapter;
+  private readonly keyPrefix: string;
+
+  constructor(
+    persistence: CompareAndSwapPersistenceAdapter,
+    options?: { keyPrefix?: string },
+  ) {
+    this.persistence = persistence;
+    this.durability = persistence.durability;
+    this.keyPrefix = options?.keyPrefix ?? 'approval-jti:';
+  }
+
+  async consume(jti: string): Promise<boolean> {
+    const key = `${this.keyPrefix}${jti}`;
+    return this.persistence.setIfAbsent(key, { consumedAt: Date.now() });
+  }
+
+  async isConsumed(jti: string): Promise<boolean> {
+    return this.persistence.has(`${this.keyPrefix}${jti}`);
+  }
+}
+
 function hmac(secret: string, payload: string): string {
-  return createHash('sha256').update(`${secret}:${payload}`).digest('hex');
+  return createHmac('sha256', secret).update(payload).digest('hex');
 }
 
 function encodeToken(claims: BoundApprovalClaims, secret: string): string {
   const body = Buffer.from(JSON.stringify(claims), 'utf8').toString('base64url');
   const sig = hmac(secret, body);
-  return `${body}.${sig}`;
+  return `${TOKEN_VERSION}.${body}.${sig}`;
 }
 
 function decodeToken(token: string, secret: string): BoundApprovalClaims | null {
   const parts = token.split('.');
-  if (parts.length !== 2) return null;
-  const [body, sig] = parts;
-  if (!body || !sig) return null;
+  if (parts.length !== 3) return null;
+  const [version, body, sig] = parts;
+  if (version !== TOKEN_VERSION || !body || !sig) return null;
   const expected = hmac(secret, body);
   const a = Buffer.from(sig);
   const b = Buffer.from(expected);
@@ -71,15 +108,17 @@ function decodeToken(token: string, secret: string): BoundApprovalClaims | null 
 }
 
 export function hashApprovalInput(input: unknown): string {
-  const json = JSON.stringify(input, (_k, v) => {
-    if (v && typeof v === 'object' && 'approvalToken' in v) {
-      const rest: Record<string, unknown> = { ...(v as Record<string, unknown>) };
-      delete rest['approvalToken'];
-      return rest;
-    }
-    return v;
-  });
-  return createHash('sha256').update(json).digest('hex');
+  const stripped = stripApprovalToken(input);
+  return createHash('sha256').update(canonicalJson(stripped)).digest('hex');
+}
+
+function stripApprovalToken(input: unknown): unknown {
+  if (input && typeof input === 'object' && !Array.isArray(input) && 'approvalToken' in input) {
+    const rest: Record<string, unknown> = { ...(input as Record<string, unknown>) };
+    delete rest['approvalToken'];
+    return rest;
+  }
+  return input;
 }
 
 export interface IssueBoundApprovalInput {

--- a/packages/core/src/approval/index.ts
+++ b/packages/core/src/approval/index.ts
@@ -1,4 +1,5 @@
 export {
+  CasBoundApprovalTokenStore,
   consumeBoundApprovalToken,
   createBoundApprovalPolicy,
   hashApprovalInput,

--- a/packages/core/src/effect-ledger/file-effect-ledger.ts
+++ b/packages/core/src/effect-ledger/file-effect-ledger.ts
@@ -1,0 +1,73 @@
+/**
+ * File-backed effect ledger — reference durable store for live drills.
+ * Built on {@link FileCompareAndSwapPersistenceAdapter}.
+ */
+
+import { FileCompareAndSwapPersistenceAdapter } from '../persistence/file-cas-adapter.js';
+import type { CompareAndSwapPersistenceAdapter } from '../persistence/types.js';
+import { InMemoryEffectLedger } from './in-memory-effect-ledger.js';
+import type {
+  BeginEffectInput,
+  BeginEffectResult,
+  EffectLedger,
+  EffectOutcome,
+  EffectRecord,
+} from './types.js';
+
+/**
+ * Durable EffectLedger. Declares `durability: 'durable'` so live mode
+ * can execute irreversible ops without a caller-asserted durability upgrade.
+ */
+export class FileEffectLedger implements EffectLedger {
+  readonly durability = 'durable' as const;
+  private readonly inner: InMemoryEffectLedger;
+
+  constructor(options: {
+    /** Path to the JSON file used as the CAS store. */
+    filePath: string;
+    /** Optional override (must itself be durable). */
+    persistence?: CompareAndSwapPersistenceAdapter;
+    now?: () => Date;
+  }) {
+    const persistence =
+      options.persistence ?? new FileCompareAndSwapPersistenceAdapter(options.filePath);
+    if (persistence.durability !== 'durable') {
+      throw new Error(
+        'FileEffectLedger requires a durable CompareAndSwapPersistenceAdapter',
+      );
+    }
+    this.inner = new InMemoryEffectLedger({
+      persistence,
+      ...(options.now !== undefined ? { now: options.now } : {}),
+    });
+  }
+
+  begin<TResponse = unknown>(
+    input: BeginEffectInput,
+  ): Promise<BeginEffectResult<TResponse>> {
+    return this.inner.begin(input);
+  }
+
+  resolve<TResponse = unknown>(
+    idempotencyKey: string,
+    outcome: Exclude<EffectOutcome, 'pending'>,
+    response?: TResponse,
+    externalRef?: string,
+  ): Promise<EffectRecord<TResponse> | null> {
+    return this.inner.resolve(idempotencyKey, outcome, response, externalRef);
+  }
+
+  get<TResponse = unknown>(
+    idempotencyKey: string,
+  ): Promise<EffectRecord<TResponse> | null> {
+    return this.inner.get(idempotencyKey);
+  }
+
+  listUnresolved(olderThanMs?: number): Promise<readonly EffectRecord[]> {
+    return this.inner.listUnresolved(olderThanMs);
+  }
+
+  listUnknown(olderThanMs?: number): Promise<readonly EffectRecord[]> {
+    return this.inner.listUnknown(olderThanMs);
+  }
+}

--- a/packages/core/src/effect-ledger/in-memory-effect-ledger.ts
+++ b/packages/core/src/effect-ledger/in-memory-effect-ledger.ts
@@ -10,7 +10,12 @@ import type {
 
 const KEY_PREFIX = 'effect:';
 
+/**
+ * In-memory effect ledger — always ephemeral, even if a custom persistence
+ * adapter is injected. Use {@link FileEffectLedger} for durable live drills.
+ */
 export class InMemoryEffectLedger implements EffectLedger {
+  readonly durability = 'ephemeral' as const;
   private readonly persistence: CompareAndSwapPersistenceAdapter;
   private readonly now: () => Date;
 
@@ -101,16 +106,22 @@ export class InMemoryEffectLedger implements EffectLedger {
     return this.persistence.get<EffectRecord<TResponse>>(`${KEY_PREFIX}${idempotencyKey}`);
   }
 
-  async listUnknown(olderThanMs = 0): Promise<readonly EffectRecord[]> {
+  async listUnresolved(olderThanMs = 0): Promise<readonly EffectRecord[]> {
     const keys = await this.persistence.list(KEY_PREFIX);
     const now = this.now().getTime();
     const out: EffectRecord[] = [];
     for (const key of keys) {
       const record = await this.persistence.get<EffectRecord>(key);
-      if (!record || record.outcome !== 'unknown') continue;
+      if (!record) continue;
+      if (record.outcome !== 'unknown' && record.outcome !== 'pending') continue;
       const age = now - Date.parse(record.updatedAt);
       if (age >= olderThanMs) out.push(record);
     }
     return out;
+  }
+
+  /** @deprecated Prefer {@link listUnresolved} */
+  async listUnknown(olderThanMs = 0): Promise<readonly EffectRecord[]> {
+    return this.listUnresolved(olderThanMs);
   }
 }

--- a/packages/core/src/effect-ledger/index.ts
+++ b/packages/core/src/effect-ledger/index.ts
@@ -6,3 +6,4 @@ export type {
   EffectRecord,
 } from './types.js';
 export { InMemoryEffectLedger } from './in-memory-effect-ledger.js';
+export { FileEffectLedger } from './file-effect-ledger.js';

--- a/packages/core/src/effect-ledger/types.ts
+++ b/packages/core/src/effect-ledger/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { MutationEffectType } from '../command-store/types.js';
+import type { StoreDurability } from '../safety/live-safety-mode.js';
 
 export type EffectOutcome = 'pending' | 'succeeded' | 'failed' | 'unknown';
 
@@ -36,6 +37,12 @@ export type BeginEffectResult<TResponse = unknown> =
   | { readonly kind: 'conflict'; readonly record: EffectRecord<TResponse>; readonly reason: string };
 
 export interface EffectLedger {
+  /**
+   * Store-declared durability. MoneyPathExecutor reads this — callers cannot
+   * upgrade an ephemeral ledger to durable via config.
+   */
+  readonly durability: StoreDurability;
+
   begin<TResponse = unknown>(input: BeginEffectInput): Promise<BeginEffectResult<TResponse>>;
 
   resolve<TResponse = unknown>(
@@ -47,5 +54,12 @@ export interface EffectLedger {
 
   get<TResponse = unknown>(idempotencyKey: string): Promise<EffectRecord<TResponse> | null>;
 
+  /**
+   * List unresolved effects (outcome `unknown` or crash-left `pending`)
+   * older than the given age threshold.
+   */
+  listUnresolved(olderThanMs?: number): Promise<readonly EffectRecord[]>;
+
+  /** @deprecated Prefer {@link listUnresolved} — includes aged pending. */
   listUnknown(olderThanMs?: number): Promise<readonly EffectRecord[]>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -144,7 +144,7 @@ export type {
   EffectOutcome,
   EffectRecord,
 } from './effect-ledger/index.js';
-export { InMemoryEffectLedger } from './effect-ledger/index.js';
+export { FileEffectLedger, InMemoryEffectLedger } from './effect-ledger/index.js';
 
 export type { LiveSafetyModeConfig, StoreDurability } from './safety/index.js';
 export {
@@ -188,6 +188,7 @@ export type {
   IssueBoundApprovalInput,
 } from './approval/index.js';
 export {
+  CasBoundApprovalTokenStore,
   InMemoryBoundApprovalTokenStore,
   consumeBoundApprovalToken,
   createBoundApprovalPolicy,
@@ -200,8 +201,12 @@ export type {
   BookingFailureSignal,
   BookingFailureStage,
   IrreversibleAuditEntry,
+  MutationOpsSubscriber,
 } from './ops/index.js';
-export { MutationOpsCollector } from './ops/index.js';
+export {
+  getProcessMutationOpsCollector,
+  MutationOpsCollector,
+} from './ops/index.js';
 
 export type { RateLimiterConfig } from './rate-limiter/index.js';
 export { RateLimiter } from './rate-limiter/index.js';

--- a/packages/core/src/money-path/__tests__/money-path-executor.test.ts
+++ b/packages/core/src/money-path/__tests__/money-path-executor.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { InMemoryEffectLedger } from '../../effect-ledger/in-memory-effect-ledger.js';
-import { FileCompareAndSwapPersistenceAdapter } from '../../persistence/file-cas-adapter.js';
-import { MutationKillSwitch } from '../../safety/mutation-kill-switch.js';
-import { LiveSafetyError } from '../../safety/live-safety-mode.js';
-import { MoneyPathExecutor } from '../money-path-executor.js';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { FileEffectLedger } from '../../effect-ledger/file-effect-ledger.js';
+import { InMemoryEffectLedger } from '../../effect-ledger/in-memory-effect-ledger.js';
+import { MutationOpsCollector } from '../../ops/mutation-ops.js';
+import { MutationKillSwitch } from '../../safety/mutation-kill-switch.js';
+import { LiveSafetyError } from '../../safety/live-safety-mode.js';
+import { MoneyPathExecutor } from '../money-path-executor.js';
 
 describe('MoneyPathExecutor', () => {
   it('marks ambiguous 503 as unknown and does not re-invoke on replay', async () => {
@@ -38,8 +39,14 @@ describe('MoneyPathExecutor', () => {
     expect(calls).toBe(1);
   });
 
-  it('refuses live mode with ephemeral stores by default', async () => {
-    const exec = new MoneyPathExecutor({ liveMode: true });
+  it('refuses live mode with ephemeral InMemoryEffectLedger', async () => {
+    expect(
+      () => new MoneyPathExecutor({ ledger: new InMemoryEffectLedger(), liveMode: true }),
+    ).not.toThrow();
+    const exec = new MoneyPathExecutor({
+      ledger: new InMemoryEffectLedger(),
+      liveMode: true,
+    });
     await expect(
       exec.executeUnsafe({
         operation: 'book',
@@ -51,15 +58,25 @@ describe('MoneyPathExecutor', () => {
     ).rejects.toBeInstanceOf(LiveSafetyError);
   });
 
-  it('allows live mode with durable file-backed ledger', async () => {
+  it('rejects storeDurability upgrade of ephemeral ledger', () => {
+    expect(
+      () =>
+        new MoneyPathExecutor({
+          ledger: new InMemoryEffectLedger(),
+          storeDurability: 'durable',
+          liveMode: true,
+        }),
+    ).toThrow(LiveSafetyError);
+  });
+
+  it('allows live mode with FileEffectLedger (store-declared durable)', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'otaip-mp-'));
-    const persistence = new FileCompareAndSwapPersistenceAdapter(join(dir, 'ledger.json'));
-    const ledger = new InMemoryEffectLedger({ persistence });
+    const ledger = new FileEffectLedger({ filePath: join(dir, 'ledger.json') });
     const exec = new MoneyPathExecutor({
       ledger,
-      storeDurability: 'durable',
       liveMode: true,
     });
+    expect(exec.safetyConfig.storeDurability).toBe('durable');
     const outcome = await exec.executeUnsafe({
       operation: 'book',
       idempotencyKey: 'live-ok',
@@ -86,7 +103,8 @@ describe('MoneyPathExecutor', () => {
   });
 
   it('records ops audits on mutation', async () => {
-    const exec = new MoneyPathExecutor({ liveMode: false });
+    const ops = new MutationOpsCollector();
+    const exec = new MoneyPathExecutor({ liveMode: false, ops });
     await exec.executeUnsafe({
       operation: 'book',
       idempotencyKey: 'ops-1',
@@ -94,6 +112,37 @@ describe('MoneyPathExecutor', () => {
       supplierId: 'x',
       fn: async () => ({ ok: true }),
     });
-    expect(exec.opsCollector.listAudits().length).toBe(1);
+    expect(ops.listAudits().length).toBe(1);
+  });
+
+  it('maps refund failures to refund stage', async () => {
+    const ops = new MutationOpsCollector();
+    const exec = new MoneyPathExecutor({ liveMode: false, ops });
+    await exec.executeUnsafe({
+      operation: 'refund',
+      idempotencyKey: 'refund-1',
+      request: {},
+      supplierId: 'x',
+      fn: async () => {
+        throw new Error('refund failed hard');
+      },
+    });
+    expect(ops.failuresByStage().get('refund')).toBe(1);
+  });
+
+  it('listUnresolved includes aged pending left by crash', async () => {
+    let now = new Date('2026-01-01T00:00:00.000Z');
+    const ledger = new InMemoryEffectLedger({ now: () => now });
+    await ledger.begin({
+      effectId: 'e1',
+      effectType: 'book',
+      idempotencyKey: 'crash-pending',
+      requestHash: 'abc',
+      supplierId: 'x',
+    });
+    now = new Date('2026-01-01T00:05:00.000Z');
+    const unresolved = await ledger.listUnresolved(60_000);
+    expect(unresolved.some((r) => r.idempotencyKey === 'crash-pending')).toBe(true);
+    expect(unresolved[0]?.outcome).toBe('pending');
   });
 });

--- a/packages/core/src/money-path/money-path-executor.ts
+++ b/packages/core/src/money-path/money-path-executor.ts
@@ -3,14 +3,19 @@
  * for irreversible supplier mutations (DoD 1/2/3/8).
  */
 
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { InMemoryEffectLedger } from '../effect-ledger/in-memory-effect-ledger.js';
 import type { EffectLedger } from '../effect-ledger/types.js';
 import type { MutationEffectType } from '../command-store/types.js';
-import { MutationOpsCollector } from '../ops/mutation-ops.js';
+import {
+  getProcessMutationOpsCollector,
+  MutationOpsCollector,
+  type BookingFailureStage,
+} from '../ops/mutation-ops.js';
 import {
   assertIrreversibleAllowed,
   isLiveModeFromEnv,
+  LiveSafetyError,
   type LiveSafetyModeConfig,
   type StoreDurability,
 } from '../safety/live-safety-mode.js';
@@ -18,6 +23,8 @@ import {
   MutationKillSwitch,
   MutationKillSwitchError,
 } from '../safety/mutation-kill-switch.js';
+import { canonicalJson } from '../util/canonical-json.js';
+import { createHash } from 'node:crypto';
 import { isAmbiguousMutationError } from './ambiguity.js';
 import {
   MoneyPathError,
@@ -30,8 +37,9 @@ export interface MoneyPathExecutorConfig {
   readonly killSwitch?: MutationKillSwitch;
   readonly ops?: MutationOpsCollector;
   /**
-   * Store durability of the injected ledger/persistence.
-   * Defaults to `ephemeral` when ledger is the default in-memory impl.
+   * Optional durability override. May only equal or be stricter-as-ephemeral
+   * relative to the ledger — never upgrade ephemeral → durable.
+   * Default: ledger.durability.
    */
   readonly storeDurability?: StoreDurability;
   /** When true, mock adapters / synthetic ticketing are in use. */
@@ -47,19 +55,43 @@ export interface MoneyPathExecutorConfig {
 }
 
 function requestHash(input: unknown): string {
-  return createHash('sha256').update(JSON.stringify(input)).digest('hex');
+  return createHash('sha256').update(canonicalJson(input)).digest('hex');
 }
 
 function mapEffectType(operation: string): MutationEffectType {
-  if (operation.includes('ticket')) return 'ticket';
-  if (operation.includes('void')) return 'void';
-  if (operation.includes('refund')) return 'refund';
-  if (operation.includes('cancel')) return 'cancel';
-  if (operation.includes('pay')) return 'pay';
-  if (operation.includes('book') || operation.includes('Booking') || operation.includes('order')) {
+  const op = operation.toLowerCase();
+  if (op.includes('ticket')) return 'ticket';
+  if (op.includes('void')) return 'void';
+  if (op.includes('refund')) return 'refund';
+  if (op.includes('cancel')) return 'cancel';
+  if (op.includes('pay')) return 'pay';
+  if (op.includes('book') || op.includes('order') || op.includes('modify')) {
     return 'book';
   }
   return 'book';
+}
+
+function effectTypeToStage(effectType: MutationEffectType): BookingFailureStage {
+  switch (effectType) {
+    case 'book':
+      return 'book';
+    case 'pay':
+      return 'pay';
+    case 'ticket':
+      return 'ticket';
+    case 'void':
+      return 'void';
+    case 'refund':
+      return 'refund';
+    case 'cancel':
+      return 'cancel';
+    case 'exchange':
+      return 'unknown';
+    default: {
+      const _exhaustive: never = effectType;
+      return _exhaustive;
+    }
+  }
 }
 
 /** Shared process kill switch — env engage at import time. */
@@ -84,12 +116,19 @@ export class MoneyPathExecutor {
   private readonly inFlight = new Map<string, Promise<MoneyPathOutcome<unknown>>>();
 
   constructor(config?: MoneyPathExecutorConfig) {
-    const usingDefaultLedger = config?.ledger === undefined;
     this.ledger = config?.ledger ?? new InMemoryEffectLedger();
     this.killSwitch = config?.killSwitch ?? processKillSwitch;
-    this.ops = config?.ops ?? new MutationOpsCollector();
-    this.storeDurability =
-      config?.storeDurability ?? (usingDefaultLedger ? 'ephemeral' : 'durable');
+    this.ops = config?.ops ?? getProcessMutationOpsCollector();
+
+    const ledgerDurability = this.ledger.durability;
+    if (config?.storeDurability === 'durable' && ledgerDurability === 'ephemeral') {
+      throw new LiveSafetyError(
+        'Cannot upgrade ephemeral EffectLedger to durable via storeDurability. ' +
+          'Use FileEffectLedger (or another store-declared durable ledger).',
+      );
+    }
+    this.storeDurability = config?.storeDurability ?? ledgerDurability;
+
     this.mockAdapters = config?.mockAdapters ?? false;
     this.liveMode = config?.liveMode ?? isLiveModeFromEnv();
     this.idFactory = config?.idFactory ?? ((): string => randomUUID());
@@ -191,6 +230,7 @@ export class MoneyPathExecutor {
 
     const hash = requestHash(params.request);
     const effectType = mapEffectType(params.operation);
+    const stage = effectTypeToStage(effectType);
 
     this.ops.recordIrreversible({
       actionId: this.idFactory(),
@@ -210,7 +250,7 @@ export class MoneyPathExecutor {
 
     if (begun.kind === 'conflict') {
       this.ops.recordFailure({
-        stage: effectType === 'cancel' ? 'cancel' : effectType === 'ticket' ? 'ticket' : 'book',
+        stage,
         code: 'IDEMPOTENCY_CONFLICT',
         supplierId: params.supplierId,
       });
@@ -255,7 +295,7 @@ export class MoneyPathExecutor {
       if (isAmbiguousMutationError(error)) {
         await this.ledger.resolve(params.idempotencyKey, 'unknown');
         this.ops.recordFailure({
-          stage: effectType === 'cancel' ? 'cancel' : effectType === 'ticket' ? 'ticket' : 'book',
+          stage,
           code: 'OUTCOME_UNKNOWN',
           supplierId: params.supplierId,
         });
@@ -268,7 +308,7 @@ export class MoneyPathExecutor {
       }
       await this.ledger.resolve(params.idempotencyKey, 'failed');
       this.ops.recordFailure({
-        stage: effectType === 'cancel' ? 'cancel' : effectType === 'ticket' ? 'ticket' : 'book',
+        stage,
         code: 'MUTATION_FAILED',
         supplierId: params.supplierId,
       });

--- a/packages/core/src/ops/index.ts
+++ b/packages/core/src/ops/index.ts
@@ -2,5 +2,9 @@ export type {
   BookingFailureSignal,
   BookingFailureStage,
   IrreversibleAuditEntry,
+  MutationOpsSubscriber,
 } from './mutation-ops.js';
-export { MutationOpsCollector } from './mutation-ops.js';
+export {
+  getProcessMutationOpsCollector,
+  MutationOpsCollector,
+} from './mutation-ops.js';

--- a/packages/core/src/ops/mutation-ops.ts
+++ b/packages/core/src/ops/mutation-ops.ts
@@ -33,27 +33,50 @@ export interface IrreversibleAuditEntry {
   readonly at: string;
 }
 
+export type MutationOpsSubscriber = (signal: {
+  readonly kind: 'failure' | 'irreversible';
+  readonly payload: BookingFailureSignal | IrreversibleAuditEntry;
+}) => void;
+
 export class MutationOpsCollector {
   private readonly failures: BookingFailureSignal[] = [];
   private readonly audits: IrreversibleAuditEntry[] = [];
+  private readonly subscribers: MutationOpsSubscriber[] = [];
   private readonly now: () => Date;
 
   constructor(now: () => Date = () => new Date()) {
     this.now = now;
   }
 
+  /** Optional subscribe hook — no fake external APM. */
+  subscribe(subscriber: MutationOpsSubscriber): () => void {
+    this.subscribers.push(subscriber);
+    return () => {
+      const idx = this.subscribers.indexOf(subscriber);
+      if (idx >= 0) this.subscribers.splice(idx, 1);
+    };
+  }
+
   recordFailure(signal: Omit<BookingFailureSignal, 'at'> & { at?: string }): void {
-    this.failures.push({
+    const entry: BookingFailureSignal = {
       ...signal,
       at: signal.at ?? this.now().toISOString(),
-    });
+    };
+    this.failures.push(entry);
+    for (const sub of this.subscribers) {
+      sub({ kind: 'failure', payload: entry });
+    }
   }
 
   recordIrreversible(entry: Omit<IrreversibleAuditEntry, 'at'> & { at?: string }): void {
-    this.audits.push({
+    const audit: IrreversibleAuditEntry = {
       ...entry,
       at: entry.at ?? this.now().toISOString(),
-    });
+    };
+    this.audits.push(audit);
+    for (const sub of this.subscribers) {
+      sub({ kind: 'irreversible', payload: audit });
+    }
   }
 
   failuresByStage(): ReadonlyMap<BookingFailureStage, number> {
@@ -71,4 +94,11 @@ export class MutationOpsCollector {
   listAudits(): readonly IrreversibleAuditEntry[] {
     return this.audits;
   }
+}
+
+/** Process-global ops collector — mirror of process kill switch. */
+const processOpsCollector = new MutationOpsCollector();
+
+export function getProcessMutationOpsCollector(): MutationOpsCollector {
+  return processOpsCollector;
 }

--- a/packages/core/src/persistence/file-cas-adapter.ts
+++ b/packages/core/src/persistence/file-cas-adapter.ts
@@ -26,6 +26,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
 }
 
 export class FileCompareAndSwapPersistenceAdapter implements CompareAndSwapPersistenceAdapter {
+  readonly durability = 'durable' as const;
   private readonly path: string;
 
   constructor(filePath: string) {

--- a/packages/core/src/persistence/in-memory-adapter.ts
+++ b/packages/core/src/persistence/in-memory-adapter.ts
@@ -29,6 +29,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
  * (see LiveSafetyMode).
  */
 export class InMemoryPersistenceAdapter implements CompareAndSwapPersistenceAdapter {
+  readonly durability = 'ephemeral' as const;
   private readonly store = new Map<string, StoredEntry<unknown>>();
 
   async get<T>(key: string): Promise<T | null> {

--- a/packages/core/src/persistence/types.ts
+++ b/packages/core/src/persistence/types.ts
@@ -9,7 +9,15 @@
  * multi-instance idempotency.
  */
 
+import type { StoreDurability } from '../safety/live-safety-mode.js';
+
 export interface PersistenceAdapter {
+  /**
+   * Store-declared durability. Never self-asserted by callers —
+   * live money paths read this from the concrete store.
+   */
+  readonly durability: StoreDurability;
+
   /** Retrieve a value by key. Returns null if not found or expired. */
   get<T>(key: string): Promise<T | null>;
 

--- a/packages/core/src/pipeline-validator/__tests__/approval-before-execute.test.ts
+++ b/packages/core/src/pipeline-validator/__tests__/approval-before-execute.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PipelineOrchestrator } from '../orchestrator.js';
 import type { Agent } from '../../types/agent.js';
 import type { AgentContract, ReferenceDataProvider } from '../types.js';
 import {
+  CasBoundApprovalTokenStore,
   InMemoryBoundApprovalTokenStore,
   issueBoundApprovalToken,
 } from '../../approval/bound-approval.js';
+import { FileCompareAndSwapPersistenceAdapter } from '../../persistence/file-cas-adapter.js';
+import { LiveSafetyError } from '../../safety/live-safety-mode.js';
 
 const emptyReference: ReferenceDataProvider = {
   async resolveAirport() {
@@ -19,6 +25,13 @@ const emptyReference: ReferenceDataProvider = {
     return null;
   },
 };
+
+function durableApprovalStore(): CasBoundApprovalTokenStore {
+  const dir = mkdtempSync(join(tmpdir(), 'otaip-orch-appr-'));
+  return new CasBoundApprovalTokenStore(
+    new FileCompareAndSwapPersistenceAdapter(join(dir, 'jti.json')),
+  );
+}
 
 describe('approval before execute (DoD 6)', () => {
   it('does not call execute when approval fails', async () => {
@@ -66,9 +79,22 @@ describe('approval before execute (DoD 6)', () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it('live mode refuses ephemeral approval token store', () => {
+    expect(
+      () =>
+        new PipelineOrchestrator({
+          reference: emptyReference,
+          contracts: new Map(),
+          agents: new Map(),
+          liveMode: true,
+          approvalTokenStore: new InMemoryBoundApprovalTokenStore(),
+        }),
+    ).toThrow(LiveSafetyError);
+  });
+
   it('live mode consumes single-use HMAC token before execute', async () => {
     const execute = vi.fn(async () => ({ data: { ok: true }, confidence: 1 }));
-    const store = new InMemoryBoundApprovalTokenStore();
+    const store = durableApprovalStore();
     const secret = 'live-secret';
     const contract: AgentContract = {
       agentId: 'irrev',
@@ -162,6 +188,7 @@ describe('approval before execute (DoD 6)', () => {
       agents: new Map([['irrev', agent]]),
       liveMode: true,
       approvalSecret: '',
+      approvalTokenStore: durableApprovalStore(),
     });
     const session = orch.createSession({
       type: 'test',

--- a/packages/core/src/pipeline-validator/action-classifier.ts
+++ b/packages/core/src/pipeline-validator/action-classifier.ts
@@ -27,8 +27,8 @@ export interface ApprovalPolicy {
   ): SemanticValidationResult;
 }
 
-/** Bound token shape: base64url_body.sha256_hex_signature */
-const BOUND_TOKEN_RE = /^[A-Za-z0-9_-]+\.[a-f0-9]{64}$/;
+/** Bound token shape: v1.base64url_body.hmac_sha256_hex_signature */
+const BOUND_TOKEN_RE = /^v1\.[A-Za-z0-9_-]+\.[a-f0-9]{64}$/;
 
 function defaultValidateApprovalToken(
   token: unknown,

--- a/packages/core/src/pipeline-validator/orchestrator.ts
+++ b/packages/core/src/pipeline-validator/orchestrator.ts
@@ -26,7 +26,7 @@ import {
 } from './action-classifier.js';
 import type { MutationKillSwitch } from '../safety/mutation-kill-switch.js';
 import { getProcessMutationKillSwitch } from '../money-path/money-path-executor.js';
-import { isLiveModeFromEnv } from '../safety/live-safety-mode.js';
+import { isLiveModeFromEnv, LiveSafetyError } from '../safety/live-safety-mode.js';
 import {
   InMemoryBoundApprovalTokenStore,
   consumeBoundApprovalToken,
@@ -185,15 +185,23 @@ export class PipelineOrchestrator {
         );
       }
     }
+    const liveMode = config.liveMode ?? isLiveModeFromEnv();
+    const approvalTokenStore =
+      config.approvalTokenStore ?? new InMemoryBoundApprovalTokenStore();
+    if (liveMode && approvalTokenStore.durability === 'ephemeral') {
+      throw new LiveSafetyError(
+        'Live mode refuses ephemeral BoundApprovalTokenStore. ' +
+          'Inject CasBoundApprovalTokenStore backed by a durable CompareAndSwapPersistenceAdapter.',
+      );
+    }
     this.config = {
       ...config,
       reference: config.reference,
       contracts: config.contracts,
       agents: config.agents,
       killSwitch: config.killSwitch ?? getProcessMutationKillSwitch(),
-      approvalTokenStore:
-        config.approvalTokenStore ?? new InMemoryBoundApprovalTokenStore(),
-      liveMode: config.liveMode ?? isLiveModeFromEnv(),
+      approvalTokenStore,
+      liveMode,
       approvalSecret:
         config.approvalSecret ?? process.env['OTAIP_APPROVAL_SECRET'],
     };

--- a/packages/core/src/rate-limiter/__tests__/rate-limiter.test.ts
+++ b/packages/core/src/rate-limiter/__tests__/rate-limiter.test.ts
@@ -81,4 +81,20 @@ describe('RateLimiter', () => {
     vi.advanceTimersByTime(1001);
     expect(limiter.available).toBe(10);
   });
+
+  it('10 concurrent acquires with maxRequests:1 never exceed 1 dispatch per window', async () => {
+    vi.useRealTimers();
+    const limiter = new RateLimiter({ maxRequests: 1, windowMs: 50 });
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const dispatch = async (): Promise<void> => {
+      await limiter.acquire();
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+    };
+    await Promise.all(Array.from({ length: 10 }, () => dispatch()));
+    expect(maxInFlight).toBe(1);
+  });
 });

--- a/packages/core/src/rate-limiter/rate-limiter.ts
+++ b/packages/core/src/rate-limiter/rate-limiter.ts
@@ -5,12 +5,16 @@ import type { RateLimiterConfig } from './types.js';
  *
  * Adapters should wrap their HTTP calls with `await limiter.acquire()`
  * to respect supplier rate limits and avoid throttling.
+ *
+ * Concurrent waiters are serialized: on wake each waiter rechecks capacity
+ * and only one grant is issued per freed slot.
  */
 export class RateLimiter {
   private readonly maxRequests: number;
   private readonly windowMs: number;
   private readonly timestamps: number[] = [];
   private readonly waitQueue: Array<() => void> = [];
+  private drainScheduled = false;
 
   constructor(config: RateLimiterConfig) {
     this.maxRequests = config.maxRequests;
@@ -29,27 +33,9 @@ export class RateLimiter {
       return;
     }
 
-    // Wait until the oldest request expires
-    const oldestTimestamp = this.timestamps[0]!;
-    const waitTime = oldestTimestamp + this.windowMs - Date.now();
-
-    if (waitTime <= 0) {
-      this.timestamps.shift();
-      this.timestamps.push(Date.now());
-      return;
-    }
-
     await new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        this.pruneExpired();
-        this.timestamps.push(Date.now());
-        resolve();
-      }, waitTime);
-
-      // Prevent timer from blocking Node.js shutdown
-      if (typeof timer === 'object' && 'unref' in timer) {
-        timer.unref();
-      }
+      this.waitQueue.push(resolve);
+      this.scheduleDrain();
     });
   }
 
@@ -65,15 +51,54 @@ export class RateLimiter {
     return this.timestamps.length >= this.maxRequests;
   }
 
-  /** Reset the limiter, clearing all tracked requests. */
+  /** Reset the limiter, clearing tracked requests and granting queued waiters. */
   reset(): void {
     this.timestamps.length = 0;
+    this.grantNextWaiters();
   }
 
   private pruneExpired(): void {
     const cutoff = Date.now() - this.windowMs;
     while (this.timestamps.length > 0 && this.timestamps[0]! <= cutoff) {
       this.timestamps.shift();
+    }
+  }
+
+  private scheduleDrain(): void {
+    if (this.drainScheduled || this.waitQueue.length === 0) return;
+    this.drainScheduled = true;
+
+    this.pruneExpired();
+    if (this.timestamps.length < this.maxRequests) {
+      this.drainScheduled = false;
+      this.grantNextWaiters();
+      return;
+    }
+
+    const oldestTimestamp = this.timestamps[0]!;
+    const waitTime = Math.max(0, oldestTimestamp + this.windowMs - Date.now());
+
+    const timer = setTimeout(() => {
+      this.drainScheduled = false;
+      this.pruneExpired();
+      this.grantNextWaiters();
+      if (this.waitQueue.length > 0) {
+        this.scheduleDrain();
+      }
+    }, waitTime);
+
+    if (typeof timer === 'object' && 'unref' in timer) {
+      timer.unref();
+    }
+  }
+
+  /** Grant at most one waiter per available slot after rechecking capacity. */
+  private grantNextWaiters(): void {
+    this.pruneExpired();
+    while (this.waitQueue.length > 0 && this.timestamps.length < this.maxRequests) {
+      const resolve = this.waitQueue.shift();
+      this.timestamps.push(Date.now());
+      resolve?.();
     }
   }
 }

--- a/packages/core/src/util/canonical-json.ts
+++ b/packages/core/src/util/canonical-json.ts
@@ -1,0 +1,24 @@
+/**
+ * Deterministic JSON serialization: object keys sorted recursively.
+ * Used for request hashes and approval input binding.
+ */
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const out: Record<string, unknown> = {};
+  for (const key of keys) {
+    out[key] = canonicalize(obj[key]);
+  }
+  return out;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Criteria → changes → evidence

| Criterion | What changed | Tests |
|---|---|---|
| 1 Mutations safe | Hotelbeds `fetchOnce` + `MoneyPathExecutor` on book/hard-cancel; HAIP create/modify/cancel via `MoneyPathExecutor`; HAIP registered in `createAdapter` → `GuardedConnectAdapter` | `hotelbeds/.../money-path.test.ts`, `haip/.../money-path.test.ts`, `duffel/.../money-path.test.ts`, `guarded-adapter.test.ts` |
| 2 Money state survives crash | Ledger durability store-declared; `listUnresolved` includes aged `pending` | `money-path-executor.test.ts` |
| 3 Persistence can do #2 | `EffectLedger`/`CAS` `durability`; `InMemory*=ephemeral`, `File*=durable`; reject ephemeral→durable upgrade; `FileEffectLedger` live book | `money-path-executor.test.ts` |
| 4 Supplier backpressure | RateLimiter serializes waiters (recheck capacity); Hotelbeds RL+CB on `request()` | `rate-limiter.test.ts` (10@limit1) |
| 5 Live tickets not invented | Unchanged from prior enforcement | existing live ticket guards |
| 6 Irreversible LLM gate | Real `createHmac`; `v1.` token version; canonical JSON hashes; `CasBoundApprovalTokenStore`; live orchestrator refuses ephemeral token store | `bound-approval.test.ts`, `approval-before-execute.test.ts` |
| 7 Reversal works | `executeReversal` requires shared `MutationExecutor`; void/refund fail closed; Hotelbeds activity/transfer cancel fail closed (`DOMAIN_QUESTION`) | `mutation-executor.test.ts`, activity/transfer adapter tests |
| 8 Ops see/stop damage | Process-global `MutationOpsCollector`; `effectType`→stage 1:1; kill switch | `money-path-executor.test.ts` |

Scorecard: `docs/engineering/PRODUCTION_DOD_SCORECARD.md` (PASS only with drill citations).

Also: `createAdapter({ unguarded: true })` throws in live mode; production Duffel/Hotelbeds endpoints force live.

**Verification:** `pnpm test` — 3424 passed / 17 skipped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3359bdd7-0df8-450b-8493-63132da9a593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3359bdd7-0df8-450b-8493-63132da9a593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

