### PR TITLE
fix: bind MCP approval tokens to tool name

### DIFF
--- a/docs/engineering/PRODUCTION_DOD_SCORECARD.md
+++ b/docs/engineering/PRODUCTION_DOD_SCORECARD.md
@@ -19,7 +19,7 @@ Covered money-path surfaces: Connect `createAdapter` (TripPro/Sabre/Navitaire/Am
 | 3 | Persistence can do #2 | PASS | default (single-host) | Store-declared durability; `FileEffectLedger` + File CAS lockfile (`cas-persistence.test.ts`). **Reference store:** single-host File CAS — multi-node deployers inject their own CAS |
 | 4 | Supplier backpressure real | PASS | default | `BaseAdapter` RL+CB on by default; Duffel/Hotelbeds RL+CB on `request()`; HAIP/TripPro mutations via `withRetry` (unsafe → maxRetries 0) — `rate-limiter.test.ts`, `haip/.../money-path.test.ts` |
 | 5 | Live tickets not invented | PASS | default | `issueTickets` liveMode guard; Duffel maps order documents only |
-| 6 | Irreversible LLM gate has teeth | PASS | default | Orchestrator HMAC + durable single-use. MCP live: no tmpdir fallback; requires inject or `OTAIP_MCP_APPROVAL_STORE_PATH`; restart-replay refuses consumed jti (`mcp-live-approval.test.ts`) |
+| 6 | Irreversible LLM gate has teeth | PASS | default | Orchestrator HMAC + durable single-use. MCP live: no tmpdir fallback; requires inject or `OTAIP_MCP_APPROVAL_STORE_PATH`; tokens bind via `mcpMutationApprovalInput(tool, args)` so ticket≠cancel; restart-replay refuses consumed jti (`mcp-live-approval.test.ts`) |
 | 7 | Reversal works | PASS | default | `executeReversal` shared executor; void/refund fail closed without capability; Duffel air cancel via order_cancellations confirm (once); Hotelbeds activity/transfer hard cancel once (`money-path` / adapter cancel drills) |
 | 8 | Ops see/stop damage | PASS | default | Durable damage visibility = `FileEffectLedger.listUnresolved` across fresh instance (`file-ledger-crash-visibility.test.ts`) + `OTAIP_MUTATION_KILL_SWITCH=1`. `MutationOpsCollector` is in-process only |
 

--- a/packages/connect/src/channels/claude/__tests__/mcp-live-approval.test.ts
+++ b/packages/connect/src/channels/claude/__tests__/mcp-live-approval.test.ts
@@ -15,7 +15,7 @@ import {
   LiveSafetyError,
 } from '@otaip/core';
 import type { ConnectAdapter } from '../../../types.js';
-import { generateMcpServer } from '../mcp-server.js';
+import { generateMcpServer, mcpMutationApprovalInput } from '../mcp-server.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -198,7 +198,7 @@ describe('MCP live approval gate', () => {
         const token = issueBoundApprovalToken({
           sessionId,
           agentId,
-          input,
+          input: mcpMutationApprovalInput('create_booking', input),
           secret,
         });
 
@@ -216,6 +216,61 @@ describe('MCP live approval gate', () => {
         });
         expect(replay.isError).toBe(true);
         expect(createBooking).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it('refuses ticket approval token on cancel_booking (tool binding)', async () => {
+    const createBooking = vi.fn(async () => ({ bookingId: 'B1' }));
+    const cancelBooking = vi.fn(async () => ({ success: true, message: 'ok' }));
+    const requestTicketing = vi.fn(async () => ({
+      bookingId: 'B1',
+      supplier: 'mock',
+      status: 'ticketed' as const,
+      segments: [],
+      passengers: [],
+      totalPrice: { amount: '1', currency: 'USD' },
+    }));
+    const store = new CasBoundApprovalTokenStore(
+      new FileCompareAndSwapPersistenceAdapter(
+        join(mkdtempSync(join(tmpdir(), 'mcp-appr-')), 'jti.json'),
+      ),
+    );
+    const secret = 'live-secret';
+    const sessionId = 'mcp-session';
+    const agentId = 'mcp-connect';
+    const bookingArgs = { bookingId: 'B1' };
+    const ticketToken = issueBoundApprovalToken({
+      sessionId,
+      agentId,
+      input: mcpMutationApprovalInput('request_ticketing', bookingArgs),
+      secret,
+    });
+
+    await withClient(
+      {
+        ...mockAdapter({ createBooking, cancelBooking }),
+        requestTicketing,
+      },
+      {
+        serverName: 'test',
+        version: '1',
+        liveMode: true,
+        approvalSecret: secret,
+        approvalTokenStore: store,
+        sessionId,
+        agentId,
+      },
+      async (client) => {
+        const result = await client.callTool({
+          name: 'cancel_booking',
+          arguments: { ...bookingArgs, approvalToken: ticketToken },
+        });
+        expect(result.isError).toBe(true);
+        const content = result.content as Array<{ type: string; text: string }>;
+        expect(content[0]!.text).toMatch(/input hash mismatch|approval/i);
+        expect(cancelBooking).not.toHaveBeenCalled();
+        expect(requestTicketing).not.toHaveBeenCalled();
       },
     );
   });
@@ -278,7 +333,12 @@ describe('MCP live approval gate', () => {
       contact: { email: 'a@b.com', phone: '+1' },
       idempotencyKey: 'k-restart',
     };
-    const token = issueBoundApprovalToken({ sessionId, agentId, input, secret });
+    const token = issueBoundApprovalToken({
+      sessionId,
+      agentId,
+      input: mcpMutationApprovalInput('create_booking', input),
+      secret,
+    });
 
     const storeA = new CasBoundApprovalTokenStore(
       new FileCompareAndSwapPersistenceAdapter(storePath),

--- a/packages/connect/src/channels/claude/mcp-server.ts
+++ b/packages/connect/src/channels/claude/mcp-server.ts
@@ -4,7 +4,8 @@
  *
  * Live mode: create_booking / request_ticketing / cancel_booking require a
  * bound approval token (createHmac + durable single-use consume) before the
- * adapter is called (DoD 6).
+ * adapter is called (DoD 6). Tokens bind to tool name + args so a ticket
+ * approval cannot authorize cancel (and vice versa).
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -30,6 +31,24 @@ import type {
 import { generateMcpTools } from './tool-generator.js';
 
 const MUTATION_TOOLS = new Set(['create_booking', 'request_ticketing', 'cancel_booking']);
+
+/** Reserved key in approval input hash — binds token to the MCP tool name. */
+export const MCP_APPROVAL_TOOL_KEY = 'mcpTool' as const;
+
+/**
+ * Canonical input for {@link issueBoundApprovalToken} / live MCP validation.
+ * Includes tool name so ticketing and cancel tokens for the same bookingId
+ * cannot be cross-used.
+ */
+export function mcpMutationApprovalInput(
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const rest: Record<string, unknown> = { ...(args ?? {}) };
+  delete rest['approvalToken'];
+  delete rest[MCP_APPROVAL_TOOL_KEY];
+  return { [MCP_APPROVAL_TOOL_KEY]: toolName, ...rest };
+}
 
 export interface McpServerConfig {
   serverName: string;
@@ -141,8 +160,7 @@ export function generateMcpServer(adapter: ConnectAdapter, config: McpServerConf
         if (typeof token !== 'string' || token.length === 0) {
           return toolError('Approval token is missing or empty');
         }
-        const expectedInput = { ...(args ?? {}) };
-        delete expectedInput['approvalToken'];
+        const expectedInput = mcpMutationApprovalInput(name, args as Record<string, unknown>);
         const policy = createBoundApprovalPolicy({
           secret: approvalSecret,
           store: approvalTokenStore,

--- a/packages/connect/src/channels/claude/tool-generator.ts
+++ b/packages/connect/src/channels/claude/tool-generator.ts
@@ -128,7 +128,8 @@ export function generateMcpTools(
             ? {
                 approvalToken: {
                   type: 'string',
-                  description: 'Bound single-use approval token (issueBoundApprovalToken)',
+                  description:
+                    'Bound single-use approval token — issueBoundApprovalToken with mcpMutationApprovalInput("create_booking", args)',
                 },
                 idempotencyKey: {
                   type: 'string',
@@ -175,7 +176,8 @@ export function generateMcpTools(
             ? {
                 approvalToken: {
                   type: 'string',
-                  description: 'Bound single-use approval token (issueBoundApprovalToken)',
+                  description:
+                    'Bound single-use approval token — issueBoundApprovalToken with mcpMutationApprovalInput("request_ticketing", args)',
                 },
               }
             : {}),
@@ -197,7 +199,8 @@ export function generateMcpTools(
             ? {
                 approvalToken: {
                   type: 'string',
-                  description: 'Bound single-use approval token (issueBoundApprovalToken)',
+                  description:
+                    'Bound single-use approval token — issueBoundApprovalToken with mcpMutationApprovalInput("cancel_booking", args)',
                 },
               }
             : {}),

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -89,7 +89,11 @@ export { generateOpenAPISpec } from './channels/chatgpt/openapi-generator.js';
 export type { OpenAPIGeneratorConfig } from './channels/chatgpt/openapi-generator.js';
 export { generateGptInstructions } from './channels/chatgpt/gpt-instructions.js';
 export type { GptInstructionsConfig } from './channels/chatgpt/gpt-instructions.js';
-export { generateMcpServer } from './channels/claude/mcp-server.js';
+export {
+  generateMcpServer,
+  mcpMutationApprovalInput,
+  MCP_APPROVAL_TOOL_KEY,
+} from './channels/claude/mcp-server.js';
 export type { McpServerConfig } from './channels/claude/mcp-server.js';
 export { generateMcpTools } from './channels/claude/tool-generator.js';
 export type { McpToolDefinition } from './channels/claude/tool-generator.js';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Closes the MCP live approval cross-tool hole: tokens for `request_ticketing` could authorize `cancel_booking` (same `bookingId` hash, no tool binding). Approvals now bind via `mcpMutationApprovalInput(tool, args)`.

## Type of change

- [x] Bug fix
- [ ] New agent or adapter
- [ ] Enhancement to existing agent
- [ ] Domain logic correction
- [x] Documentation
- [ ] Infrastructure / CI
- [ ] Refactor (no behavior change)

## Checklist

- [x] `pnpm test` passes (all tests, not just mine) — 3452 passed | 17 skipped
- [x] `pnpm typecheck` passes (`@otaip/connect`)
- [ ] `pnpm lint` passes with zero errors
- [x] No `any` types without a justification comment
- [x] No floating point for currency — use string-based decimal or `decimal.js`
- [ ] Agent spec in `agents/specs/` updated if behavior changed
- [x] New domain logic has a source (N/A — security binding fix)
- [x] Tests encode domain knowledge, not just `expect(result).toBeDefined()`

## Domain impact

N/A — approval binding / money-path safety.

## Changes

- Export `mcpMutationApprovalInput` / `MCP_APPROVAL_TOOL_KEY`
- Live MCP validation hashes `{ mcpTool, ...args }`
- Cross-tool refusal test: ticket token → cancel refused
- Scorecard criterion 6 evidence updated

## Test plan

- `mcp-live-approval.test.ts` — existing + new tool-binding case
- Full `pnpm test` green locally
- GPT-5.6 hostile re-audit of criterion 6 → PASS after fix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3359bdd7-0df8-450b-8493-63132da9a593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3359bdd7-0df8-450b-8493-63132da9a593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

