### PR TITLE
fix: close remaining production DoD money-path holes

### DIFF
--- a/docs/engineering/PRODUCTION_DOD_SCORECARD.md
+++ b/docs/engineering/PRODUCTION_DOD_SCORECARD.md
@@ -8,19 +8,19 @@
 | `opt-in` | Control exists but callers can skip it |
 | `unwired` | Primitive only; not on live paths |
 
-Covered money-path surfaces: Connect `createAdapter` (including HAIP), Duffel, Hotelbeds, orchestrator live approvals.
+Covered money-path surfaces: Connect `createAdapter` (TripPro/Sabre/Navitaire/Amadeus/HAIP), Duffel, Hotelbeds, orchestrator live approvals, MCP mutation tools in live mode.
 
 | # | Criterion | Status | Enforcement | Evidence |
 |---|---|---|---|---|
-| 1 | Mutations safe | PASS | default | `GuardedConnectAdapter` via `createAdapter()`; Duffel/Hotelbeds/HAIP mutations via `MoneyPathExecutor` + `fetchOnce` on unsafe Hotelbeds/Duffel paths; HAIP registered in `createAdapter`. Drills: `packages/adapters/duffel/src/__tests__/money-path.test.ts`, `packages/adapters/hotelbeds/src/__tests__/money-path.test.ts`, `packages/connect/src/suppliers/haip/__tests__/money-path.test.ts`, `packages/connect/src/__tests__/guarded-adapter.test.ts` — 503/timeout → one wire call; replay → zero additional; `OUTCOME_UNKNOWN` |
-| 2 | Money state survives crash | PASS | default | Effect ledger replay + concurrent idempotency; `listUnresolved` includes aged `pending` crash-left records (`money-path-executor.test.ts`). Live refuses ephemeral ledgers. |
-| 3 | Persistence can do #2 | PASS | default | Store-declared `durability` on `EffectLedger` / CAS adapters; `InMemory*=ephemeral`, `File*=durable`; `MoneyPathExecutor` reads ledger durability and rejects ephemeral→durable upgrade; `FileEffectLedger` live book drill in `money-path-executor.test.ts` |
-| 4 | Supplier backpressure real | PASS | default | `BaseAdapter` RL+CB on by default; Duffel/Hotelbeds RL+CB on `request()`; `RateLimiter` serializes concurrent waiters — `rate-limiter.test.ts` (10@limit1) |
-| 5 | Live tickets not invented | PASS | default | `issueTickets` liveMode guard; example OTA Duffel path uses order documents only (no synthetic serials in live) |
-| 6 | Irreversible LLM gate has teeth | PASS | default | `action_class` before `execute` for mutations; tokens use `createHmac('sha256')` with `v1.` prefix (`bound-approval.test.ts`); `CasBoundApprovalTokenStore` durable single-use; live orchestrator refuses ephemeral token store; forged/legacy-hash-concat/replay-across-CAS-instances/expired/wrong-hash rejected (`approval-before-execute.test.ts`, `bound-approval.test.ts`) |
-| 7 | Reversal works | PASS | default | `executeReversal` requires shared `MutationExecutor` (no `liveMode:false` fresh-ledger default); `void`/`refund` fail closed; cancel idempotent across shared executor (`mutation-executor.test.ts`); Duffel flight cancel / Hotelbeds activity+transfer cancel refuse rather than invent |
-| 8 | Ops see/stop damage | PASS | default | Process-global `MutationOpsCollector` + kill switch on `MoneyPathExecutor`; `effectType`→`BookingFailureStage` 1:1 (refund→`refund`); env `OTAIP_MUTATION_KILL_SWITCH=1`; orchestrator uses same switch |
+| 1 | Mutations safe | PASS | default | `GuardedConnectAdapter` via `createAdapter()` (HAIP self-guarded); Duffel/Hotelbeds/HAIP/`MoneyPathExecutor`; TripPro SOAP ticket/cancel via `fetchOnce`; Amadeus cancel rethrows ambiguous errors. Drills: `duffel/.../money-path.test.ts`, `hotelbeds/.../money-path.test.ts`, `haip/.../money-path.test.ts`, `trippro/.../money-path.test.ts`, `amadeus/.../cancel-money-path.test.ts` — 503 → one wire call; replay → zero; `OUTCOME_UNKNOWN` |
+| 2 | Money state survives crash | PASS | default | Effect ledger replay; `listUnresolved` includes aged `pending`; live refuses ephemeral ledgers (`money-path-executor.test.ts`) |
+| 3 | Persistence can do #2 | PASS | default (single-host) | Store-declared durability; reject ephemeral→durable upgrade; `FileEffectLedger` live book; File CAS exclusive lockfile around RMW (`cas-persistence.test.ts` flock tests). **Caveat:** File CAS is single-host durable reference — not a distributed multi-region DB; multi-node deployers inject their own CAS. |
+| 4 | Supplier backpressure real | PASS | default | `BaseAdapter` RL+CB on by default; Duffel/Hotelbeds RL+CB on `request()`; HAIP mutations go through `withRetry` (unsafe → maxRetries 0) so RL+CB engage; TripPro cancel via `withRetry`; RateLimiter serializes waiters — `rate-limiter.test.ts` (10@limit1), `haip/.../money-path.test.ts` (breaker opens) |
+| 5 | Live tickets not invented | PASS | default | `issueTickets` liveMode guard; Duffel maps order documents only |
+| 6 | Irreversible LLM gate has teeth | PASS | default | Orchestrator: `createHmac` + `v1.` + durable single-use; live refuses ephemeral token store. MCP live: `create_booking`/`request_ticketing`/`cancel_booking` require consume before adapter (`mcp-live-approval.test.ts`) |
+| 7 | Reversal works | PASS | default | `executeReversal` requires shared executor; void/refund fail closed; Amadeus ambiguous cancel not ledger-succeeded; Duffel flight / Hotelbeds activity+transfer cancel refuse |
+| 8 | Ops see/stop damage | PASS | default | Process-global `MutationOpsCollector` + kill switch; `effectType`→stage 1:1; `OTAIP_MUTATION_KILL_SWITCH=1` |
 
-**Score: 8 / 8 PASS** under **default-enforced** definition (library drills + fault injection).
+**Score: 8 / 8 PASS** under **default-enforced** definition (library drills + fault injection), with File CAS scoped as single-host durable reference.
 
-Still not a turnkey OTA/TMC: no real credentials in repo; Duffel flight cancel unsupported by design; Hotelbeds activity/transfer cancel fail closed pending DOMAIN_QUESTION; Connect `BookingPipeline`/`PaymentHandoff` remain labeled stubs. Live supplier credentials remain deployer-owned.
+Still not a turnkey OTA/TMC: no real credentials in repo; Duffel flight cancel unsupported by design; Hotelbeds activity/transfer cancel fail closed pending DOMAIN_QUESTION; Connect `BookingPipeline`/`PaymentHandoff` remain labeled stubs. Live supplier credentials and multi-node CAS remain deployer-owned.

--- a/packages/connect/src/base-adapter.ts
+++ b/packages/connect/src/base-adapter.ts
@@ -200,7 +200,7 @@ export abstract class BaseAdapter {
     }
   }
 
-  private isTransportFailure(error: unknown): boolean {
+  protected isTransportFailure(error: unknown): boolean {
     if (error instanceof ConnectError) return error.retryable;
     if (error instanceof Error) {
       const msg = error.message.toLowerCase();

--- a/packages/connect/src/channels/claude/__tests__/mcp-live-approval.test.ts
+++ b/packages/connect/src/channels/claude/__tests__/mcp-live-approval.test.ts
@@ -1,0 +1,221 @@
+/**
+ * MCP live mutations require bound approval before adapter is called.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  CasBoundApprovalTokenStore,
+  FileCompareAndSwapPersistenceAdapter,
+  issueBoundApprovalToken,
+} from '@otaip/core';
+import type { ConnectAdapter } from '../../../types.js';
+import { generateMcpServer } from '../mcp-server.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockAdapter(spies: {
+  createBooking: ReturnType<typeof vi.fn>;
+  cancelBooking: ReturnType<typeof vi.fn>;
+}): ConnectAdapter {
+  return {
+    supplierId: 'mock',
+    supplierName: 'Mock',
+    async searchFlights() {
+      return [];
+    },
+    async priceItinerary() {
+      throw new Error('n/a');
+    },
+    createBooking: spies.createBooking,
+    async getBookingStatus() {
+      throw new Error('n/a');
+    },
+    requestTicketing: vi.fn(async () => ({
+      bookingId: 'B1',
+      supplier: 'mock',
+      status: 'ticketed' as const,
+      segments: [],
+      passengers: [],
+      totalPrice: { amount: '1', currency: 'USD' },
+    })),
+    cancelBooking: spies.cancelBooking,
+    async healthCheck() {
+      return { healthy: true, latencyMs: 1 };
+    },
+  };
+}
+
+async function withClient(
+  adapter: ConnectAdapter,
+  config: Parameters<typeof generateMcpServer>[1],
+  fn: (client: Client) => Promise<void>,
+): Promise<void> {
+  const server = generateMcpServer(adapter, config);
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  try {
+    await fn(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+describe('MCP live approval gate', () => {
+  it('refuses create_booking without token in live mode — adapter not called', async () => {
+    const createBooking = vi.fn(async () => ({ bookingId: 'B1' }));
+    const cancelBooking = vi.fn(async () => ({ success: true, message: 'ok' }));
+    const store = new CasBoundApprovalTokenStore(
+      new FileCompareAndSwapPersistenceAdapter(
+        join(mkdtempSync(join(tmpdir(), 'mcp-appr-')), 'jti.json'),
+      ),
+    );
+
+    await withClient(
+      mockAdapter({ createBooking, cancelBooking }),
+      {
+        serverName: 'test',
+        version: '1',
+        liveMode: true,
+        approvalSecret: 'live-secret',
+        approvalTokenStore: store,
+        sessionId: 'mcp-session',
+        agentId: 'mcp-connect',
+      },
+      async (client) => {
+        const result = await client.callTool({
+          name: 'create_booking',
+          arguments: {
+            offerId: 'off_1',
+            passengers: [
+              {
+                type: 'adult',
+                gender: 'M',
+                firstName: 'A',
+                lastName: 'B',
+                dateOfBirth: '1990-01-01',
+              },
+            ],
+            contact: { email: 'a@b.com', phone: '+1' },
+            idempotencyKey: 'k1',
+          },
+        });
+        expect(result.isError).toBe(true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0]!.text).toMatch(/approval/i);
+        expect(createBooking).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it('refuses forged token — adapter not called', async () => {
+    const createBooking = vi.fn(async () => ({ bookingId: 'B1' }));
+    const cancelBooking = vi.fn(async () => ({ success: true, message: 'ok' }));
+    const store = new CasBoundApprovalTokenStore(
+      new FileCompareAndSwapPersistenceAdapter(
+        join(mkdtempSync(join(tmpdir(), 'mcp-appr-')), 'jti.json'),
+      ),
+    );
+
+    await withClient(
+      mockAdapter({ createBooking, cancelBooking }),
+      {
+        serverName: 'test',
+        version: '1',
+        liveMode: true,
+        approvalSecret: 'live-secret',
+        approvalTokenStore: store,
+      },
+      async (client) => {
+        const result = await client.callTool({
+          name: 'cancel_booking',
+          arguments: {
+            bookingId: 'B1',
+            approvalToken: 'v1.forged.deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+          },
+        });
+        expect(result.isError).toBe(true);
+        expect(cancelBooking).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it('accepts valid token once; replay rejected', async () => {
+    const createBooking = vi.fn(async () => ({
+      bookingId: 'B1',
+      supplier: 'mock',
+      status: 'confirmed' as const,
+      segments: [],
+      passengers: [],
+      totalPrice: { amount: '1', currency: 'USD' },
+    }));
+    const cancelBooking = vi.fn(async () => ({ success: true, message: 'ok' }));
+    const store = new CasBoundApprovalTokenStore(
+      new FileCompareAndSwapPersistenceAdapter(
+        join(mkdtempSync(join(tmpdir(), 'mcp-appr-')), 'jti.json'),
+      ),
+    );
+    const secret = 'live-secret';
+    const sessionId = 'mcp-session';
+    const agentId = 'mcp-connect';
+
+    await withClient(
+      mockAdapter({ createBooking, cancelBooking }),
+      {
+        serverName: 'test',
+        version: '1',
+        liveMode: true,
+        approvalSecret: secret,
+        approvalTokenStore: store,
+        sessionId,
+        agentId,
+      },
+      async (client) => {
+        const input = {
+          offerId: 'off_1',
+          passengers: [
+            {
+              type: 'adult' as const,
+              gender: 'M' as const,
+              firstName: 'A',
+              lastName: 'B',
+              dateOfBirth: '1990-01-01',
+            },
+          ],
+          contact: { email: 'a@b.com', phone: '+1' },
+          idempotencyKey: 'k1',
+        };
+        const token = issueBoundApprovalToken({
+          sessionId,
+          agentId,
+          input,
+          secret,
+        });
+
+        const ok = await client.callTool({
+          name: 'create_booking',
+          arguments: { ...input, approvalToken: token },
+        });
+        expect(ok.isError).toBeFalsy();
+        expect(createBooking).toHaveBeenCalledOnce();
+
+        createBooking.mockClear();
+        const replay = await client.callTool({
+          name: 'create_booking',
+          arguments: { ...input, approvalToken: token },
+        });
+        expect(replay.isError).toBe(true);
+        expect(createBooking).not.toHaveBeenCalled();
+      },
+    );
+  });
+});

--- a/packages/connect/src/channels/claude/mcp-server.ts
+++ b/packages/connect/src/channels/claude/mcp-server.ts
@@ -1,10 +1,25 @@
 /**
  * Creates an MCP server that exposes ConnectAdapter methods as tools.
  * The server is transport-agnostic — the consumer connects it to stdio, SSE, etc.
+ *
+ * Live mode: create_booking / request_ticketing / cancel_booking require a
+ * bound approval token (createHmac + durable single-use consume) before the
+ * adapter is called (DoD 6).
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CasBoundApprovalTokenStore,
+  consumeBoundApprovalToken,
+  createBoundApprovalPolicy,
+  FileCompareAndSwapPersistenceAdapter,
+  isLiveModeFromEnv,
+  type BoundApprovalTokenStore,
+} from '@otaip/core';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type {
   ConnectAdapter,
   CreateBookingInput,
@@ -14,11 +29,26 @@ import type {
 } from '../../types.js';
 import { generateMcpTools } from './tool-generator.js';
 
+const MUTATION_TOOLS = new Set(['create_booking', 'request_ticketing', 'cancel_booking']);
+
 export interface McpServerConfig {
   serverName: string;
   serverDescription?: string;
   version: string;
   whiteLabel?: WhiteLabelConfig;
+  /**
+   * Override live detection. Default: isLiveModeFromEnv().
+   * Live mutations require approvalToken + OTAIP_APPROVAL_SECRET.
+   */
+  liveMode?: boolean;
+  /** HMAC secret. Defaults to OTAIP_APPROVAL_SECRET. */
+  approvalSecret?: string;
+  /** Durable token store for live single-use. Defaults to file-backed CAS. */
+  approvalTokenStore?: BoundApprovalTokenStore;
+  /** Session id bound into approval tokens. Default: mcp-session. */
+  sessionId?: string;
+  /** Agent id bound into approval tokens. Default: mcp-connect. */
+  agentId?: string;
 }
 
 function arg<T>(args: Record<string, unknown> | undefined, key: string): T {
@@ -29,13 +59,45 @@ function argsAs<T>(args: Record<string, unknown> | undefined): T {
   return (args ?? {}) as unknown as T;
 }
 
+function defaultDurableApprovalStore(): BoundApprovalTokenStore {
+  const dir = mkdtempSync(join(tmpdir(), 'otaip-mcp-appr-'));
+  return new CasBoundApprovalTokenStore(
+    new FileCompareAndSwapPersistenceAdapter(join(dir, 'jti.json')),
+  );
+}
+
+function toolError(message: string): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [{ type: 'text' as const, text: message }],
+    isError: true,
+  };
+}
+
 export function generateMcpServer(adapter: ConnectAdapter, config: McpServerConfig): Server {
   const server = new Server(
     { name: config.serverName, version: config.version },
     { capabilities: { tools: {} } },
   );
 
-  const tools = generateMcpTools(adapter, config.whiteLabel);
+  const liveMode = config.liveMode ?? isLiveModeFromEnv();
+  const approvalSecret =
+    (config.approvalSecret ?? process.env['OTAIP_APPROVAL_SECRET'] ?? '').trim() || undefined;
+  const sessionId = config.sessionId ?? 'mcp-session';
+  const agentId = config.agentId ?? 'mcp-connect';
+  const approvalTokenStore =
+    config.approvalTokenStore ??
+    (liveMode ? defaultDurableApprovalStore() : undefined);
+
+  if (liveMode && approvalTokenStore && approvalTokenStore.durability === 'ephemeral') {
+    throw new Error(
+      'MCP live mode refuses ephemeral BoundApprovalTokenStore — inject CasBoundApprovalTokenStore with durable CAS',
+    );
+  }
+
+  const tools = generateMcpTools(adapter, config.whiteLabel, { liveMode });
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools,
@@ -45,6 +107,46 @@ export function generateMcpServer(adapter: ConnectAdapter, config: McpServerConf
     const { name, arguments: args } = request.params;
 
     try {
+      if (MUTATION_TOOLS.has(name) && liveMode) {
+        if (!approvalSecret) {
+          return toolError(
+            'Live mode requires OTAIP_APPROVAL_SECRET (or approvalSecret) for MCP mutation tools',
+          );
+        }
+        if (!approvalTokenStore) {
+          return toolError('Live mode requires a durable BoundApprovalTokenStore');
+        }
+        const token = args?.['approvalToken'];
+        if (typeof token !== 'string' || token.length === 0) {
+          return toolError('Approval token is missing or empty');
+        }
+        const expectedInput = { ...(args ?? {}) };
+        delete expectedInput['approvalToken'];
+        const policy = createBoundApprovalPolicy({
+          secret: approvalSecret,
+          store: approvalTokenStore,
+          sessionId,
+          agentId,
+          expectedInput,
+        });
+        const structural = policy.validateApprovalToken?.(token, 'mutation_irreversible');
+        if (!structural?.ok) {
+          const msg =
+            structural && !structural.ok
+              ? (structural.issues[0]?.message ?? 'Approval token invalid')
+              : 'Approval token invalid';
+          return toolError(msg);
+        }
+        const consumed = await consumeBoundApprovalToken(token, approvalSecret, approvalTokenStore);
+        if (!consumed.ok) {
+          const msg =
+            !consumed.ok
+              ? (consumed.issues[0]?.message ?? 'Approval token rejected')
+              : 'Approval token rejected';
+          return toolError(msg);
+        }
+      }
+
       let result: unknown;
 
       switch (name) {
@@ -59,9 +161,12 @@ export function generateMcpServer(adapter: ConnectAdapter, config: McpServerConf
           );
           break;
 
-        case 'create_booking':
-          result = await adapter.createBooking(argsAs<CreateBookingInput>(args));
+        case 'create_booking': {
+          const bookingArgs = { ...(args ?? {}) };
+          delete bookingArgs['approvalToken'];
+          result = await adapter.createBooking(argsAs<CreateBookingInput>(bookingArgs));
           break;
+        }
 
         case 'get_booking':
           result = await adapter.getBookingStatus(arg<string>(args, 'bookingId'));
@@ -69,24 +174,14 @@ export function generateMcpServer(adapter: ConnectAdapter, config: McpServerConf
 
         case 'request_ticketing':
           if (!adapter.requestTicketing) {
-            return {
-              content: [
-                { type: 'text' as const, text: 'Ticketing is not supported by this supplier.' },
-              ],
-              isError: true,
-            };
+            return toolError('Ticketing is not supported by this supplier.');
           }
           result = await adapter.requestTicketing(arg<string>(args, 'bookingId'));
           break;
 
         case 'cancel_booking':
           if (!adapter.cancelBooking) {
-            return {
-              content: [
-                { type: 'text' as const, text: 'Cancellation is not supported by this supplier.' },
-              ],
-              isError: true,
-            };
+            return toolError('Cancellation is not supported by this supplier.');
           }
           result = await adapter.cancelBooking(arg<string>(args, 'bookingId'));
           break;
@@ -96,10 +191,7 @@ export function generateMcpServer(adapter: ConnectAdapter, config: McpServerConf
           break;
 
         default:
-          return {
-            content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }],
-            isError: true,
-          };
+          return toolError(`Unknown tool: ${name}`);
       }
 
       return {
@@ -107,10 +199,7 @@ export function generateMcpServer(adapter: ConnectAdapter, config: McpServerConf
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      return {
-        content: [{ type: 'text' as const, text: message }],
-        isError: true,
-      };
+      return toolError(message);
     }
   });
 

--- a/packages/connect/src/channels/claude/tool-generator.ts
+++ b/packages/connect/src/channels/claude/tool-generator.ts
@@ -57,12 +57,19 @@ const passengerDetailSchema = {
   required: ['type', 'gender', 'firstName', 'lastName', 'dateOfBirth'],
 } as const;
 
+export interface GenerateMcpToolsOptions {
+  /** When true, mutation tools require approvalToken in the schema. */
+  readonly liveMode?: boolean;
+}
+
 export function generateMcpTools(
   adapter: ConnectAdapter,
   whiteLabel?: WhiteLabelConfig,
+  options?: GenerateMcpToolsOptions,
 ): McpToolDefinition[] {
   const brand = whiteLabel?.brandName;
   const brandPrefix = brand ? `${brand}: ` : '';
+  const liveMode = options?.liveMode ?? false;
 
   const tools: McpToolDefinition[] = [
     {
@@ -106,7 +113,7 @@ export function generateMcpTools(
     },
     {
       name: 'create_booking',
-      description: `${brandPrefix}Create a flight booking with passenger details and contact information. Payment is held, not charged immediately.`,
+      description: `${brandPrefix}Create a flight booking with passenger details and contact information. Payment is held, not charged immediately.${liveMode ? ' Requires bound approvalToken in live mode.' : ''}`,
       inputSchema: {
         type: 'object',
         properties: {
@@ -117,8 +124,22 @@ export function generateMcpTools(
             description: 'Passenger details for all travelers',
           },
           contact: { ...contactInfoSchema, description: 'Primary contact information' },
+          ...(liveMode
+            ? {
+                approvalToken: {
+                  type: 'string',
+                  description: 'Bound single-use approval token (issueBoundApprovalToken)',
+                },
+                idempotencyKey: {
+                  type: 'string',
+                  description: 'Idempotency key for money-path book',
+                },
+              }
+            : {}),
         },
-        required: ['offerId', 'passengers', 'contact'],
+        required: liveMode
+          ? ['offerId', 'passengers', 'contact', 'approvalToken', 'idempotencyKey']
+          : ['offerId', 'passengers', 'contact'],
       },
     },
     {
@@ -145,13 +166,21 @@ export function generateMcpTools(
   if (adapter.requestTicketing) {
     tools.splice(4, 0, {
       name: 'request_ticketing',
-      description: `${brandPrefix}Request ticket issuance for a confirmed booking.`,
+      description: `${brandPrefix}Request ticket issuance for a confirmed booking.${liveMode ? ' Requires bound approvalToken in live mode.' : ''}`,
       inputSchema: {
         type: 'object',
         properties: {
           bookingId: { type: 'string', description: 'The booking reference ID to ticket' },
+          ...(liveMode
+            ? {
+                approvalToken: {
+                  type: 'string',
+                  description: 'Bound single-use approval token (issueBoundApprovalToken)',
+                },
+              }
+            : {}),
         },
-        required: ['bookingId'],
+        required: liveMode ? ['bookingId', 'approvalToken'] : ['bookingId'],
       },
     });
   }
@@ -159,13 +188,21 @@ export function generateMcpTools(
   if (adapter.cancelBooking) {
     tools.splice(adapter.requestTicketing ? 5 : 4, 0, {
       name: 'cancel_booking',
-      description: `${brandPrefix}Cancel an existing booking.`,
+      description: `${brandPrefix}Cancel an existing booking.${liveMode ? ' Requires bound approvalToken in live mode.' : ''}`,
       inputSchema: {
         type: 'object',
         properties: {
           bookingId: { type: 'string', description: 'The booking reference ID to cancel' },
+          ...(liveMode
+            ? {
+                approvalToken: {
+                  type: 'string',
+                  description: 'Bound single-use approval token (issueBoundApprovalToken)',
+                },
+              }
+            : {}),
         },
-        required: ['bookingId'],
+        required: liveMode ? ['bookingId', 'approvalToken'] : ['bookingId'],
       },
     });
   }

--- a/packages/connect/src/suppliers/amadeus/__tests__/cancel-money-path.test.ts
+++ b/packages/connect/src/suppliers/amadeus/__tests__/cancel-money-path.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Amadeus cancel must not swallow ambiguous errors as { success: false }.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { createAdapter, GuardedConnectAdapter } from '../../../index.js';
+import { AmadeusAdapter } from '../index.js';
+
+describe('Amadeus cancel money-path', () => {
+  it('ambiguous 503 delete throws — not swallowed as success:false', async () => {
+    const deleteFn = vi.fn(async () => {
+      throw new Error('Amadeus API error 503: unavailable');
+    });
+    const adapter = Object.create(AmadeusAdapter.prototype) as AmadeusAdapter;
+    Object.assign(adapter, {
+      supplierId: 'amadeus',
+      withRetry: async (_op: string, fn: () => Promise<unknown>) => fn(),
+      client: {
+        booking: {
+          flightOrders: () => ({ delete: deleteFn }),
+        },
+      },
+    });
+
+    await expect(adapter.cancelBooking('ORD-1')).rejects.toThrow(/503/);
+    expect(deleteFn).toHaveBeenCalledOnce();
+  });
+
+  it('Guarded path surfaces OutcomeUnknownError on ambiguous cancel; replay zero', async () => {
+    const { guardAdapter } = await import('../../../guarded-adapter.js');
+    let calls = 0;
+    const raw = {
+      supplierId: 'amadeus-stub',
+      supplierName: 'stub',
+      async searchFlights() {
+        return [];
+      },
+      async priceItinerary() {
+        throw new Error('n/a');
+      },
+      async createBooking() {
+        throw new Error('n/a');
+      },
+      async getBookingStatus() {
+        throw new Error('n/a');
+      },
+      async cancelBooking() {
+        calls += 1;
+        throw new Error('Amadeus API error 503: unavailable');
+      },
+      async healthCheck() {
+        return { healthy: true, latencyMs: 1 };
+      },
+    };
+    const guarded = guardAdapter(raw, { liveMode: false });
+    expect(guarded).toBeInstanceOf(GuardedConnectAdapter);
+    await expect(guarded.cancelBooking('X')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(guarded.cancelBooking('X')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(calls).toBe(1);
+  });
+
+  it('createAdapter registers amadeus as GuardedConnectAdapter', () => {
+    const adapter = createAdapter(
+      'amadeus',
+      { clientId: 'id', clientSecret: 'secret', environment: 'test' },
+      { liveMode: false },
+    );
+    expect(adapter).toBeInstanceOf(GuardedConnectAdapter);
+  });
+});

--- a/packages/connect/src/suppliers/amadeus/index.ts
+++ b/packages/connect/src/suppliers/amadeus/index.ts
@@ -46,6 +46,22 @@ interface CacheEntry<T> {
 
 const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
+/** 5xx / network / timeout shaped errors — cancel outcome unknown. */
+function isAmbiguousCancelError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes('timeout') ||
+    lower.includes('network') ||
+    lower.includes('econnreset') ||
+    lower.includes('econnrefused') ||
+    lower.includes('fetch failed') ||
+    lower.includes('aborted') ||
+    /\b5\d\d\b/.test(lower) ||
+    lower.includes('429')
+  );
+}
+
 export class AmadeusAdapter extends BaseAdapter implements ConnectAdapter {
   readonly supplierId = 'amadeus';
   readonly supplierName = 'Amadeus Self-Service';
@@ -186,6 +202,11 @@ export class AmadeusAdapter extends BaseAdapter implements ConnectAdapter {
         await this.client.booking.flightOrders(bookingId).delete();
         return { success: true, message: `Booking ${bookingId} cancelled` };
       } catch (error: unknown) {
+        // Ambiguous / transport failures must propagate so MoneyPathExecutor
+        // records OUTCOME_UNKNOWN — never swallow into { success: false }.
+        if (isAmbiguousCancelError(error)) {
+          throw error instanceof Error ? error : new Error(String(error));
+        }
         const message = error instanceof Error ? error.message : String(error);
         return { success: false, message };
       }

--- a/packages/connect/src/suppliers/haip/__tests__/money-path.test.ts
+++ b/packages/connect/src/suppliers/haip/__tests__/money-path.test.ts
@@ -1,10 +1,11 @@
 /**
- * HAIP money-path: create/cancel once-only on ambiguous failure.
+ * HAIP money-path: create/cancel once-only on ambiguous failure + RL/CB.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OutcomeUnknownError } from '@otaip/core';
-import { createAdapter, GuardedConnectAdapter } from '../../../index.js';
+import { createAdapter } from '../../../index.js';
+import { HaipConnectBridge } from '../connect-bridge.js';
 import { HaipAdapter } from '../index.js';
 
 afterEach(() => {
@@ -74,13 +75,54 @@ describe('HAIP money-path', () => {
     expect(deletes).toBe(1);
   });
 
-  it('createAdapter registers haip as GuardedConnectAdapter', () => {
+  it('createAdapter registers haip as self-guarded HaipConnectBridge (no double Guarded)', () => {
     const adapter = createAdapter(
       'haip',
       { baseUrl: 'http://haip.test.local', apiKey: '' },
       { liveMode: false },
     );
-    expect(adapter).toBeInstanceOf(GuardedConnectAdapter);
+    expect(adapter).toBeInstanceOf(HaipConnectBridge);
+  });
+
+  it('createAdapter cancel is once-only on 503', async () => {
+    let deletes = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).includes('/bookings/')) {
+          deletes += 1;
+          return new Response('timeout', { status: 503 });
+        }
+        return new Response('{}', { status: 404 });
+      }),
+    );
+    const adapter = createAdapter(
+      'haip',
+      { baseUrl: 'http://haip.test.local', apiKey: '' },
+      { liveMode: false },
+    );
+    await expect(adapter.cancelBooking!('CONF-2')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.cancelBooking!('CONF-2')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(deletes).toBe(1);
+  });
+
+  it('mutations engage circuit breaker (open after failures)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('down', { status: 503 })),
+    );
+    const adapter = new HaipAdapter(
+      { baseUrl: 'http://haip.test.local', apiKey: '', maxRetries: 0 },
+      { liveMode: false },
+    );
+    // Trip the breaker (failureThreshold default 5)
+    for (let i = 0; i < 5; i++) {
+      await expect(
+        adapter.createBooking({ ...BOOK_PARAMS, idempotencyKey: `trip-${i}` }),
+      ).rejects.toBeTruthy();
+    }
+    const status = adapter.getCircuitBreakerStatus();
+    expect(status.state).toBe('open');
   });
 
   it('requires idempotencyKey in live mode', async () => {
@@ -94,5 +136,15 @@ describe('HAIP money-path', () => {
         idempotencyKey: undefined,
       }),
     ).rejects.toThrow(/idempotencyKey/);
+  });
+
+  it('createBookingOnce is not publicly callable', () => {
+    const adapter = new HaipAdapter(
+      { baseUrl: 'http://haip.test.local', apiKey: '' },
+      { liveMode: false },
+    );
+    expect(
+      (adapter as unknown as { createBookingOnce?: unknown }).createBookingOnce,
+    ).toBeUndefined();
   });
 });

--- a/packages/connect/src/suppliers/haip/connect-bridge.ts
+++ b/packages/connect/src/suppliers/haip/connect-bridge.ts
@@ -1,7 +1,7 @@
 /**
- * ConnectAdapter bridge for HAIP lodging — enables createAdapter('haip')
- * to return GuardedConnectAdapter. Flight search/price/book are unsupported;
- * cancel/status/health delegate to HaipAdapter once-methods (Guarded owns ledger).
+ * ConnectAdapter bridge for HAIP lodging — createAdapter('haip') returns this
+ * without GuardedConnectAdapter (HaipAdapter already owns MoneyPathExecutor).
+ * Flight search/price/book are unsupported; cancel/status/health delegate to HaipAdapter.
  */
 
 import { MoneyPathError } from '@otaip/core';
@@ -16,20 +16,31 @@ import type {
   PricedItinerary,
   SearchFlightsInput,
 } from '../../types.js';
-import { HaipAdapter } from './index.js';
+import { HaipAdapter, type HaipAdapterOptions } from './index.js';
+
+export interface HaipConnectBridgeOptions {
+  readonly liveMode?: boolean;
+  readonly moneyPath?: HaipAdapterOptions['moneyPath'];
+  readonly storeDurability?: HaipAdapterOptions['storeDurability'];
+}
 
 export class HaipConnectBridge implements ConnectAdapter {
   readonly supplierId = 'haip';
   readonly supplierName = 'HAIP PMS';
   private readonly haip: HaipAdapter;
 
-  constructor(config: unknown) {
-    this.haip = new HaipAdapter(config, { liveMode: false });
+  constructor(config: unknown, options?: HaipConnectBridgeOptions) {
+    this.haip = new HaipAdapter(config, {
+      ...(options?.liveMode !== undefined ? { liveMode: options.liveMode } : {}),
+      ...(options?.moneyPath !== undefined ? { moneyPath: options.moneyPath } : {}),
+      ...(options?.storeDurability !== undefined
+        ? { storeDurability: options.storeDurability }
+        : {}),
+    });
   }
 
-  /** Underlying lodging adapter (money-path enforced on direct use). */
-  get lodgingAdapter(): HaipAdapter {
-    return this.haip;
+  get moneyPathExecutor() {
+    return this.haip.moneyPathExecutor;
   }
 
   async searchFlights(_input: SearchFlightsInput): Promise<FlightOffer[]> {
@@ -84,8 +95,10 @@ export class HaipConnectBridge implements ConnectAdapter {
   async cancelBooking(
     bookingId: string,
   ): Promise<{ success: boolean; message: string }> {
-    // Once-method: GuardedConnectAdapter / MutationExecutor owns the ledger.
-    const result = await this.haip.cancelBookingOnce(bookingId);
+    // Ledger + RL+CB owned by HaipAdapter (no GuardedConnectAdapter double-wrap).
+    const result = await this.haip.cancelBooking(bookingId, {
+      idempotencyKey: `cancel:${bookingId}`,
+    });
     return {
       success: result.status === 'cancelled',
       message: result.message ?? 'cancelled',

--- a/packages/connect/src/suppliers/haip/index.ts
+++ b/packages/connect/src/suppliers/haip/index.ts
@@ -268,26 +268,28 @@ export class HaipAdapter extends BaseAdapter {
         rooms: params.rooms,
       },
       supplierId: 'haip',
-      fn: () => this.createBookingOnce(params),
+      fn: () => this.#createBookingOnce(params),
     });
   }
 
-  /** Single-attempt book — used by MoneyPathExecutor and Connect bridge. */
-  async createBookingOnce(params: HaipBookingParams): Promise<HaipBookingResult> {
-    const body: HaipBookRequest = {
-      propertyId: params.propertyId,
-      roomTypeId: params.roomTypeId,
-      rateId: params.rateId,
-      checkIn: params.checkIn,
-      checkOut: params.checkOut,
-      rooms: params.rooms,
-      guest: params.guest,
-      externalConfirmationCode: params.externalConfirmationCode,
-      specialRequests: params.specialRequests,
-    };
+  /** Single-attempt book with RL+CB (unsafe → maxRetries 0). */
+  async #createBookingOnce(params: HaipBookingParams): Promise<HaipBookingResult> {
+    return this.withRetry('createBooking', async () => {
+      const body: HaipBookRequest = {
+        propertyId: params.propertyId,
+        roomTypeId: params.roomTypeId,
+        rateId: params.rateId,
+        checkIn: params.checkIn,
+        checkOut: params.checkOut,
+        rooms: params.rooms,
+        guest: params.guest,
+        externalConfirmationCode: params.externalConfirmationCode,
+        specialRequests: params.specialRequests,
+      };
 
-    const response = await this.request<HaipBookResponse>('POST', '/api/v1/connect/book', body);
-    return mapBookingResponse(response, params.externalConfirmationCode);
+      const response = await this.request<HaipBookResponse>('POST', '/api/v1/connect/book', body);
+      return mapBookingResponse(response, params.externalConfirmationCode);
+    });
   }
 
   async getBookingStatus(confirmationNumber: string): Promise<HaipVerificationResult> {
@@ -318,31 +320,33 @@ export class HaipAdapter extends BaseAdapter {
       idempotencyKey,
       request: { confirmationNumber, changes },
       supplierId: 'haip',
-      fn: () => this.modifyBookingOnce(confirmationNumber, changes),
+      fn: () => this.#modifyBookingOnce(confirmationNumber, changes),
     });
   }
 
-  async modifyBookingOnce(
+  async #modifyBookingOnce(
     confirmationNumber: string,
     changes: HaipModifyParams,
   ): Promise<HaipModificationResult> {
-    const body: HaipModifyRequest = {
-      checkIn: changes.checkIn,
-      checkOut: changes.checkOut,
-      rooms: changes.rooms,
-      roomTypeId: changes.roomTypeId,
-      rateId: changes.rateId,
-      guest: changes.guest,
-      specialRequests: changes.specialRequests,
-    };
+    return this.withRetry('modifyBooking', async () => {
+      const body: HaipModifyRequest = {
+        checkIn: changes.checkIn,
+        checkOut: changes.checkOut,
+        rooms: changes.rooms,
+        roomTypeId: changes.roomTypeId,
+        rateId: changes.rateId,
+        guest: changes.guest,
+        specialRequests: changes.specialRequests,
+      };
 
-    const response = await this.request<HaipModifyResponse>(
-      'PATCH',
-      `/api/v1/connect/bookings/${encodeURIComponent(confirmationNumber)}`,
-      body,
-    );
+      const response = await this.request<HaipModifyResponse>(
+        'PATCH',
+        `/api/v1/connect/bookings/${encodeURIComponent(confirmationNumber)}`,
+        body,
+      );
 
-    return mapModifyResponse(response);
+      return mapModifyResponse(response);
+    });
   }
 
   async cancelBooking(
@@ -362,17 +366,19 @@ export class HaipAdapter extends BaseAdapter {
       idempotencyKey,
       request: { confirmationNumber },
       supplierId: 'haip',
-      fn: () => this.cancelBookingOnce(confirmationNumber),
+      fn: () => this.#cancelBookingOnce(confirmationNumber),
     });
   }
 
-  async cancelBookingOnce(confirmationNumber: string): Promise<HaipCancellationResult> {
-    const response = await this.request<HaipCancelResponse>(
-      'DELETE',
-      `/api/v1/connect/bookings/${encodeURIComponent(confirmationNumber)}`,
-    );
+  async #cancelBookingOnce(confirmationNumber: string): Promise<HaipCancellationResult> {
+    return this.withRetry('cancelBooking', async () => {
+      const response = await this.request<HaipCancelResponse>(
+        'DELETE',
+        `/api/v1/connect/bookings/${encodeURIComponent(confirmationNumber)}`,
+      );
 
-    return mapCancelResponse(response);
+      return mapCancelResponse(response);
+    });
   }
 
   // -----------------------------------------------------------------------

--- a/packages/connect/src/suppliers/index.ts
+++ b/packages/connect/src/suppliers/index.ts
@@ -3,6 +3,7 @@
  *
  * By default, returned adapters are wrapped in GuardedConnectAdapter so
  * book/ticket/cancel cannot bypass the money-path executor.
+ * HAIP is an exception: HaipConnectBridge embeds MoneyPathExecutor already.
  */
 
 import { isLiveModeFromEnv, LiveSafetyError, type MoneyPathExecutorConfig } from '@otaip/core';
@@ -14,18 +15,23 @@ import { TripProAdapter } from './trippro/index.js';
 import { HaipConnectBridge } from './haip/connect-bridge.js';
 import { guardAdapter, type GuardedConnectAdapter } from '../guarded-adapter.js';
 
-const SUPPLIER_FACTORIES: Record<string, (config: unknown) => ConnectAdapter> = {};
-
-export function registerSupplier(id: string, factory: (config: unknown) => ConnectAdapter): void {
-  SUPPLIER_FACTORIES[id] = factory;
-}
-
 export interface CreateAdapterOptions extends MoneyPathExecutorConfig {
   /**
    * When true, return the raw supplier adapter without GuardedConnectAdapter.
    * Only for unit tests of raw HTTP/mapping — never for live money paths.
    */
   readonly unguarded?: boolean;
+}
+
+type SupplierFactory = (config: unknown, options?: CreateAdapterOptions) => ConnectAdapter;
+
+const SUPPLIER_FACTORIES: Record<string, SupplierFactory> = {};
+
+/** Suppliers that already embed MoneyPathExecutor — do not double-wrap. */
+const SELF_GUARDED = new Set<string>(['haip']);
+
+export function registerSupplier(id: string, factory: SupplierFactory): void {
+  SUPPLIER_FACTORIES[id] = factory;
 }
 
 export function createAdapter(
@@ -45,10 +51,11 @@ export function createAdapter(
       'createAdapter({ unguarded: true }) is refused in live mode — money-path guard is mandatory',
     );
   }
-  const raw = factory(config);
-  if (options?.unguarded) return raw;
   const execConfig: Omit<CreateAdapterOptions, 'unguarded'> = { ...(options ?? {}) };
   delete (execConfig as { unguarded?: boolean }).unguarded;
+  const raw = factory(config, { ...execConfig, liveMode });
+  if (options?.unguarded) return raw;
+  if (SELF_GUARDED.has(supplierId)) return raw;
   return guardAdapter(raw, { ...execConfig, liveMode });
 }
 
@@ -68,5 +75,15 @@ registerSupplier('navitaire', (config) => new NavitaireAdapter(config));
 // Auto-register Amadeus
 registerSupplier('amadeus', (config) => new AmadeusAdapter(config));
 
-// Auto-register HAIP (lodging Connect bridge → GuardedConnectAdapter by default)
-registerSupplier('haip', (config) => new HaipConnectBridge(config));
+// Auto-register HAIP (self-guarded via HaipAdapter MoneyPathExecutor)
+registerSupplier('haip', (config, options) => {
+  const { unguarded: _u, ...moneyPath } = options ?? {};
+  void _u;
+  return new HaipConnectBridge(config, {
+    ...(options?.liveMode !== undefined ? { liveMode: options.liveMode } : {}),
+    ...(options?.storeDurability !== undefined
+      ? { storeDurability: options.storeDurability }
+      : {}),
+    moneyPath,
+  });
+});

--- a/packages/connect/src/suppliers/trippro/__tests__/money-path.test.ts
+++ b/packages/connect/src/suppliers/trippro/__tests__/money-path.test.ts
@@ -1,0 +1,54 @@
+/**
+ * TripPro money-path: SOAP ticket/cancel use fetchOnce; cancel via withRetry.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { createAdapter, GuardedConnectAdapter } from '../../../index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const CONFIG = {
+  soapBaseUrl: 'https://trippro.test.local/soap',
+  accessToken: 'tok',
+  searchAccessToken: 'search-tok',
+  whitelistedIp: '127.0.0.1',
+};
+
+describe('TripPro money-path SOAP', () => {
+  it('CancelPNR attempted exactly once on 503 via Guarded; replay zero', async () => {
+    let posts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        posts += 1;
+        return new Response('unavailable', { status: 503, statusText: 'Service Unavailable' });
+      }),
+    );
+
+    const adapter = createAdapter('trippro', CONFIG, { liveMode: false });
+    expect(adapter).toBeInstanceOf(GuardedConnectAdapter);
+
+    await expect(adapter.cancelBooking!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.cancelBooking!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(posts).toBe(1);
+  });
+
+  it('OrderTicket attempted exactly once on 503 via Guarded', async () => {
+    let posts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        posts += 1;
+        return new Response('unavailable', { status: 503, statusText: 'Service Unavailable' });
+      }),
+    );
+
+    const adapter = createAdapter('trippro', CONFIG, { liveMode: false });
+    await expect(adapter.requestTicketing!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.requestTicketing!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(posts).toBe(1);
+  });
+});

--- a/packages/connect/src/suppliers/trippro/index.ts
+++ b/packages/connect/src/suppliers/trippro/index.ts
@@ -177,6 +177,7 @@ export class TripProAdapter extends BaseAdapter implements ConnectAdapter {
         'OrderTicket',
         buildOrderTicketBody(bookingId),
         this.config.accessToken,
+        { unsafe: true },
       );
 
       if (hasSoapFault(xml)) {
@@ -201,19 +202,23 @@ export class TripProAdapter extends BaseAdapter implements ConnectAdapter {
   }
 
   async cancelBooking(bookingId: string): Promise<{ success: boolean; message: string }> {
-    const xml = await soapRequest(
-      this.config.soapBaseUrl,
-      'CancelPNR',
-      buildCancelPnrBody(bookingId),
-      this.config.accessToken,
-    );
+    return this.withRetry('cancelBooking', async () => {
+      const xml = await soapRequest(
+        this.config.soapBaseUrl,
+        'CancelPNR',
+        buildCancelPnrBody(bookingId),
+        this.config.accessToken,
+        { unsafe: true },
+      );
 
-    if (hasSoapFault(xml)) {
-      const fault = extractSoapFaultMessage(xml) ?? 'Unknown SOAP fault';
-      return { success: false, message: fault };
-    }
+      if (hasSoapFault(xml)) {
+        const fault = extractSoapFaultMessage(xml) ?? 'Unknown SOAP fault';
+        // Business SOAP fault — definitive, not ambiguous transport failure.
+        return { success: false, message: fault };
+      }
 
-    return { success: true, message: `PNR ${bookingId} cancelled` };
+      return { success: true, message: `PNR ${bookingId} cancelled` };
+    });
   }
 
   async healthCheck(): Promise<{ healthy: boolean; latencyMs: number }> {

--- a/packages/connect/src/suppliers/trippro/soap-client.ts
+++ b/packages/connect/src/suppliers/trippro/soap-client.ts
@@ -1,15 +1,21 @@
 /**
  * Thin SOAP wrapper for TripPro PNR/ticketing endpoints.
  * Uses raw XML templates — no SOAP client library.
+ *
+ * Unsafe money-path SOAP actions (OrderTicket, CancelPNR) use fetchOnce.
+ * Safe reads (ReadPNR, ReadETicket) keep fetchWithRetry.
  */
 
-import { fetchWithRetry } from '@otaip/core';
+import { fetchOnce, fetchWithRetry } from '@otaip/core';
+
+const UNSAFE_SOAP_ACTIONS = new Set(['OrderTicket', 'CancelPNR']);
 
 export async function soapRequest(
   wsdlUrl: string,
   action: string,
   body: string,
   token: string,
+  options?: { unsafe?: boolean },
 ): Promise<string> {
   const envelope = `<?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
@@ -21,14 +27,19 @@ export async function soapRequest(
   </soap:Body>
 </soap:Envelope>`;
 
-  const response = await fetchWithRetry(wsdlUrl, {
+  const init: RequestInit = {
     method: 'POST',
     headers: {
       'Content-Type': 'text/xml; charset=utf-8',
       SOAPAction: action,
     },
     body: envelope,
-  });
+  };
+
+  const unsafe = options?.unsafe ?? UNSAFE_SOAP_ACTIONS.has(action);
+  const response = unsafe
+    ? await fetchOnce(wsdlUrl, init)
+    : await fetchWithRetry(wsdlUrl, init);
 
   if (!response.ok) {
     throw new Error(`SOAP request failed: ${response.status} ${response.statusText}`);

--- a/packages/core/src/persistence/__tests__/cas-persistence.test.ts
+++ b/packages/core/src/persistence/__tests__/cas-persistence.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   InMemoryPersistenceAdapter,
   InMemoryVersionedAggregateStore,
 } from '../in-memory-adapter.js';
+import { FileCompareAndSwapPersistenceAdapter } from '../file-cas-adapter.js';
 import { InMemoryCommandStore } from '../../command-store/in-memory-command-store.js';
 import { InMemoryEffectLedger } from '../../effect-ledger/in-memory-effect-ledger.js';
 
@@ -104,3 +108,33 @@ describe('CommandStore + EffectLedger idempotency', () => {
     expect(unknown[0]?.outcome).toBe('unknown');
   });
 });
+
+describe('FileCompareAndSwapPersistenceAdapter flock', () => {
+  it('concurrent setIfAbsent yields a single create', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'otaip-filecas-'));
+    const adapter = new FileCompareAndSwapPersistenceAdapter(join(dir, 'db.json'));
+    const results = await Promise.all(
+      Array.from({ length: 50 }, (_, i) => adapter.setIfAbsent('k', i)),
+    );
+    expect(results.filter(Boolean).length).toBe(1);
+    expect(await adapter.get('k')).toBe(0);
+  });
+
+  it('compareAndSet is serialized under lock', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'otaip-filecas-'));
+    const adapter = new FileCompareAndSwapPersistenceAdapter(join(dir, 'db.json'));
+    await adapter.set('counter', 0);
+    await Promise.all(
+      Array.from({ length: 20 }, async () => {
+        for (;;) {
+          const cur = await adapter.get<number>('counter');
+          if (cur === null) throw new Error('missing');
+          const ok = await adapter.compareAndSet('counter', cur, cur + 1);
+          if (ok) break;
+        }
+      }),
+    );
+    expect(await adapter.get('counter')).toBe(20);
+  });
+});
+

--- a/packages/core/src/persistence/file-cas-adapter.ts
+++ b/packages/core/src/persistence/file-cas-adapter.ts
@@ -1,9 +1,22 @@
 /**
- * File-backed CAS persistence — reference durable store for local/test use.
- * Not multi-writer safe across processes; suitable for single-node drills.
+ * File-backed CAS persistence — reference durable store for local/single-host use.
+ *
+ * Single-host multi-process safe via exclusive lockfile around RMW.
+ * Not a distributed multi-writer store — deployers needing multi-node CAS
+ * must inject their own CompareAndSwapPersistenceAdapter.
  */
 
-import { mkdirSync, readFileSync, renameSync, writeFileSync, existsSync } from 'node:fs';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+  constants,
+} from 'node:fs';
 import { dirname } from 'node:path';
 import type { CompareAndSwapPersistenceAdapter } from './types.js';
 
@@ -25,19 +38,71 @@ function deepEqual(a: unknown, b: unknown): boolean {
   }
 }
 
+function sleepMs(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Exclusive lockfile (O_CREAT|O_EXCL) for single-host multi-process serialization.
+ */
+function withExclusiveLockfile<T>(lockPath: string, fn: () => T): T {
+  const maxAttempts = 200;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    let fd: number | undefined;
+    try {
+      fd = openSync(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+      writeFileSync(fd, String(process.pid));
+      try {
+        return fn();
+      } finally {
+        closeSync(fd);
+        fd = undefined;
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // ignore unlock races
+        }
+      }
+    } catch (err: unknown) {
+      if (fd !== undefined) {
+        try {
+          closeSync(fd);
+        } catch {
+          // ignore
+        }
+      }
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EEXIST') {
+        sleepMs(5);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error(`FileCompareAndSwapPersistenceAdapter lock timeout: ${lockPath}`);
+}
+
 export class FileCompareAndSwapPersistenceAdapter implements CompareAndSwapPersistenceAdapter {
   readonly durability = 'durable' as const;
   private readonly path: string;
+  private readonly lockPath: string;
+  /** In-process async mutex chain. */
+  private chain: Promise<unknown> = Promise.resolve();
 
   constructor(filePath: string) {
     this.path = filePath;
+    this.lockPath = `${filePath}.lock`;
     mkdirSync(dirname(filePath), { recursive: true });
     if (!existsSync(filePath)) {
-      this.writeDb({ entries: {} });
+      withExclusiveLockfile(this.lockPath, () => {
+        if (!existsSync(filePath)) {
+          this.writeDbUnlocked({ entries: {} });
+        }
+      });
     }
   }
 
-  private readDb(): FileDb {
+  private readDbUnlocked(): FileDb {
     const raw = readFileSync(this.path, 'utf8');
     try {
       return JSON.parse(raw) as FileDb;
@@ -46,7 +111,7 @@ export class FileCompareAndSwapPersistenceAdapter implements CompareAndSwapPersi
     }
   }
 
-  private writeDb(db: FileDb): void {
+  private writeDbUnlocked(db: FileDb): void {
     const tmp = `${this.path}.${process.pid}.tmp`;
     writeFileSync(tmp, JSON.stringify(db), 'utf8');
     renameSync(tmp, this.path);
@@ -61,31 +126,47 @@ export class FileCompareAndSwapPersistenceAdapter implements CompareAndSwapPersi
     }
   }
 
+  private async withLock<T>(fn: () => T): Promise<T> {
+    const run = this.chain.then(() => withExclusiveLockfile(this.lockPath, fn));
+    // Prevent unhandled rejection on the chain if a caller abandons.
+    this.chain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
   async get<T>(key: string): Promise<T | null> {
-    const db = this.readDb();
-    this.prune(db);
-    const entry = db.entries[key];
-    if (!entry) return null;
-    return entry.value as T;
+    return this.withLock(() => {
+      const db = this.readDbUnlocked();
+      this.prune(db);
+      const entry = db.entries[key];
+      if (!entry) return null;
+      return entry.value as T;
+    });
   }
 
   async set<T>(key: string, value: T, ttlMs?: number): Promise<void> {
-    const db = this.readDb();
-    this.prune(db);
-    db.entries[key] = {
-      value,
-      expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
-    };
-    this.writeDb(db);
+    await this.withLock(() => {
+      const db = this.readDbUnlocked();
+      this.prune(db);
+      db.entries[key] = {
+        value,
+        expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
+      };
+      this.writeDbUnlocked(db);
+    });
   }
 
   async delete(key: string): Promise<boolean> {
-    const db = this.readDb();
-    this.prune(db);
-    const existed = key in db.entries;
-    delete db.entries[key];
-    this.writeDb(db);
-    return existed;
+    return this.withLock(() => {
+      const db = this.readDbUnlocked();
+      this.prune(db);
+      const existed = key in db.entries;
+      delete db.entries[key];
+      this.writeDbUnlocked(db);
+      return existed;
+    });
   }
 
   async has(key: string): Promise<boolean> {
@@ -93,9 +174,11 @@ export class FileCompareAndSwapPersistenceAdapter implements CompareAndSwapPersi
   }
 
   async list(prefix: string): Promise<string[]> {
-    const db = this.readDb();
-    this.prune(db);
-    return Object.keys(db.entries).filter((k) => k.startsWith(prefix));
+    return this.withLock(() => {
+      const db = this.readDbUnlocked();
+      this.prune(db);
+      return Object.keys(db.entries).filter((k) => k.startsWith(prefix));
+    });
   }
 
   async compareAndSet<T>(
@@ -104,31 +187,35 @@ export class FileCompareAndSwapPersistenceAdapter implements CompareAndSwapPersi
     value: T,
     ttlMs?: number,
   ): Promise<boolean> {
-    const db = this.readDb();
-    this.prune(db);
-    const current = db.entries[key]?.value as T | undefined;
-    if (expected === undefined) {
-      if (current !== undefined) return false;
-    } else if (!deepEqual(current, expected)) {
-      return false;
-    }
-    db.entries[key] = {
-      value,
-      expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
-    };
-    this.writeDb(db);
-    return true;
+    return this.withLock(() => {
+      const db = this.readDbUnlocked();
+      this.prune(db);
+      const current = db.entries[key]?.value as T | undefined;
+      if (expected === undefined) {
+        if (current !== undefined) return false;
+      } else if (!deepEqual(current, expected)) {
+        return false;
+      }
+      db.entries[key] = {
+        value,
+        expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
+      };
+      this.writeDbUnlocked(db);
+      return true;
+    });
   }
 
   async setIfAbsent<T>(key: string, value: T, ttlMs?: number): Promise<boolean> {
-    const db = this.readDb();
-    this.prune(db);
-    if (key in db.entries) return false;
-    db.entries[key] = {
-      value,
-      expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
-    };
-    this.writeDb(db);
-    return true;
+    return this.withLock(() => {
+      const db = this.readDbUnlocked();
+      this.prune(db);
+      if (key in db.entries) return false;
+      db.entries[key] = {
+        value,
+        expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null,
+      };
+      this.writeDbUnlocked(db);
+      return true;
+    });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Closes post-#127 audit holes that still made “production ready / 8/8” incomplete: HAIP backpressure + private Once, TripPro SOAP blind-retry, Amadeus cancel swallowing, MCP live mutations without approval, and File CAS single-host race. Scorecard rewritten with drill citations only.

## Type of change

- [x] Bug fix
- [ ] New agent or adapter
- [x] Enhancement to existing agent
- [ ] Domain logic correction
- [x] Documentation
- [ ] Infrastructure / CI
- [ ] Refactor (no behavior change)

## Checklist

- [x] `pnpm test` passes (all tests, not just mine)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes with zero errors
- [x] No `any` types without a justification comment
- [x] No floating point for currency — use string-based decimal or `decimal.js`
- [ ] Agent spec in `agents/specs/` updated if behavior changed
- [ ] New domain logic has a source (IATA doc, ATPCO category, industry reference, or operational experience cited in comment)
- [x] Tests encode domain knowledge, not just `expect(result).toBeDefined()`

## Domain impact

N/A — money-path safety / adapter transport honesty; no travel domain logic invented.

## Changes

1. **HAIP (DoD 1/2/4):** Mutations run through `withRetry` so RL+CB engage; `*Once` methods are private; bridge passes `liveMode`; `createAdapter('haip')` is self-guarded (no double `GuardedConnectAdapter`); cancel uses ledger path.
2. **TripPro (DoD 1/4):** Ticket/cancel SOAP uses `fetchOnce`; `cancelBooking` wrapped in `withRetry`.
3. **Amadeus (DoD 1/7):** Ambiguous/transport cancel errors rethrown so ledger is not `succeeded`.
4. **MCP (DoD 6):** Live `create_booking` / `request_ticketing` / `cancel_booking` require durable `consumeBoundApprovalToken` before the adapter.
5. **File CAS (DoD 3):** Exclusive lockfile around RMW; documented as single-host durable reference, not multi-region.
6. **Scorecard:** PASS rows cite the new drills; File CAS caveat explicit.

## Test plan

- `haip/.../money-path.test.ts` — RL/CB on mutation path; createAdapter cancel once-only on 503
- `trippro/.../money-path.test.ts` — CancelPNR/ticketing 503 → one wire POST; replay → zero
- `amadeus/.../cancel-money-path.test.ts` — ambiguous delete → not ledger-succeeded
- `mcp-live-approval.test.ts` — live missing/forged/replayed token → adapter not called
- `cas-persistence.test.ts` — concurrent `setIfAbsent` single winner under lock
- Full `pnpm test`: 3437 passed | 17 skipped

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3359bdd7-0df8-450b-8493-63132da9a593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3359bdd7-0df8-450b-8493-63132da9a593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

