### PR TITLE
fix: close platform money-path holes for builder readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ internal/
 # General
 .DS_Store
 .AppleDouble
-.LSOverride
+.LSOverride.tmp-mcp-appr-test/

--- a/.tmp-mcp-appr-test/jti-1785606799086.json
+++ b/.tmp-mcp-appr-test/jti-1785606799086.json
@@ -1,1 +1,0 @@
-{"entries":{"approval-jti:02549766c58f75e5a273f7a02f7a84ec":{"value":{"consumedAt":1785606799088},"expiresAt":null}}}

--- a/.tmp-mcp-appr-test/jti-1785606799086.json
+++ b/.tmp-mcp-appr-test/jti-1785606799086.json
@@ -1,0 +1,1 @@
+{"entries":{"approval-jti:02549766c58f75e5a273f7a02f7a84ec":{"value":{"consumedAt":1785606799088},"expiresAt":null}}}

--- a/.tmp-mcp-appr-test/jti-1785607015204.json
+++ b/.tmp-mcp-appr-test/jti-1785607015204.json
@@ -1,1 +1,0 @@
-{"entries":{"approval-jti:3349c50e94fbc194c138a9cb4c77b2a5":{"value":{"consumedAt":1785607015208},"expiresAt":null}}}

--- a/.tmp-mcp-appr-test/jti-1785607015204.json
+++ b/.tmp-mcp-appr-test/jti-1785607015204.json
@@ -1,0 +1,1 @@
+{"entries":{"approval-jti:3349c50e94fbc194c138a9cb4c77b2a5":{"value":{"consumedAt":1785607015208},"expiresAt":null}}}

--- a/demo/book-flight-amadeus.ts
+++ b/demo/book-flight-amadeus.ts
@@ -17,9 +17,10 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
-import { AmadeusAdapter } from '../packages/connect/src/suppliers/amadeus/index.ts';
+import { createAdapter } from '../packages/connect/src/suppliers/index.ts';
 import type {
   CabinClass,
+  ConnectAdapter,
   FlightOffer,
   PassengerDetail,
 } from '../packages/connect/src/types.ts';
@@ -32,12 +33,16 @@ config({ path: resolve(__dirname, '../.env') });
 
 const client = new Anthropic({ apiKey: process.env['ANTHROPIC_API_KEY'] });
 
-const adapter = new AmadeusAdapter({
-  environment: (process.env['AMADEUS_ENVIRONMENT'] ?? 'test') as 'test' | 'production',
-  clientId: process.env['AMADEUS_CLIENT_ID'] ?? '',
-  clientSecret: process.env['AMADEUS_CLIENT_SECRET'] ?? '',
-  defaultCurrency: process.env['AMADEUS_CURRENCY'] ?? 'USD',
-});
+const adapter: ConnectAdapter = createAdapter(
+  'amadeus',
+  {
+    environment: (process.env['AMADEUS_ENVIRONMENT'] ?? 'test') as 'test' | 'production',
+    clientId: process.env['AMADEUS_CLIENT_ID'] ?? '',
+    clientSecret: process.env['AMADEUS_CLIENT_SECRET'] ?? '',
+    defaultCurrency: process.env['AMADEUS_CURRENCY'] ?? 'USD',
+  },
+  { liveMode: false },
+);
 
 // Cache search results so the agent can reference offers by ID
 let lastSearchResults: FlightOffer[] = [];

--- a/demo/book-flight-sabre.ts
+++ b/demo/book-flight-sabre.ts
@@ -17,9 +17,10 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
-import { SabreAdapter } from '../packages/connect/src/suppliers/sabre/index.ts';
+import { createAdapter } from '../packages/connect/src/suppliers/index.ts';
 import type {
   CabinClass,
+  ConnectAdapter,
   FlightOffer,
   PassengerDetail,
 } from '../packages/connect/src/types.ts';
@@ -32,12 +33,16 @@ config({ path: resolve(__dirname, '../.env') });
 
 const client = new Anthropic({ apiKey: process.env['ANTHROPIC_API_KEY'] });
 
-const adapter = new SabreAdapter({
-  environment: (process.env['SABRE_ENVIRONMENT'] ?? 'cert') as 'cert' | 'prod',
-  clientId: process.env['SABRE_CLIENT_ID'] ?? '',
-  clientSecret: process.env['SABRE_CLIENT_SECRET'] ?? '',
-  pcc: process.env['SABRE_PCC'],
-});
+const adapter: ConnectAdapter = createAdapter(
+  'sabre',
+  {
+    environment: (process.env['SABRE_ENVIRONMENT'] ?? 'cert') as 'cert' | 'prod',
+    clientId: process.env['SABRE_CLIENT_ID'] ?? '',
+    clientSecret: process.env['SABRE_CLIENT_SECRET'] ?? '',
+    pcc: process.env['SABRE_PCC'],
+  },
+  { liveMode: false },
+);
 
 // Cache search results so the agent can reference offers by ID
 let lastSearchResults: FlightOffer[] = [];

--- a/docs/adapters/amadeus.md
+++ b/docs/adapters/amadeus.md
@@ -54,9 +54,9 @@ Validated at construction time with Zod. Invalid config throws immediately.
 ## Usage
 
 ```typescript
-import { AmadeusAdapter } from '@otaip/connect';
+import { createAdapter } from '@otaip/connect';
 
-const adapter = new AmadeusAdapter({
+const adapter = createAdapter('amadeus', {
   environment: 'test',
   clientId: process.env.AMADEUS_CLIENT_ID,
   clientSecret: process.env.AMADEUS_CLIENT_SECRET,

--- a/docs/adapters/haip.md
+++ b/docs/adapters/haip.md
@@ -53,9 +53,9 @@ Validated at construction time with Zod. Trailing slashes on `baseUrl` are strip
 ## Usage
 
 ```typescript
-import { HaipAdapter } from '@otaip/connect';
+import { createAdapter } from '@otaip/connect';
 
-const adapter = new HaipAdapter({
+const adapter = createAdapter('haip', {
   baseUrl: 'http://localhost:3000',
   apiKey: '',
   timeoutMs: 10000,

--- a/docs/adapters/navitaire.md
+++ b/docs/adapters/navitaire.md
@@ -70,9 +70,9 @@ Validated at construction time with Zod.
 ## Usage
 
 ```typescript
-import { NavitaireAdapter } from '@otaip/connect';
+import { createAdapter } from '@otaip/connect';
 
-const adapter = new NavitaireAdapter({
+const adapter = createAdapter('navitaire', {
   environment: 'test',
   baseUrl: 'https://dotrezapi.test.1n.navitaire.com',
   credentials: {

--- a/docs/adapters/sabre.md
+++ b/docs/adapters/sabre.md
@@ -56,9 +56,9 @@ Validated at construction time with Zod.
 ## Usage
 
 ```typescript
-import { SabreAdapter } from '@otaip/connect';
+import { createAdapter } from '@otaip/connect';
 
-const adapter = new SabreAdapter({
+const adapter = createAdapter('sabre', {
   environment: 'cert',
   clientId: process.env.SABRE_CLIENT_ID,
   clientSecret: process.env.SABRE_CLIENT_SECRET,

--- a/docs/adapters/trippro.md
+++ b/docs/adapters/trippro.md
@@ -60,9 +60,9 @@ Validated at construction time with Zod.
 ## Usage
 
 ```typescript
-import { TripProAdapter } from '@otaip/connect';
+import { createAdapter } from '@otaip/connect';
 
-const adapter = new TripProAdapter({
+const adapter = createAdapter('trippro', {
   soapBaseUrl: 'https://soap.trippro.com',
   accessToken: process.env.TRIPPRO_ACCESS_TOKEN,
   searchAccessToken: process.env.TRIPPRO_SEARCH_TOKEN,

--- a/docs/engineering/PRODUCTION_DOD_SCORECARD.md
+++ b/docs/engineering/PRODUCTION_DOD_SCORECARD.md
@@ -2,6 +2,8 @@
 
 **PASS means default-enforced on the normal money-path API — not “a class exists if you wire it.”**
 
+OTAIP is a **platform** for building OTA / TMC / airline distribution stacks. This scorecard measures **platform money-path readiness** for builders — not whether the repo contains a finished consumer OTA.
+
 | Enforcement | Meaning |
 |---|---|
 | `default` | Normal call path cannot bypass the control |
@@ -12,15 +14,15 @@ Covered money-path surfaces: Connect `createAdapter` (TripPro/Sabre/Navitaire/Am
 
 | # | Criterion | Status | Enforcement | Evidence |
 |---|---|---|---|---|
-| 1 | Mutations safe | PASS | default | `GuardedConnectAdapter` via `createAdapter()` (HAIP self-guarded); Duffel/Hotelbeds/HAIP/`MoneyPathExecutor`; TripPro SOAP ticket/cancel via `fetchOnce`; Amadeus cancel rethrows ambiguous errors. Drills: `duffel/.../money-path.test.ts`, `hotelbeds/.../money-path.test.ts`, `haip/.../money-path.test.ts`, `trippro/.../money-path.test.ts`, `amadeus/.../cancel-money-path.test.ts` — 503 → one wire call; replay → zero; `OUTCOME_UNKNOWN` |
+| 1 | Mutations safe | PASS | default | `createAdapter()` → `GuardedConnectAdapter` (HAIP self-guarded); live refuses raw Connect adapters (`live-refuse-raw-adapter.test.ts`). Drills: Sabre/Navitaire/TripPro/Amadeus/HAIP/Duffel/Hotelbeds money-path tests — 503 → one wire; replay → zero; `OUTCOME_UNKNOWN` |
 | 2 | Money state survives crash | PASS | default | Effect ledger replay; `listUnresolved` includes aged `pending`; live refuses ephemeral ledgers (`money-path-executor.test.ts`) |
-| 3 | Persistence can do #2 | PASS | default (single-host) | Store-declared durability; reject ephemeral→durable upgrade; `FileEffectLedger` live book; File CAS exclusive lockfile around RMW (`cas-persistence.test.ts` flock tests). **Caveat:** File CAS is single-host durable reference — not a distributed multi-region DB; multi-node deployers inject their own CAS. |
-| 4 | Supplier backpressure real | PASS | default | `BaseAdapter` RL+CB on by default; Duffel/Hotelbeds RL+CB on `request()`; HAIP mutations go through `withRetry` (unsafe → maxRetries 0) so RL+CB engage; TripPro cancel via `withRetry`; RateLimiter serializes waiters — `rate-limiter.test.ts` (10@limit1), `haip/.../money-path.test.ts` (breaker opens) |
+| 3 | Persistence can do #2 | PASS | default (single-host) | Store-declared durability; `FileEffectLedger` + File CAS lockfile (`cas-persistence.test.ts`). **Reference store:** single-host File CAS — multi-node deployers inject their own CAS |
+| 4 | Supplier backpressure real | PASS | default | `BaseAdapter` RL+CB on by default; Duffel/Hotelbeds RL+CB on `request()`; HAIP/TripPro mutations via `withRetry` (unsafe → maxRetries 0) — `rate-limiter.test.ts`, `haip/.../money-path.test.ts` |
 | 5 | Live tickets not invented | PASS | default | `issueTickets` liveMode guard; Duffel maps order documents only |
-| 6 | Irreversible LLM gate has teeth | PASS | default | Orchestrator: `createHmac` + `v1.` + durable single-use; live refuses ephemeral token store. MCP live: `create_booking`/`request_ticketing`/`cancel_booking` require consume before adapter (`mcp-live-approval.test.ts`) |
-| 7 | Reversal works | PASS | default | `executeReversal` requires shared executor; void/refund fail closed; Amadeus ambiguous cancel not ledger-succeeded; Duffel flight / Hotelbeds activity+transfer cancel refuse |
-| 8 | Ops see/stop damage | PASS | default | Process-global `MutationOpsCollector` + kill switch; `effectType`→stage 1:1; `OTAIP_MUTATION_KILL_SWITCH=1` |
+| 6 | Irreversible LLM gate has teeth | PASS | default | Orchestrator HMAC + durable single-use. MCP live: no tmpdir fallback; requires inject or `OTAIP_MCP_APPROVAL_STORE_PATH`; restart-replay refuses consumed jti (`mcp-live-approval.test.ts`) |
+| 7 | Reversal works | PASS | default | `executeReversal` shared executor; void/refund fail closed without capability; Duffel air cancel via order_cancellations confirm (once); Hotelbeds activity/transfer hard cancel once (`money-path` / adapter cancel drills) |
+| 8 | Ops see/stop damage | PASS | default | Durable damage visibility = `FileEffectLedger.listUnresolved` across fresh instance (`file-ledger-crash-visibility.test.ts`) + `OTAIP_MUTATION_KILL_SWITCH=1`. `MutationOpsCollector` is in-process only |
 
-**Score: 8 / 8 PASS** under **default-enforced** definition (library drills + fault injection), with File CAS scoped as single-host durable reference.
+**Score: 8 / 8 PASS** under **default-enforced platform money-path** definition (fault-injection drills + single-host File CAS reference).
 
-Still not a turnkey OTA/TMC: no real credentials in repo; Duffel flight cancel unsupported by design; Hotelbeds activity/transfer cancel fail closed pending DOMAIN_QUESTION; Connect `BookingPipeline`/`PaymentHandoff` remain labeled stubs. Live supplier credentials and multi-node CAS remain deployer-owned.
+**Platform ready for builders.** Product app (OTA/TMC/airline UX), live credentials, PSP checkout, and multi-node CAS are deployer-owned on top of OTAIP. Connect `BookingPipeline` / `PaymentHandoff` remain labeled stubs (optional product-layer orchestration, not required for adapter money-path).

--- a/docs/knowledge-base/activities.md
+++ b/docs/knowledge-base/activities.md
@@ -72,7 +72,17 @@ Returns `{ bookingReference, status: 'CONFIRMED' | 'ON_REQUEST', clientReference
 
 ## Cancellation
 
-The brief specifies the OTAIP method signature `cancelActivity(bookingReference)` returning `{ status: 'CANCELLED', cancellationReference }`. The HTTP-level details (DELETE vs POST, two-step simulate-confirm pattern à la Hotels) are NOT documented for Activities — DQ-A1.
+Official Hotelbeds Activities Booking API cancel:
+
+`DELETE /activity-api/3.0/bookings/{language}/{reference}?cancellationFlag=SIMULATION|CANCELLATION`
+
+Source: https://developer.hotelbeds.com/documentation/activities/booking-api/booking-and-post-booking/cancel/
+
+Two-step: SIMULATION previews fees; CANCELLATION is the hard cancel (money-path / once-only).
+
+OTAIP method: `cancelActivity(bookingReference, flag?, options?)` → `{ status: 'CANCELLED', cancellationReference }`.
+
+**DQ-A1: CLOSED** (official docs above).
 
 ## Sandbox
 
@@ -82,7 +92,6 @@ The brief specifies the OTAIP method signature `cancelActivity(bookingReference)
 
 ## Open DOMAIN_QUESTIONs
 
-- **DQ-A1** — Cancellation HTTP shape. Hotels supports a SIMULATION/CANCELLATION two-step (DELETE with `cancellationFlag` query param). Activities cancel HTTP shape is unverified. The adapter assumes `DELETE /activities/booking/{ref}` with no flag. Confirm against sandbox and update if different.
 - **DQ-A2** — Net vs selling rate field names. The brief uses a single `Money` per modality. The Hotels API returns `net` and `sellingRate` as separate string fields. The adapter mapper currently treats the modality price as net and does not surface a separate selling rate. If Activities does the same, surface it; if not, the price field is treated as net per the brief.
 - **DQ-A3** — `'ON_REQUEST'` confirmation flow. No retrieval endpoint or poll cadence is documented. The adapter returns the status as-is and leaves the orchestration agent to decide whether and how to confirm later.
 - **DQ-A4** — `voucherUrl` access semantics. Whether the URL requires auth, has an expiry, or is anonymously accessible is unverified. The adapter passes the URL through unmodified.

--- a/docs/knowledge-base/transfers.md
+++ b/docs/knowledge-base/transfers.md
@@ -69,7 +69,17 @@ Returns `{ bookingReference, status: 'CONFIRMED' | 'ON_REQUEST', clientReference
 
 ## Cancellation
 
-The brief specifies the OTAIP method signature `cancelTransfer(bookingReference)` returning `{ status: 'CANCELLED', cancellationReference }`. The HTTP-level details (DELETE vs POST, simulate-confirm pattern) are NOT documented for Transfers — DQ-T1.
+Official Hotelbeds Transfers Booking API cancel:
+
+`DELETE /transfer-api/1.0/bookings/{language}/reference/{booking_reference}`
+
+Optional `?simulation=true`. Absent simulation = hard cancel. Partial cancel via `/id/{service_id}` is out of scope for the adapter.
+
+Source: https://developer.hotelbeds.com/documentation/transfers/booking-api/booking-post-booking/booking-cancellation/
+
+OTAIP method: `cancelTransfer(bookingReference, options?)` → `{ status: 'CANCELLED', cancellationReference }`.
+
+**DQ-T1: CLOSED** (official docs above).
 
 ## Sandbox
 
@@ -79,7 +89,6 @@ The brief specifies the OTAIP method signature `cancelTransfer(bookingReference)
 
 ## Open DOMAIN_QUESTIONs
 
-- **DQ-T1** — Cancellation HTTP shape. Same situation as Activities. The adapter assumes `DELETE /bookings/{ref}` with no flag. Confirm against sandbox.
 - **DQ-T2** — `GPS` location code format. The brief lists `'GPS'` as a `from.type` / `to.type` value but does not document the `code` payload — comma-separated `lat,lon`? URL-encoded JSON? Unknown. The adapter passes the supplied string through verbatim; callers must format correctly until verified.
 - **DQ-T3** — `outbound.time` timezone. Local at `from` or UTC? The adapter passes through unchanged. Operators using non-IATA `from` types must confirm.
 - **DQ-T4** — Per-vehicle vs per-pax pricing. Brief implies per-vehicle but doesn't state. The adapter exposes a single `price` and treats it as the booking-line total.

--- a/packages/adapters/duffel/src/__tests__/money-path.test.ts
+++ b/packages/adapters/duffel/src/__tests__/money-path.test.ts
@@ -128,10 +128,36 @@ describe('Duffel money-path book', () => {
     ).rejects.toThrow(/idempotencyKey/);
   });
 
-  it('flight cancel fails closed', async () => {
+  it('flight cancel confirm 503 → one confirm wire; replay → zero', async () => {
+    let confirms = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/air/order_cancellations') && !url.includes('/actions/confirm')) {
+          return new Response(JSON.stringify({ data: { id: 'ore_1' } }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.includes('/actions/confirm')) {
+          confirms += 1;
+          return new Response('unavailable', { status: 503, statusText: 'Service Unavailable' });
+        }
+        return new Response('{}', { status: 200 });
+      }),
+    );
     const adapter = new DuffelAdapter({
       baseUrl: 'https://api.test.duffel.local',
- apiKey: 'duffel_test_key', liveMode: false });
-    await expect(adapter.cancelFlightBooking('ord_1')).rejects.toThrow(/not supported/);
+      apiKey: 'duffel_test_key',
+      liveMode: false,
+    });
+    await expect(
+      adapter.cancelFlightBooking('ord_1', { idempotencyKey: 'air-cxl-1' }),
+    ).rejects.toThrow(/503|unknown|reconcil/i);
+    await expect(
+      adapter.cancelFlightBooking('ord_1', { idempotencyKey: 'air-cxl-1' }),
+    ).rejects.toThrow(/503|unknown|reconcil/i);
+    expect(confirms).toBe(1);
   });
 });

--- a/packages/adapters/duffel/src/duffel-adapter.ts
+++ b/packages/adapters/duffel/src/duffel-adapter.ts
@@ -293,9 +293,22 @@ export interface BookRequest {
 /** Paths that create/cancel money-path side effects — never auto-retried. */
 function isUnsafeDuffelPath(method: string, path: string): boolean {
   if (method !== 'POST' && method !== 'DELETE' && method !== 'PATCH') return false;
+  // Confirm cancel is irreversible; create quote may retry
+  if (path.includes('/air/order_cancellations/') && path.endsWith('/actions/confirm')) {
+    return true;
+  }
+  if (path === '/air/order_cancellations') return false;
   if (path === '/air/orders' || path.startsWith('/air/orders/')) return true;
   if (path === '/cars/bookings' || path.includes('/cars/bookings/')) return true;
   return false;
+}
+
+export interface FlightCancelResponse {
+  status: 'cancelled';
+  orderId: string;
+  cancellationId: string;
+  refundAmount?: string;
+  refundCurrency?: string;
 }
 
 export interface BookTicketNumber {
@@ -810,13 +823,75 @@ export class DuffelAdapter implements DistributionAdapter {
   }
 
   /**
-   * Flight cancel is not available on the Duffel public order API used here.
-   * Do not invent cancel behavior — fail closed (DoD 7).
+   * Cancel a flight order via Duffel Order Cancellations API:
+   *   POST /air/order_cancellations (quote — retryable)
+   *   POST /air/order_cancellations/{id}/actions/confirm (hard cancel — MoneyPath + once)
+   * Docs: https://duffel.com/docs/api/order-cancellations
    */
-  async cancelFlightBooking(_orderId: string): Promise<never> {
-    throw new MoneyPathError(
-      'Duffel flight cancel is not supported on this adapter — refuse rather than alias',
-    );
+  async cancelFlightBooking(
+    orderId: string,
+    options?: { idempotencyKey?: string; signal?: AbortSignal },
+  ): Promise<FlightCancelResponse> {
+    const key = options?.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'DuffelAdapter.cancelFlightBooking requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `duffel-air-cancel:${orderId}`;
+    const signal = options?.signal;
+
+    const quote = (await this.request(
+      'POST',
+      '/air/order_cancellations',
+      { data: { order_id: orderId } },
+      signal ? { signal } : {},
+    )) as {
+      data?: {
+        id?: string;
+        refund_amount?: string;
+        refund_currency?: string;
+      };
+    };
+    const cancellationId = quote.data?.id;
+    if (!cancellationId) {
+      throw new MoneyPathError(
+        'Duffel order cancellation quote returned no id — cannot confirm cancel',
+      );
+    }
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'cancelFlightBooking',
+      idempotencyKey,
+      request: { orderId, cancellationId },
+      supplierId: 'duffel',
+      fn: async () => {
+        const confirmed = (await this.request(
+          'POST',
+          `/air/order_cancellations/${encodeURIComponent(cancellationId)}/actions/confirm`,
+          undefined,
+          signal ? { signal } : {},
+        )) as {
+          data?: {
+            id?: string;
+            refund_amount?: string;
+            refund_currency?: string;
+          };
+        };
+        const result: FlightCancelResponse = {
+          status: 'cancelled',
+          orderId,
+          cancellationId: confirmed.data?.id ?? cancellationId,
+        };
+        if (confirmed.data?.refund_amount !== undefined) {
+          result.refundAmount = confirmed.data.refund_amount;
+        }
+        if (confirmed.data?.refund_currency !== undefined) {
+          result.refundCurrency = confirmed.data.refund_currency;
+        }
+        return result;
+      },
+    });
   }
 
   private async request(

--- a/packages/adapters/duffel/src/index.ts
+++ b/packages/adapters/duffel/src/index.ts
@@ -12,6 +12,7 @@ export type {
   BookTicketNumber,
   DuffelAdapterOptions,
   DuffelOrder,
+  FlightCancelResponse,
 } from './duffel-adapter.js';
 export { DuffelOrderBridge } from './order-bridge.js';
 export { duffelCapabilities } from './capabilities.js';

--- a/packages/adapters/hotelbeds/src/__tests__/activities-adapter.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/activities-adapter.test.ts
@@ -358,10 +358,44 @@ describe('HotelbedsAdapter.cancelActivity', () => {
     adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
   });
 
-  it('fails closed — activity cancel HTTP contract undocumented (DOMAIN_QUESTION)', async () => {
-    await expect(adapter.cancelActivity('HB-ACT-9001')).rejects.toThrow(
-      /DOMAIN_QUESTION|not wired|undocumented/i,
+  it('SIMULATION hits documented DELETE path with cancellationFlag', async () => {
+    const { calls } = captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
+    const result = await adapter.cancelActivity('HB-ACT-9001', 'SIMULATION');
+    expect(result).toEqual({
+      status: 'CANCELLED',
+      cancellationReference: 'CXL-HB-ACT-9001',
+    });
+    expect(calls[0]!.url).toContain(
+      '/activity-api/3.0/bookings/en/HB-ACT-9001?cancellationFlag=SIMULATION',
     );
+    expect(calls[0]!.init.method).toBe('DELETE');
+  });
+
+  it('CANCELLATION 503 → one wire; replay → zero', async () => {
+    let deletes = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        deletes += 1;
+        return {
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          json: async () => ({}),
+        };
+      }),
+    );
+    await expect(
+      adapter.cancelActivity('HB-ACT-9001', 'CANCELLATION', {
+        idempotencyKey: 'act-cxl-1',
+      }),
+    ).rejects.toThrow(/503|unknown|reconcil/i);
+    await expect(
+      adapter.cancelActivity('HB-ACT-9001', 'CANCELLATION', {
+        idempotencyKey: 'act-cxl-1',
+      }),
+    ).rejects.toThrow(/503|unknown|reconcil/i);
+    expect(deletes).toBe(1);
   });
 });
 

--- a/packages/adapters/hotelbeds/src/__tests__/activities-integration.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/activities-integration.test.ts
@@ -48,11 +48,15 @@ describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Activities — sandbox integration'
   });
 
   afterAll(async () => {
-    // Activity cancel is fail-closed pending DOMAIN_QUESTION — no adapter cleanup.
     if (bookingRef && !cancelled) {
-      console.warn(
-        `[activities-integration] left sandbox booking ${bookingRef} (cancel not wired)`,
-      );
+      try {
+        await adapter.cancelActivity(bookingRef, 'CANCELLATION', {
+          idempotencyKey: `cleanup:${bookingRef}`,
+        });
+        cancelled = true;
+      } catch (err) {
+        console.warn(`[activities-integration] cleanup cancel failed for ${bookingRef}`, err);
+      }
     }
   });
 
@@ -88,9 +92,9 @@ describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Activities — sandbox integration'
     bookingRef = result.bookingReference;
   });
 
-  it('cancelActivity fails closed until DOMAIN_QUESTION resolved', async () => {
-    await expect(adapter.cancelActivity(bookingRef ?? 'NOREF')).rejects.toThrow(
-      /DOMAIN_QUESTION|not wired|undocumented/i,
-    );
+  it('cancelActivity SIMULATION against sandbox', async () => {
+    const result = await adapter.cancelActivity(bookingRef ?? 'NOREF', 'SIMULATION');
+    expect(result.status).toBe('CANCELLED');
+    expect(result.cancellationReference.length).toBeGreaterThan(0);
   });
 });

--- a/packages/adapters/hotelbeds/src/__tests__/transfers-adapter.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/transfers-adapter.test.ts
@@ -331,9 +331,39 @@ describe('HotelbedsAdapter.cancelTransfer', () => {
     adapter = new HotelbedsAdapter({ apiKey: 'test-key', secret: 'test-secret' });
   });
 
-  it('fails closed — transfer cancel HTTP contract undocumented (DOMAIN_QUESTION)', async () => {
-    await expect(adapter.cancelTransfer('HB-TRF-3001')).rejects.toThrow(
-      /DOMAIN_QUESTION|not wired|undocumented/i,
+  it('simulation hits documented DELETE path with simulation=true', async () => {
+    const { calls } = captureFetch([{ status: 200, body: CANCELLATION_RESPONSE }]);
+    const result = await adapter.cancelTransfer('HB-TRF-3001', { simulation: true });
+    expect(result).toEqual({
+      status: 'CANCELLED',
+      cancellationReference: 'CXL-HB-TRF-3001',
+    });
+    expect(calls[0]!.url).toContain(
+      '/transfer-api/1.0/bookings/en/reference/HB-TRF-3001?simulation=true',
     );
+    expect(calls[0]!.init.method).toBe('DELETE');
+  });
+
+  it('hard cancel 503 → one wire; replay → zero', async () => {
+    let deletes = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        deletes += 1;
+        return {
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          json: async () => ({}),
+        };
+      }),
+    );
+    await expect(
+      adapter.cancelTransfer('HB-TRF-3001', { idempotencyKey: 'trf-cxl-1' }),
+    ).rejects.toThrow(/503|unknown|reconcil/i);
+    await expect(
+      adapter.cancelTransfer('HB-TRF-3001', { idempotencyKey: 'trf-cxl-1' }),
+    ).rejects.toThrow(/503|unknown|reconcil/i);
+    expect(deletes).toBe(1);
   });
 });

--- a/packages/adapters/hotelbeds/src/__tests__/transfers-integration.test.ts
+++ b/packages/adapters/hotelbeds/src/__tests__/transfers-integration.test.ts
@@ -46,11 +46,15 @@ describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Transfers — sandbox integration',
   });
 
   afterAll(async () => {
-    // Transfer cancel is fail-closed pending DOMAIN_QUESTION — no adapter cleanup.
     if (bookingRef && !cancelled) {
-      console.warn(
-        `[transfers-integration] left sandbox booking ${bookingRef} (cancel not wired)`,
-      );
+      try {
+        await adapter.cancelTransfer(bookingRef, {
+          idempotencyKey: `cleanup:${bookingRef}`,
+        });
+        cancelled = true;
+      } catch (err) {
+        console.warn(`[transfers-integration] cleanup cancel failed for ${bookingRef}`, err);
+      }
     }
   });
 
@@ -88,9 +92,9 @@ describe.skipIf(!HAS_CREDENTIALS)('Hotelbeds Transfers — sandbox integration',
     bookingRef = result.bookingReference;
   });
 
-  it('cancelTransfer fails closed until DOMAIN_QUESTION resolved', async () => {
-    await expect(adapter.cancelTransfer(bookingRef ?? 'NOREF')).rejects.toThrow(
-      /DOMAIN_QUESTION|not wired|undocumented/i,
-    );
+  it('cancelTransfer simulation against sandbox', async () => {
+    const result = await adapter.cancelTransfer(bookingRef ?? 'NOREF', { simulation: true });
+    expect(result.status).toBe('CANCELLED');
+    expect(result.cancellationReference.length).toBeGreaterThan(0);
   });
 });

--- a/packages/adapters/hotelbeds/src/hotelbeds-adapter.ts
+++ b/packages/adapters/hotelbeds/src/hotelbeds-adapter.ts
@@ -28,10 +28,12 @@ import { mapHotelToRawResult, summarizeBooking, type BookingSummary } from './fi
 import {
   mapActivityAvailability,
   mapActivityBookingResponse,
+  mapActivityCancellation,
 } from './activities-mapper.js';
 import {
   mapTransferAvailability,
   mapTransferBookingResponse,
+  mapTransferCancellation,
 } from './transfers-mapper.js';
 import type {
   HotelbedsAdapterConfig,
@@ -58,12 +60,14 @@ import type {
   HotelbedsActivitiesAvailabilityResponse,
   HotelbedsActivitiesBookingRequest,
   HotelbedsActivitiesBookingResponse,
+  HotelbedsActivitiesCancellationResponse,
 } from './activities-types.js';
 import type {
   HotelbedsTransfersAvailabilityRequest,
   HotelbedsTransfersAvailabilityResponse,
   HotelbedsTransfersBookingRequest,
   HotelbedsTransfersBookingResponse,
+  HotelbedsTransfersCancellationResponse,
   TransferBookRequest,
   TransferBookResponse,
   TransferCancelResponse,
@@ -91,11 +95,19 @@ export type { HotelSearchParams, HotelSourceAdapter } from './lodging-source-int
 export interface HotelbedsBookOptions {
   /** Required in live mode — same key → at most one supplier book. */
   idempotencyKey?: string;
+  /** Language path segment for activity/transfer cancel. Default: en. */
+  language?: string;
+}
+
+export interface HotelbedsTransferCancelOptions extends HotelbedsBookOptions {
+  /** When true, simulate cancel (retryable). Hard cancel when false/absent. */
+  simulation?: boolean;
 }
 
 function isUnsafeHotelbedsPath(method: string, path: string): boolean {
   const upper = method.toUpperCase();
   const pathOnly = path.split('?')[0] ?? path;
+  const query = path.includes('?') ? (path.split('?')[1] ?? '') : '';
 
   if (upper === 'POST') {
     if (pathOnly === `${HOTELS_BASE_PATH}/bookings`) return true;
@@ -103,10 +115,25 @@ function isUnsafeHotelbedsPath(method: string, path: string): boolean {
     if (pathOnly === `${TRANSFERS_BASE_PATH}/bookings`) return true;
   }
   if (upper === 'DELETE') {
-    // Hard hotel cancel only — SIMULATION may retry
+    // Hard hotel cancel — SIMULATION may retry
     if (
       pathOnly.startsWith(`${HOTELS_BASE_PATH}/bookings/`) &&
-      path.includes('cancellationFlag=CANCELLATION')
+      query.includes('cancellationFlag=CANCELLATION')
+    ) {
+      return true;
+    }
+    // Hard activity cancel
+    if (
+      pathOnly.startsWith(`${ACTIVITIES_BASE_PATH}/bookings/`) &&
+      query.includes('cancellationFlag=CANCELLATION')
+    ) {
+      return true;
+    }
+    // Hard transfer cancel: DELETE .../reference/{ref} without simulation=true
+    if (
+      pathOnly.includes(`${TRANSFERS_BASE_PATH}/bookings/`) &&
+      pathOnly.includes('/reference/') &&
+      !query.includes('simulation=true')
     ) {
       return true;
     }
@@ -401,15 +428,49 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
   }
 
   /**
-   * Activity cancel HTTP contract is not fully documented.
-   * // TODO: DOMAIN_QUESTION: What is the authoritative Hotelbeds Activities
-   * // cancel HTTP shape (method, path, SIMULATION/CANCELLATION flags)?
-   * Fail closed — do not invent the wire call.
+   * Cancel an activity booking.
+   * Official: DELETE /activity-api/3.0/bookings/{language}/{reference}?cancellationFlag=
+   * SIMULATION | CANCELLATION (see Hotelbeds Activities Cancel docs).
    */
-  async cancelActivity(_bookingReference: string): Promise<ActivityCancelResponse> {
-    throw new MoneyPathError(
-      'Hotelbeds activity cancel is not wired — activity cancel HTTP contract undocumented (DOMAIN_QUESTION). Refusing rather than inventing.',
-    );
+  async cancelActivity(
+    bookingReference: string,
+    flag: HotelbedsCancellationFlag = 'SIMULATION',
+    options?: HotelbedsBookOptions,
+  ): Promise<ActivityCancelResponse> {
+    const language = options?.language?.trim() || 'en';
+    const path =
+      `${ACTIVITIES_BASE_PATH}/bookings/${encodeURIComponent(language)}/` +
+      `${encodeURIComponent(bookingReference)}?cancellationFlag=${flag}`;
+
+    if (flag !== 'CANCELLATION') {
+      const response = (await this.request(
+        'DELETE',
+        path,
+      )) as HotelbedsActivitiesCancellationResponse;
+      return mapActivityCancellation(response);
+    }
+
+    const key = options?.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HotelbedsAdapter.cancelActivity (CANCELLATION) requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `hotelbeds-activity-cancel:${bookingReference}`;
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'cancelActivity',
+      idempotencyKey,
+      request: { bookingReference, flag, language },
+      supplierId: 'hotelbeds',
+      fn: async () => {
+        const response = (await this.request(
+          'DELETE',
+          path,
+        )) as HotelbedsActivitiesCancellationResponse;
+        return mapActivityCancellation(response);
+      },
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -471,15 +532,53 @@ export class HotelbedsAdapter implements HotelSourceAdapter {
   }
 
   /**
-   * Transfer cancel HTTP contract is not fully documented.
-   * // TODO: DOMAIN_QUESTION: What is the authoritative Hotelbeds Transfers
-   * // cancel HTTP shape (method, path, flags)?
-   * Fail closed — do not invent the wire call.
+   * Cancel a transfer booking.
+   * Official: DELETE /transfer-api/1.0/bookings/{language}/reference/{ref}
+   * Optional ?simulation=true. Absent simulation = hard cancel.
+   * Partial cancel via /id/{service_id} is out of scope.
    */
-  async cancelTransfer(_bookingReference: string): Promise<TransferCancelResponse> {
-    throw new MoneyPathError(
-      'Hotelbeds transfer cancel is not wired — transfer cancel HTTP contract undocumented (DOMAIN_QUESTION). Refusing rather than inventing.',
-    );
+  async cancelTransfer(
+    bookingReference: string,
+    options?: HotelbedsTransferCancelOptions,
+  ): Promise<TransferCancelResponse> {
+    const language = options?.language?.trim() || 'en';
+    const simulation = options?.simulation === true;
+    let path =
+      `${TRANSFERS_BASE_PATH}/bookings/${encodeURIComponent(language)}/reference/` +
+      `${encodeURIComponent(bookingReference)}`;
+    if (simulation) {
+      path += '?simulation=true';
+    }
+
+    if (simulation) {
+      const response = (await this.request(
+        'DELETE',
+        path,
+      )) as HotelbedsTransfersCancellationResponse;
+      return mapTransferCancellation(response);
+    }
+
+    const key = options?.idempotencyKey?.trim();
+    if (this.liveMode && !key) {
+      throw new MoneyPathError(
+        'HotelbedsAdapter.cancelTransfer (hard cancel) requires idempotencyKey in live mode (DoD 1/2)',
+      );
+    }
+    const idempotencyKey = key ?? `hotelbeds-transfer-cancel:${bookingReference}`;
+
+    return this.moneyPath.executeUnsafeOrThrow({
+      operation: 'cancelTransfer',
+      idempotencyKey,
+      request: { bookingReference, language, simulation: false },
+      supplierId: 'hotelbeds',
+      fn: async () => {
+        const response = (await this.request(
+          'DELETE',
+          path,
+        )) as HotelbedsTransfersCancellationResponse;
+        return mapTransferCancellation(response);
+      },
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/packages/connect/GUIDE.md
+++ b/packages/connect/GUIDE.md
@@ -28,10 +28,12 @@ pnpm --filter @otaip/connect test
 
 ### 1. Create the adapter
 
-```typescript
-import { SabreAdapter } from '@otaip/connect';
+Prefer `createAdapter` — it wraps money-path mutations (ledger, idempotency, kill switch). Raw `new SabreAdapter(...)` is for unit tests only and is refused for unsafe mutations in live mode.
 
-const adapter = new SabreAdapter({
+```typescript
+import { createAdapter } from '@otaip/connect';
+
+const adapter = createAdapter('sabre', {
   environment: 'cert',           // 'cert' for sandbox, 'prod' for production
   clientId: process.env.SABRE_CLIENT_ID,
   clientSecret: process.env.SABRE_CLIENT_SECRET,
@@ -169,9 +171,9 @@ console.log(`Healthy: ${health.healthy}, Latency: ${health.latencyMs}ms`);
 Same interface, different config.
 
 ```typescript
-import { TripProAdapter } from '@otaip/connect';
+import { createAdapter } from '@otaip/connect';
 
-const adapter = new TripProAdapter({
+const adapter = createAdapter('trippro', {
   soapBaseUrl: 'https://your-trippro-endpoint.com',
   accessToken: process.env.TRIPPRO_ACCESS_TOKEN,
   searchAccessToken: process.env.TRIPPRO_SEARCH_ACCESS_TOKEN,
@@ -203,7 +205,7 @@ You can also create adapters dynamically by supplier ID:
 ```typescript
 import { createAdapter, listSuppliers } from '@otaip/connect';
 
-console.log(listSuppliers()); // ['trippro', 'sabre']
+console.log(listSuppliers()); // includes tripppro, sabre, navitaire, amadeus, haip
 
 const adapter = createAdapter('sabre', {
   environment: 'cert',
@@ -363,7 +365,7 @@ The HAIP adapter connects to a HAIP PMS instance via its Connect API. Unlike the
 ```typescript
 import { HaipAdapter } from '@otaip/connect';
 
-const adapter = new HaipAdapter({
+const adapter = createAdapter('haip', {
   baseUrl: process.env.HAIP_BASE_URL ?? 'http://localhost:3000',
   apiKey: process.env.HAIP_API_KEY ?? '',  // No auth in HAIP v1.0.0
   timeoutMs: 10_000,
@@ -408,7 +410,7 @@ const modified = await adapter.modifyBooking(booking.confirmation.crsConfirmatio
 const cancelled = await adapter.cancelBooking(booking.confirmation.crsConfirmation);
 ```
 
-The HAIP adapter is **not** registered in the flight supplier registry (`createAdapter`). Instantiate it directly. It can be passed to Agent 20.1 (Hotel Search Aggregator) as a `HotelSourceAdapter` since it implements `searchHotels()` and `isAvailable()`.
+HAIP is registered as `createAdapter('haip', config)` (self-guarded money path). It can be passed to Agent 20.1 (Hotel Search Aggregator) as a `HotelSourceAdapter` since it implements `searchHotels()` and `isAvailable()`.
 
 ---
 

--- a/packages/connect/src/__tests__/live-refuse-raw-adapter.test.ts
+++ b/packages/connect/src/__tests__/live-refuse-raw-adapter.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Live mode refuses mutations on raw Connect adapters (must use createAdapter).
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { LiveSafetyError } from '@otaip/core';
+import { SabreAdapter } from '../suppliers/sabre/index.js';
+import { createAdapter } from '../suppliers/index.js';
+
+afterEach(() => {
+  delete process.env['OTAIP_MODE'];
+});
+
+describe('live refuse raw Connect adapters', () => {
+  it('new SabreAdapter createBooking throws LiveSafetyError in live mode', async () => {
+    process.env['OTAIP_MODE'] = 'live';
+    const adapter = new SabreAdapter({
+      clientId: 'id',
+      clientSecret: 'secret',
+      environment: 'cert',
+    });
+
+    await expect(
+      adapter.createBooking({
+        offerId: 'o1',
+        passengers: [
+          {
+            type: 'adult',
+            gender: 'M',
+            firstName: 'A',
+            lastName: 'B',
+            dateOfBirth: '1990-01-01',
+          },
+        ],
+        contact: { email: 'a@b.com', phone: '+1' },
+        idempotencyKey: 'k1',
+      }),
+    ).rejects.toBeInstanceOf(LiveSafetyError);
+  });
+
+  it('createAdapter live path marks adapter — does not refuse at construction', () => {
+    process.env['OTAIP_MODE'] = 'live';
+    expect(() =>
+      createAdapter(
+        'sabre',
+        { clientId: 'id', clientSecret: 'secret', environment: 'cert' },
+        { liveMode: true },
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/connect/src/base-adapter.ts
+++ b/packages/connect/src/base-adapter.ts
@@ -8,6 +8,8 @@ import {
   RateLimiter,
   CircuitBreaker,
   CircuitOpenError,
+  isLiveModeFromEnv,
+  LiveSafetyError,
   type RetryConfig as CoreRetryConfig,
   type RateLimiterConfig,
   type CircuitBreakerConfig,
@@ -66,6 +68,10 @@ export abstract class BaseAdapter {
   private readonly rateLimiter: RateLimiter | null;
   private readonly circuitBreaker: CircuitBreaker;
   private readonly disableUnsafeAutoRetry: boolean;
+  /** Set by createAdapter / guardAdapter — required for live unsafe mutations. */
+  private moneyPathGuarded = false;
+  /** Override for live detection; default isLiveModeFromEnv(). */
+  private liveModeOverride: boolean | undefined;
 
   constructor(
     retryConfig?: Partial<RetryConfig>,
@@ -88,6 +94,33 @@ export abstract class BaseAdapter {
     this.disableUnsafeAutoRetry = resilience?.disableUnsafeAutoRetry ?? true;
   }
 
+  /**
+   * Marks this adapter as constructed via createAdapter / guardAdapter.
+   * Live unsafe mutations refuse without this marker.
+   */
+  markMoneyPathGuarded(): void {
+    this.moneyPathGuarded = true;
+  }
+
+  /** Override live detection for this instance (from createAdapter options). */
+  setLiveMode(liveMode: boolean): void {
+    this.liveModeOverride = liveMode;
+  }
+
+  private isLiveMode(): boolean {
+    return this.liveModeOverride ?? isLiveModeFromEnv();
+  }
+
+  private assertLiveMoneyPathAllowed(operation: string): void {
+    if (!isUnsafeAdapterOperation(operation)) return;
+    if (!this.isLiveMode()) return;
+    if (this.moneyPathGuarded) return;
+    throw new LiveSafetyError(
+      `Live mode refuses unguarded ${operation} on ${this.supplierId} — ` +
+        'use createAdapter() or guardAdapter() (DoD 1/2)',
+    );
+  }
+
   /** Expose breaker status for health / tests. */
   getCircuitBreakerStatus(): ReturnType<CircuitBreaker['getStatus']> {
     return this.circuitBreaker.getStatus();
@@ -99,6 +132,7 @@ export abstract class BaseAdapter {
   }
 
   protected async withRetry<T>(operation: string, fn: () => Promise<T>): Promise<T> {
+    this.assertLiveMoneyPathAllowed(operation);
     const unsafe = isUnsafeAdapterOperation(operation);
     const maxRetries =
       unsafe && this.disableUnsafeAutoRetry ? 0 : this.retryConfig.maxRetries;

--- a/packages/connect/src/channels/claude/__tests__/mcp-live-approval.test.ts
+++ b/packages/connect/src/channels/claude/__tests__/mcp-live-approval.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -12,6 +12,7 @@ import {
   CasBoundApprovalTokenStore,
   FileCompareAndSwapPersistenceAdapter,
   issueBoundApprovalToken,
+  LiveSafetyError,
 } from '@otaip/core';
 import type { ConnectAdapter } from '../../../types.js';
 import { generateMcpServer } from '../mcp-server.js';
@@ -209,6 +210,124 @@ describe('MCP live approval gate', () => {
         expect(createBooking).toHaveBeenCalledOnce();
 
         createBooking.mockClear();
+        const replay = await client.callTool({
+          name: 'create_booking',
+          arguments: { ...input, approvalToken: token },
+        });
+        expect(replay.isError).toBe(true);
+        expect(createBooking).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it('live mode without store or OTAIP_MCP_APPROVAL_STORE_PATH throws at construction', () => {
+    const prev = process.env['OTAIP_MCP_APPROVAL_STORE_PATH'];
+    delete process.env['OTAIP_MCP_APPROVAL_STORE_PATH'];
+    try {
+      expect(() =>
+        generateMcpServer(mockAdapter({ createBooking: vi.fn(), cancelBooking: vi.fn() }), {
+          serverName: 'test',
+          version: '1',
+          liveMode: true,
+          approvalSecret: 'live-secret',
+        }),
+      ).toThrow(LiveSafetyError);
+    } finally {
+      if (prev !== undefined) process.env['OTAIP_MCP_APPROVAL_STORE_PATH'] = prev;
+      else delete process.env['OTAIP_MCP_APPROVAL_STORE_PATH'];
+    }
+  });
+
+  it('live mode refuses approval store path under os.tmpdir()', () => {
+    const prev = process.env['OTAIP_MCP_APPROVAL_STORE_PATH'];
+    const underTmp = join(mkdtempSync(join(tmpdir(), 'mcp-bad-')), 'jti.json');
+    process.env['OTAIP_MCP_APPROVAL_STORE_PATH'] = underTmp;
+    try {
+      expect(() =>
+        generateMcpServer(mockAdapter({ createBooking: vi.fn(), cancelBooking: vi.fn() }), {
+          serverName: 'test',
+          version: '1',
+          liveMode: true,
+          approvalSecret: 'live-secret',
+        }),
+      ).toThrow(/tmpdir/i);
+    } finally {
+      if (prev !== undefined) process.env['OTAIP_MCP_APPROVAL_STORE_PATH'] = prev;
+      else delete process.env['OTAIP_MCP_APPROVAL_STORE_PATH'];
+    }
+  });
+
+  it('restart-replay: consumed jti refused on fresh store sharing persistent path', async () => {
+    const persistentDir = join(process.cwd(), '.tmp-mcp-appr-test');
+    mkdirSync(persistentDir, { recursive: true });
+    const storePath = join(persistentDir, `jti-${Date.now()}.json`);
+    const secret = 'live-secret';
+    const sessionId = 'mcp-session';
+    const agentId = 'mcp-connect';
+    const input = {
+      offerId: 'off_1',
+      passengers: [
+        {
+          type: 'adult' as const,
+          gender: 'M' as const,
+          firstName: 'A',
+          lastName: 'B',
+          dateOfBirth: '1990-01-01',
+        },
+      ],
+      contact: { email: 'a@b.com', phone: '+1' },
+      idempotencyKey: 'k-restart',
+    };
+    const token = issueBoundApprovalToken({ sessionId, agentId, input, secret });
+
+    const storeA = new CasBoundApprovalTokenStore(
+      new FileCompareAndSwapPersistenceAdapter(storePath),
+    );
+    const createBooking = vi.fn(async () => ({
+      bookingId: 'B1',
+      supplier: 'mock',
+      status: 'confirmed' as const,
+      segments: [],
+      passengers: [],
+      totalPrice: { amount: '1', currency: 'USD' },
+    }));
+
+    await withClient(
+      mockAdapter({ createBooking, cancelBooking: vi.fn() }),
+      {
+        serverName: 'test',
+        version: '1',
+        liveMode: true,
+        approvalSecret: secret,
+        approvalTokenStore: storeA,
+        sessionId,
+        agentId,
+      },
+      async (client) => {
+        const ok = await client.callTool({
+          name: 'create_booking',
+          arguments: { ...input, approvalToken: token },
+        });
+        expect(ok.isError).toBeFalsy();
+      },
+    );
+
+    createBooking.mockClear();
+    const storeB = new CasBoundApprovalTokenStore(
+      new FileCompareAndSwapPersistenceAdapter(storePath),
+    );
+    await withClient(
+      mockAdapter({ createBooking, cancelBooking: vi.fn() }),
+      {
+        serverName: 'test',
+        version: '1',
+        liveMode: true,
+        approvalSecret: secret,
+        approvalTokenStore: storeB,
+        sessionId,
+        agentId,
+      },
+      async (client) => {
         const replay = await client.callTool({
           name: 'create_booking',
           arguments: { ...input, approvalToken: token },

--- a/packages/connect/src/channels/claude/mcp-server.ts
+++ b/packages/connect/src/channels/claude/mcp-server.ts
@@ -15,11 +15,11 @@ import {
   createBoundApprovalPolicy,
   FileCompareAndSwapPersistenceAdapter,
   isLiveModeFromEnv,
+  LiveSafetyError,
   type BoundApprovalTokenStore,
 } from '@otaip/core';
-import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, resolve } from 'node:path';
 import type {
   ConnectAdapter,
   CreateBookingInput,
@@ -43,7 +43,11 @@ export interface McpServerConfig {
   liveMode?: boolean;
   /** HMAC secret. Defaults to OTAIP_APPROVAL_SECRET. */
   approvalSecret?: string;
-  /** Durable token store for live single-use. Defaults to file-backed CAS. */
+  /**
+   * Durable token store for live single-use.
+   * Live mode: inject this, or set OTAIP_MCP_APPROVAL_STORE_PATH (persistent path).
+   * Paths under os.tmpdir() are refused.
+   */
   approvalTokenStore?: BoundApprovalTokenStore;
   /** Session id bound into approval tokens. Default: mcp-session. */
   sessionId?: string;
@@ -59,11 +63,27 @@ function argsAs<T>(args: Record<string, unknown> | undefined): T {
   return (args ?? {}) as unknown as T;
 }
 
-function defaultDurableApprovalStore(): BoundApprovalTokenStore {
-  const dir = mkdtempSync(join(tmpdir(), 'otaip-mcp-appr-'));
-  return new CasBoundApprovalTokenStore(
-    new FileCompareAndSwapPersistenceAdapter(join(dir, 'jti.json')),
-  );
+function isUnderTmpdir(filePath: string): boolean {
+  const resolved = resolve(filePath);
+  const tmp = resolve(tmpdir());
+  return resolved === tmp || resolved.startsWith(tmp + '/');
+}
+
+function approvalStoreFromEnvPath(): BoundApprovalTokenStore {
+  const raw = (process.env['OTAIP_MCP_APPROVAL_STORE_PATH'] ?? '').trim();
+  if (!raw) {
+    throw new LiveSafetyError(
+      'MCP live mode requires approvalTokenStore or OTAIP_MCP_APPROVAL_STORE_PATH ' +
+        '(persistent path). No tmpdir fallback.',
+    );
+  }
+  const filePath = isAbsolute(raw) ? resolve(raw) : resolve(process.cwd(), raw);
+  if (isUnderTmpdir(filePath)) {
+    throw new LiveSafetyError(
+      'MCP live mode refuses approval store under os.tmpdir() — set OTAIP_MCP_APPROVAL_STORE_PATH to a persistent path',
+    );
+  }
+  return new CasBoundApprovalTokenStore(new FileCompareAndSwapPersistenceAdapter(filePath));
 }
 
 function toolError(message: string): {
@@ -87,12 +107,13 @@ export function generateMcpServer(adapter: ConnectAdapter, config: McpServerConf
     (config.approvalSecret ?? process.env['OTAIP_APPROVAL_SECRET'] ?? '').trim() || undefined;
   const sessionId = config.sessionId ?? 'mcp-session';
   const agentId = config.agentId ?? 'mcp-connect';
-  const approvalTokenStore =
-    config.approvalTokenStore ??
-    (liveMode ? defaultDurableApprovalStore() : undefined);
+  let approvalTokenStore = config.approvalTokenStore;
+  if (liveMode && !approvalTokenStore) {
+    approvalTokenStore = approvalStoreFromEnvPath();
+  }
 
   if (liveMode && approvalTokenStore && approvalTokenStore.durability === 'ephemeral') {
-    throw new Error(
+    throw new LiveSafetyError(
       'MCP live mode refuses ephemeral BoundApprovalTokenStore — inject CasBoundApprovalTokenStore with durable CAS',
     );
   }

--- a/packages/connect/src/guarded-adapter.ts
+++ b/packages/connect/src/guarded-adapter.ts
@@ -22,7 +22,7 @@ import type {
   FlightOffer,
 } from './types.js';
 import { MutationExecutor } from './mutation-executor.js';
-import { ConnectError } from './base-adapter.js';
+import { BaseAdapter, ConnectError } from './base-adapter.js';
 
 export interface GuardedConnectAdapterOptions extends MoneyPathExecutorConfig {
   /** Underlying supplier adapter (unguarded). */
@@ -152,5 +152,11 @@ export function guardAdapter(
   adapter: ConnectAdapter,
   config?: Omit<GuardedConnectAdapterOptions, 'adapter'>,
 ): GuardedConnectAdapter {
+  if (adapter instanceof BaseAdapter) {
+    adapter.markMoneyPathGuarded();
+    if (config?.liveMode !== undefined) {
+      adapter.setLiveMode(config.liveMode);
+    }
+  }
   return new GuardedConnectAdapter({ adapter, ...config });
 }

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -55,20 +55,32 @@ export type { BaseAdapterConfig } from './config.js';
 export { registerSupplier, createAdapter, listSuppliers } from './suppliers/index.js';
 export type { CreateAdapterOptions } from './suppliers/index.js';
 
-// TripPro adapter
+/**
+ * @deprecated Prefer `createAdapter('trippro', config)` for application code.
+ * Raw class is for unit tests; live unsafe mutations require createAdapter/guardAdapter.
+ */
 export { TripProAdapter } from './suppliers/trippro/index.js';
 export type { TripProConfig } from './suppliers/trippro/config.js';
 
-// Sabre adapter
+/**
+ * @deprecated Prefer `createAdapter('sabre', config)` for application code.
+ * Raw class is for unit tests; live unsafe mutations require createAdapter/guardAdapter.
+ */
 export { SabreAdapter } from './suppliers/sabre/index.js';
 export type { SabreConfig } from './suppliers/sabre/config.js';
 
-// Navitaire adapter
+/**
+ * @deprecated Prefer `createAdapter('navitaire', config)` for application code.
+ * Raw class is for unit tests; live unsafe mutations require createAdapter/guardAdapter.
+ */
 export { NavitaireAdapter } from './suppliers/navitaire/index.js';
 export { NavitaireOrderOperations } from './suppliers/navitaire/order-operations.js';
 export type { NavitaireConfig } from './suppliers/navitaire/config.js';
 
-// Amadeus adapter
+/**
+ * @deprecated Prefer `createAdapter('amadeus', config)` for application code.
+ * Raw class is for unit tests; live unsafe mutations require createAdapter/guardAdapter.
+ */
 export { AmadeusAdapter } from './suppliers/amadeus/index.js';
 export type { AmadeusConfig } from './suppliers/amadeus/config.js';
 

--- a/packages/connect/src/suppliers/amadeus/__tests__/create-booking-money-path.test.ts
+++ b/packages/connect/src/suppliers/amadeus/__tests__/create-booking-money-path.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Amadeus createBooking money-path — ambiguous failure → OUTCOME_UNKNOWN; replay → zero.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { GuardedConnectAdapter, guardAdapter } from '../../../index.js';
+
+describe('Amadeus createBooking money-path', () => {
+  it('Guarded createBooking 503 → one wire; replay → zero', async () => {
+    let posts = 0;
+    const raw = {
+      supplierId: 'amadeus',
+      supplierName: 'Amadeus Self-Service',
+      async searchFlights() {
+        return [];
+      },
+      async priceItinerary() {
+        throw new Error('n/a');
+      },
+      async createBooking() {
+        posts += 1;
+        throw new Error('Amadeus API error 503: unavailable');
+      },
+      async getBookingStatus() {
+        throw new Error('n/a');
+      },
+      async healthCheck() {
+        return { healthy: true, latencyMs: 1 };
+      },
+    };
+
+    const guarded = guardAdapter(raw, { liveMode: false });
+    expect(guarded).toBeInstanceOf(GuardedConnectAdapter);
+
+    const input = {
+      offerId: 'amadeus-1',
+      passengers: [
+        {
+          type: 'adult' as const,
+          gender: 'M' as const,
+          firstName: 'A',
+          lastName: 'B',
+          dateOfBirth: '1990-01-01',
+        },
+      ],
+      contact: { email: 'a@b.com', phone: '+1' },
+      idempotencyKey: 'amadeus-book-1',
+    };
+
+    await expect(guarded.createBooking(input)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(guarded.createBooking(input)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(posts).toBe(1);
+  });
+});

--- a/packages/connect/src/suppliers/index.ts
+++ b/packages/connect/src/suppliers/index.ts
@@ -8,12 +8,20 @@
 
 import { isLiveModeFromEnv, LiveSafetyError, type MoneyPathExecutorConfig } from '@otaip/core';
 import type { ConnectAdapter } from '../types.js';
+import { BaseAdapter } from '../base-adapter.js';
 import { AmadeusAdapter } from './amadeus/index.js';
 import { NavitaireAdapter } from './navitaire/index.js';
 import { SabreAdapter } from './sabre/index.js';
 import { TripProAdapter } from './trippro/index.js';
 import { HaipConnectBridge } from './haip/connect-bridge.js';
 import { guardAdapter, type GuardedConnectAdapter } from '../guarded-adapter.js';
+
+function markGuardedForLive(adapter: ConnectAdapter, liveMode: boolean): void {
+  if (adapter instanceof BaseAdapter) {
+    adapter.markMoneyPathGuarded();
+    adapter.setLiveMode(liveMode);
+  }
+}
 
 export interface CreateAdapterOptions extends MoneyPathExecutorConfig {
   /**
@@ -54,6 +62,8 @@ export function createAdapter(
   const execConfig: Omit<CreateAdapterOptions, 'unguarded'> = { ...(options ?? {}) };
   delete (execConfig as { unguarded?: boolean }).unguarded;
   const raw = factory(config, { ...execConfig, liveMode });
+  // Always mark factory-built adapters — GuardedConnectAdapter calls into them.
+  markGuardedForLive(raw, liveMode);
   if (options?.unguarded) return raw;
   if (SELF_GUARDED.has(supplierId)) return raw;
   return guardAdapter(raw, { ...execConfig, liveMode });

--- a/packages/connect/src/suppliers/navitaire/__tests__/money-path.test.ts
+++ b/packages/connect/src/suppliers/navitaire/__tests__/money-path.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Navitaire money-path: commit-step 503 → one commit POST; replay → zero.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { createAdapter, GuardedConnectAdapter } from '../../../index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const CONFIG = {
+  baseUrl: 'https://navitaire.test.local',
+  credentials: {
+    domain: 'WW',
+    username: 'user',
+    password: 'pass',
+  },
+  defaultCurrencyCode: 'USD',
+};
+
+const bookingInput = {
+  offerId: 'navitaire-journeyKey1-fareKey1',
+  passengers: [
+    {
+      type: 'adult' as const,
+      gender: 'M' as const,
+      firstName: 'A',
+      lastName: 'B',
+      dateOfBirth: '1990-01-01',
+    },
+  ],
+  contact: { email: 'a@b.com', phone: '+1' },
+  idempotencyKey: 'nav-book-1',
+};
+
+describe('Navitaire money-path via createAdapter', () => {
+  it('503 at commit → one commit POST; replay → zero', async () => {
+    let commitPosts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = (init?.method ?? 'GET').toUpperCase();
+
+        if (url.includes('/api/auth/v1/token')) {
+          return new Response(
+            JSON.stringify({ token: 'tok', idleTimeoutInMinutes: 60 }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+
+        if (method === 'POST' && url.includes('/api/nsk/v3/booking')) {
+          commitPosts += 1;
+          return new Response('unavailable', { status: 503, statusText: 'Service Unavailable' });
+        }
+
+        // Prior stateful hops succeed with minimal bodies
+        if (url.includes('/trip/sell') || url.includes('/passengers') || url.includes('/contacts')) {
+          return new Response(JSON.stringify({ data: { passengers: { P0: {} } } }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.includes('/booking/payments')) {
+          return new Response(JSON.stringify({ data: {} }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (method === 'GET' && url.includes('/api/nsk/v1/booking')) {
+          return new Response(
+            JSON.stringify({ data: { breakdown: { balanceDue: 100, totalAmount: 100 } } }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+
+        return new Response(JSON.stringify({ data: {} }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+
+    const adapter = createAdapter('navitaire', CONFIG, { liveMode: false });
+    expect(adapter).toBeInstanceOf(GuardedConnectAdapter);
+
+    await expect(adapter.createBooking(bookingInput)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.createBooking(bookingInput)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(commitPosts).toBe(1);
+  });
+});

--- a/packages/connect/src/suppliers/sabre/__tests__/money-path.test.ts
+++ b/packages/connect/src/suppliers/sabre/__tests__/money-path.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Sabre money-path drills via createAdapter — 503 → one wire; replay → zero.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OutcomeUnknownError } from '@otaip/core';
+import { createAdapter, GuardedConnectAdapter } from '../../../index.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const CONFIG = {
+  clientId: 'test-client',
+  clientSecret: 'test-secret',
+  environment: 'cert' as const,
+};
+
+function stubFetch503OnMutation(): { mutationPosts: () => number } {
+  let mutationPosts = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/v2/auth/token')) {
+        return new Response(
+          JSON.stringify({ access_token: 'tok', token_type: 'Bearer', expires_in: 3600 }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (
+        url.includes('createBooking') ||
+        url.includes('fulfillFlightTickets') ||
+        url.includes('cancelBooking')
+      ) {
+        mutationPosts += 1;
+        return new Response('unavailable', { status: 503, statusText: 'Service Unavailable' });
+      }
+      return new Response('{}', { status: 200 });
+    }),
+  );
+  return { mutationPosts: () => mutationPosts };
+}
+
+const bookingInput = {
+  offerId: 'offer-1',
+  passengers: [
+    {
+      type: 'adult' as const,
+      gender: 'M' as const,
+      firstName: 'A',
+      lastName: 'B',
+      dateOfBirth: '1990-01-01',
+    },
+  ],
+  contact: { email: 'a@b.com', phone: '+1' },
+  idempotencyKey: 'sabre-book-1',
+};
+
+describe('Sabre money-path via createAdapter', () => {
+  it('createBooking 503 → one wire; replay → zero', async () => {
+    const { mutationPosts } = stubFetch503OnMutation();
+    const adapter = createAdapter('sabre', CONFIG, { liveMode: false });
+    expect(adapter).toBeInstanceOf(GuardedConnectAdapter);
+
+    await expect(adapter.createBooking(bookingInput)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.createBooking(bookingInput)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(mutationPosts()).toBe(1);
+  });
+
+  it('requestTicketing 503 → one wire; replay → zero', async () => {
+    const { mutationPosts } = stubFetch503OnMutation();
+    const adapter = createAdapter('sabre', CONFIG, { liveMode: false });
+
+    await expect(adapter.requestTicketing!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.requestTicketing!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(mutationPosts()).toBe(1);
+  });
+
+  it('cancelBooking 503 → one wire; replay → zero', async () => {
+    const { mutationPosts } = stubFetch503OnMutation();
+    const adapter = createAdapter('sabre', CONFIG, { liveMode: false });
+
+    await expect(adapter.cancelBooking!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.cancelBooking!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(mutationPosts()).toBe(1);
+  });
+});

--- a/packages/connect/src/suppliers/trippro/__tests__/money-path.test.ts
+++ b/packages/connect/src/suppliers/trippro/__tests__/money-path.test.ts
@@ -51,4 +51,39 @@ describe('TripPro money-path SOAP', () => {
     await expect(adapter.requestTicketing!('ABC123')).rejects.toBeInstanceOf(OutcomeUnknownError);
     expect(posts).toBe(1);
   });
+
+  it('REST createBooking 503 → one wire; replay → zero', async () => {
+    let bookPosts = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('bookItinerary') || url.includes('/book')) {
+          bookPosts += 1;
+          return new Response('unavailable', { status: 503, statusText: 'Service Unavailable' });
+        }
+        return new Response('{}', { status: 200 });
+      }),
+    );
+
+    const adapter = createAdapter('trippro', CONFIG, { liveMode: false });
+    const input = {
+      offerId: 'off-1',
+      passengers: [
+        {
+          type: 'adult' as const,
+          gender: 'M' as const,
+          firstName: 'A',
+          lastName: 'B',
+          dateOfBirth: '1990-01-01',
+        },
+      ],
+      contact: { email: 'a@b.com', phone: '+1' },
+      idempotencyKey: 'tp-book-1',
+    };
+
+    await expect(adapter.createBooking(input)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    await expect(adapter.createBooking(input)).rejects.toBeInstanceOf(OutcomeUnknownError);
+    expect(bookPosts).toBe(1);
+  });
 });

--- a/packages/core/src/effect-ledger/__tests__/file-ledger-crash-visibility.test.ts
+++ b/packages/core/src/effect-ledger/__tests__/file-ledger-crash-visibility.test.ts
@@ -1,0 +1,34 @@
+/**
+ * FileEffectLedger: unresolved effects survive a fresh ledger instance (crash visibility).
+ */
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FileEffectLedger } from '../file-effect-ledger.js';
+
+describe('FileEffectLedger crash visibility', () => {
+  it('fresh instance on same file sees prior unresolved pending/unknown', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'otaip-ledger-'));
+    const filePath = join(dir, 'effects.json');
+
+    const ledgerA = new FileEffectLedger({ filePath });
+    const begin = await ledgerA.begin({
+      effectId: 'e-crash-1',
+      effectType: 'book',
+      idempotencyKey: 'crash-key-1',
+      requestHash: 'hash-1',
+      supplierId: 'test',
+    });
+    expect(begin.kind).toBe('begun');
+
+    await ledgerA.resolve('crash-key-1', 'unknown');
+
+    const ledgerB = new FileEffectLedger({ filePath });
+    const unresolved = await ledgerB.listUnresolved();
+    expect(unresolved.some((r) => r.idempotencyKey === 'crash-key-1')).toBe(true);
+    const unknown = await ledgerB.listUnknown();
+    expect(unknown.some((r) => r.idempotencyKey === 'crash-key-1')).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Closes platform money-path gaps so OTAIP is safe to build OTA/TMC/airline distribution on: durable MCP approvals, supplier `createAdapter` drills, live refuse of unguarded raw adapters, Hotelbeds activity/transfer cancel, Duffel air cancel, ledger crash visibility, and an honest builder-focused scorecard.

## Type of change

- [x] Bug fix
- [ ] New agent or adapter
- [x] Enhancement to existing agent
- [ ] Domain logic correction
- [x] Documentation
- [ ] Infrastructure / CI
- [ ] Refactor (no behavior change)

## Checklist

- [x] `pnpm test` passes (all tests, not just mine)
- [x] `pnpm typecheck` passes
- [ ] `pnpm lint` passes with zero errors
- [x] No `any` types without a justification comment
- [x] No floating point for currency — use string-based decimal or `decimal.js`
- [ ] Agent spec in `agents/specs/` updated if behavior changed
- [x] New domain logic has a source (Hotelbeds/Duffel official cancel docs cited in KB/adapter)
- [x] Tests encode domain knowledge, not just `expect(result).toBeDefined()`

## Domain impact

Hotelbeds activity/transfer cancel and Duffel air cancel wired from vendor docs (DQ-A1/DQ-T1 closed). No invented fare/DOT logic.

## Changes

1. **MCP live approval:** no tmpdir default; require inject or `OTAIP_MCP_APPROVAL_STORE_PATH`; restart-replay jti test
2. **Supplier drills:** Sabre / Navitaire commit / TripPro book / Amadeus book via `createAdapter`
3. **Live refuse raw adapters:** unguarded Connect mutations throw `LiveSafetyError` in live mode
4. **Hotelbeds:** activity + transfer hard cancel + `isUnsafeHotelbedsPath` fix
5. **Duffel:** air `order_cancellations` create + confirm via MoneyPath
6. **Demos/docs:** `createAdapter`; deprecate raw class re-exports
7. **DoD 8:** `FileEffectLedger` fresh-instance `listUnresolved`
8. **Scorecard:** platform money-path ready for builders (not turnkey-OTA framing)

## Test plan

- `mcp-live-approval.test.ts` — no path / tmpdir refuse; restart-replay
- Sabre/Navitaire/TripPro/Amadeus money-path drills
- `live-refuse-raw-adapter.test.ts`
- Hotelbeds activity/transfer cancel unit drills
- Duffel air cancel confirm once-only
- `file-ledger-crash-visibility.test.ts`
- Full `pnpm test` — **3451 passed | 17 skipped**; CI green on this branch

## Out of scope (deployer-owned)

Stripe / full Connect `BookingPipeline` product UX; multi-node CAS; inventing fare/DOT/Cat33 engines inside Connect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3359bdd7-0df8-450b-8493-63132da9a593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3359bdd7-0df8-450b-8493-63132da9a593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

